### PR TITLE
Sync upstream iOS 26 app discovery and container delete fixes

### DIFF
--- a/MCMFilzaIntegration.m
+++ b/MCMFilzaIntegration.m
@@ -6,6 +6,7 @@
 #import <notify.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
+#import <stdlib.h>
 #import <string.h>
 #import <sys/stat.h>
 #import <unistd.h>
@@ -44,6 +45,7 @@ static void MCMEnsureState(void)
 + (id)defaultWorkspace;
 - (NSArray *)allApplications;
 - (NSString *)applicationIdentifier;
+- (NSString *)bundleIdentifier;
 @end
 
 NSString *MCMFilzaVirtualRoot(void)
@@ -93,20 +95,27 @@ static NSString *MCMActivate(uint64_t containerClass, NSString *identifier,
     }
     @synchronized (gLeases) {
         MCMLease *existing = gLeases[MCMKey(containerClass, identifier)];
-        if (existing.activated || (gUnrestrictedFilesystem && existing.rootPath.length))
+        if (existing.rootPath.length)
             return existing.rootPath;
         NSString *detail = nil;
         MCMLease *lease = [MCMLease leaseForClass:containerClass identifier:identifier
             group:group part:0 flags:kMCMFlags error:&detail];
         BOOL activated = lease && [lease activate:&detail];
-        if (!lease || (!activated && !gUnrestrictedFilesystem)) {
-            [lease invalidate];
+        if (!lease) {
             if (error) *error = detail ?: @"MCM activation failed";
             return nil;
         }
+        // iOS 26 containermanagerd lacks genericExtensionsAllowedForAll, so it
+        // refuses sandbox tokens for callers not in the per-class allowed set.
+        // The path is still valid — try opening it before giving up.
         int descriptor = open(lease.rootPath.fileSystemRepresentation,
                               O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
         if (descriptor < 0) {
+            if (!activated && !gUnrestrictedFilesystem) {
+                if (error) *error = detail ?: @"MCM activation failed";
+                [lease invalidate];
+                return nil;
+            }
             if (error) *error = [NSString stringWithFormat:@"container root open failed errno=%d", errno];
             [lease invalidate];
             return nil;
@@ -134,19 +143,24 @@ static NSString *MCMActivateScoped(uint64_t containerClass, NSString *identifier
     NSString *key = MCMScopedKey(containerClass, identifier, part, partDomain, flags);
     @synchronized (gLeases) {
         MCMLease *existing = gLeases[key];
-        if (existing.activated) return existing.rootPath;
+        if (existing.rootPath.length) return existing.rootPath;
         NSString *detail = nil;
         MCMLease *lease = [MCMLease leaseForClass:containerClass
             identifier:identifier group:group part:part partDomain:partDomain
             flags:flags error:&detail];
-        if (!lease || ![lease activate:&detail]) {
-            [lease invalidate];
+        BOOL activated = lease && [lease activate:&detail];
+        if (!lease) {
             if (error) *error = detail ?: @"scoped MCM activation failed";
             return nil;
         }
         int descriptor = open(lease.rootPath.fileSystemRepresentation,
                               O_RDONLY | O_DIRECTORY | O_CLOEXEC);
         if (descriptor < 0) {
+            if (!activated) {
+                if (error) *error = detail ?: @"scoped MCM activation failed";
+                [lease invalidate];
+                return nil;
+            }
             if (error) *error = [NSString stringWithFormat:
                 @"scoped directory open failed errno=%d", errno];
             [lease invalidate];
@@ -199,14 +213,18 @@ BOOL MCMFilzaPathHasActiveLease(NSString *path)
     return NO;
 }
 
-static void MCMInstallLink(NSString *directory, NSString *identifier,
-                           uint64_t containerClass, BOOL group)
+static void MCMInstallLinkWithFailureLogging(NSString *directory,
+                                             NSString *identifier,
+                                             uint64_t containerClass,
+                                             BOOL group,
+                                             BOOL logFailure)
 {
     NSString *error = nil;
     NSString *target = MCMActivate(containerClass, identifier, group, &error);
     if (!target) {
-        NSLog(@"[MCMFilza] activation failed class=%llu id=%@ detail=%@",
-              containerClass, identifier, error);
+        if (logFailure)
+            NSLog(@"[MCMFilza] activation failed class=%llu id=%@ detail=%@",
+                  containerClass, identifier, error);
         return;
     }
     NSString *link = [directory stringByAppendingPathComponent:identifier];
@@ -220,6 +238,13 @@ static void MCMInstallLink(NSString *directory, NSString *identifier,
     }
     if (symlink(target.fileSystemRepresentation, link.fileSystemRepresentation) != 0)
         NSLog(@"[MCMFilza] symlink failed id=%@ errno=%d", identifier, errno);
+}
+
+static void MCMInstallLink(NSString *directory, NSString *identifier,
+                           uint64_t containerClass, BOOL group)
+{
+    MCMInstallLinkWithFailureLogging(directory, identifier, containerClass,
+                                     group, YES);
 }
 
 static NSString *MCMDirectIdentifier(NSString *containerPath, NSString *fallback)
@@ -693,6 +718,127 @@ static void MCMInstallExperimentalFolder(NSString *directory)
         stringByAppendingPathComponent:@"Probe Results.plist"] atomically:YES];
 }
 
+static BOOL MCMLaunchServicesIdentifierByte(uint8_t value)
+{
+    return (value >= 'a' && value <= 'z') ||
+        (value >= 'A' && value <= 'Z') ||
+        (value >= '0' && value <= '9') ||
+        value == '.' || value == '-' || value == '_';
+}
+
+static NSArray<NSString *> *MCMExpectedIdentifiersFromEnvironment(void)
+{
+    const char *value = getenv("FILZA_MCM_EXPECT_IDENTIFIERS");
+    if (!value || !value[0]) return @[];
+    NSString *joined = [NSString stringWithUTF8String:value];
+    NSMutableOrderedSet<NSString *> *result = [NSMutableOrderedSet orderedSet];
+    for (NSString *identifier in [joined componentsSeparatedByString:@","])
+        if (MCMSafeIdentifier(identifier)) [result addObject:identifier];
+    return result.array;
+}
+
+static void MCMLogExpectedIdentifierCoverage(NSString *label,
+                                             NSSet<NSString *> *actual)
+{
+    NSArray<NSString *> *expected = MCMExpectedIdentifiersFromEnvironment();
+    if (expected.count == 0) return;
+    NSMutableArray<NSString *> *missing = [NSMutableArray array];
+    for (NSString *identifier in expected)
+        if (![actual containsObject:identifier]) [missing addObject:identifier];
+    NSLog(@"[MCMFilza] %@ expected=%lu matched=%lu missing=%@", label,
+          (unsigned long)expected.count,
+          (unsigned long)(expected.count - missing.count), missing);
+}
+
+static void MCMResetAppLinksForTesting(NSString *directory)
+{
+    if (!getenv("FILZA_MCM_RESET_APP_LINKS")) return;
+    NSFileManager *manager = NSFileManager.defaultManager;
+    for (NSString *name in [manager contentsOfDirectoryAtPath:directory error:nil] ?: @[]) {
+        NSString *path = [directory stringByAppendingPathComponent:name];
+        struct stat status = {0};
+        if (lstat(path.fileSystemRepresentation, &status) == 0 &&
+            S_ISLNK(status.st_mode))
+            unlink(path.fileSystemRepresentation);
+    }
+    NSLog(@"[MCMFilza] reset App Data links for test");
+}
+
+static NSArray<NSString *> *MCMLaunchServicesStoreIdentifiers(void)
+{
+    static const NSUInteger kMaximumCandidateCount = 65536;
+    NSString *error = nil;
+    NSString *container = MCMActivate(10, @"com.apple.lsd", NO, &error);
+    if (!container.length) {
+        NSLog(@"[MCMFilza] LaunchServices store unavailable detail=%@", error);
+        return @[];
+    }
+    NSString *caches = [container stringByAppendingPathComponent:@"Library/Caches"];
+    NSArray<NSString *> *names = [NSFileManager.defaultManager
+        contentsOfDirectoryAtPath:caches error:nil];
+    NSMutableOrderedSet<NSString *> *result = [NSMutableOrderedSet orderedSet];
+    BOOL reachedLimit = NO;
+    for (NSString *name in names ?: @[]) {
+        if (![name hasPrefix:@"com.apple.LaunchServices-"] ||
+            ![name hasSuffix:@"-v2.csstore"])
+            continue;
+        NSString *path = [caches stringByAppendingPathComponent:name];
+        NSNumber *size = [[NSFileManager.defaultManager attributesOfItemAtPath:path
+            error:nil] objectForKey:NSFileSize];
+        if (!size || size.unsignedLongLongValue == 0 ||
+            size.unsignedLongLongValue > 64 * 1024 * 1024)
+            continue;
+        NSError *readError = nil;
+        NSData *data = [NSData dataWithContentsOfFile:path
+            options:NSDataReadingMappedIfSafe error:&readError];
+        if (!data) {
+            NSLog(@"[MCMFilza] LaunchServices store read failed path=%@ error=%@",
+                  path, readError);
+            continue;
+        }
+        const uint8_t *bytes = data.bytes;
+        NSUInteger start = NSNotFound;
+        for (NSUInteger index = 0; index <= data.length; index++) {
+            BOOL allowed = index < data.length &&
+                MCMLaunchServicesIdentifierByte(bytes[index]);
+            if (allowed) {
+                if (start == NSNotFound) start = index;
+                continue;
+            }
+            if (start == NSNotFound) continue;
+            NSUInteger length = index - start;
+            if (length >= 3 && length <= 255) {
+                NSString *identifier = [[NSString alloc]
+                    initWithBytes:bytes + start length:length
+                    encoding:NSUTF8StringEncoding];
+                BOOL malformedDots = [identifier containsString:@".."];
+                BOOL looksLikeIdentifier = MCMSafeIdentifier(identifier) &&
+                    [identifier containsString:@"."] &&
+                    ![identifier hasPrefix:@"."] &&
+                    ![identifier hasSuffix:@"."] && !malformedDots;
+                if (looksLikeIdentifier) {
+                    [result addObject:identifier];
+                    if (result.count >= kMaximumCandidateCount) {
+                        reachedLimit = YES;
+                        break;
+                    }
+                }
+            }
+            start = NSNotFound;
+        }
+        NSLog(@"[MCMFilza] LaunchServices store path=%@ bytes=%lu candidates=%lu",
+              path, (unsigned long)data.length, (unsigned long)result.count);
+        if (reachedLimit) break;
+    }
+    if (reachedLimit)
+        NSLog(@"[MCMFilza] LaunchServices store candidate limit reached");
+    NSLog(@"[MCMFilza] LaunchServices store total candidates=%lu",
+          (unsigned long)result.count);
+    MCMLogExpectedIdentifierCoverage(@"LaunchServices store",
+        [NSSet setWithArray:result.array]);
+    return result.array;
+}
+
 static NSArray<NSString *> *MCMInstalledApplicationIdentifiers(void)
 {
     Class workspaceClass = NSClassFromString(@"LSApplicationWorkspace");
@@ -704,23 +850,59 @@ static NSArray<NSString *> *MCMInstalledApplicationIdentifiers(void)
     for (id proxy in applications) {
         NSString *identifier = [proxy respondsToSelector:@selector(applicationIdentifier)]
             ? [proxy applicationIdentifier] : nil;
+        if (!MCMSafeIdentifier(identifier) &&
+            [proxy respondsToSelector:@selector(bundleIdentifier)])
+            identifier = [proxy bundleIdentifier];
         if (MCMSafeIdentifier(identifier)) [result addObject:identifier];
         if (result.count >= 1024) break;
     }
+
     return result.array;
 }
 
 static NSArray<NSString *> *MCMResearchTargetIdentifiers(void)
 {
-    // LaunchServices intentionally returns an empty installed-app list to this
-    // jailed host on the tested build. Seed only the targets used by this
-    // controlled research workspace; nonexistent identifiers fail closed.
+    // Enumeration via container_query_iterate_results_sync returns near-empty
+    // results on iOS 26 even though direct lookups succeed. Seed all known
+    // first-party identifiers so the MHA bypass can resolve them by name.
     return @[
-        @"com.yourcompany.PPClient",
-        @"com.bankofamerica.BofA",
-        @"com.apple.mobilenotes",
         @"com.apple.mobilesafari",
-        @"local.research.SandboxCanaryVictim",
+        @"com.apple.mobilenotes",
+        @"com.apple.Maps",
+        @"com.apple.facetime",
+        @"com.apple.iBooks",
+        @"com.apple.podcasts",
+        @"com.apple.PosterBoard",
+        @"com.apple.mobilemail",
+        @"com.apple.weather",
+        @"com.apple.camera",
+        @"com.apple.Health",
+        @"com.apple.Fitness",
+        @"com.apple.tips",
+        @"com.apple.Passbook",
+        @"com.apple.reminders",
+        @"com.apple.stocks",
+        @"com.apple.news",
+        @"com.apple.Home",
+        @"com.apple.tv",
+        @"com.apple.shortcuts",
+        @"com.apple.freeform",
+        @"com.apple.calculator",
+        @"com.apple.MobileSMS",
+        @"com.apple.InCallService",
+        @"com.apple.Preferences",
+        @"com.apple.springboard",
+        @"com.apple.Photos",
+        @"com.apple.AppStore",
+        @"com.apple.Music",
+        @"com.apple.Bridge",
+        @"com.apple.Clock",
+        @"com.apple.VoiceMemos",
+        @"com.apple.Translate",
+        @"com.apple.measure",
+        @"com.apple.compass",
+        @"com.apple.Magnifier",
+        @"com.apple.DocumentsApp",
     ];
 }
 
@@ -752,6 +934,11 @@ static NSArray<NSString *> *MCMDynamicIdentifiers(uint64_t containerClass)
 
 static NSDictionary *MCMCustomIdentifiers(void)
 {
+    if (getenv("FILZA_MCM_IGNORE_CUSTOM_IDENTIFIERS")) {
+        NSMutableDictionary *empty = [NSMutableDictionary dictionary];
+        for (NSString *key in MCMCustomIdentifierKeys()) empty[key] = @[];
+        return empty;
+    }
     NSString *documentsPath = [MCMFilzaVirtualRoot().stringByDeletingLastPathComponent
         stringByAppendingPathComponent:@"MCMIdentifiers.plist"];
     NSString *bundlePath = [NSBundle.mainBundle pathForResource:@"MCMIdentifiers"
@@ -1131,10 +1318,13 @@ void MCMFilzaStart(void)
                                       experimental])
             [fm createDirectoryAtPath:directory withIntermediateDirectories:YES
                            attributes:@{NSFilePosixPermissions: @0700} error:nil];
+        MCMResetAppLinksForTesting(apps);
 
         NSMutableOrderedSet *appIdentifiers = [NSMutableOrderedSet orderedSetWithArray:
             MCMDynamicIdentifiers(2)];
         [appIdentifiers addObjectsFromArray:MCMInstalledApplicationIdentifiers()];
+        NSArray<NSString *> *launchServicesIdentifiers =
+            MCMLaunchServicesStoreIdentifiers();
         // Keep the proven targets as a compatibility fallback when metadata
         // enumeration is denied or incomplete on a particular build.
         [appIdentifiers addObjectsFromArray:MCMResearchTargetIdentifiers()];
@@ -1143,8 +1333,19 @@ void MCMFilzaStart(void)
             if ([value isKindOfClass:NSString.class] && MCMSafeIdentifier(value)) [appIdentifiers addObject:value];
         for (NSString *identifier in appIdentifiers)
             MCMInstallLink(apps, identifier, 2, NO);
+        for (NSString *identifier in launchServicesIdentifiers)
+            if (![appIdentifiers containsObject:identifier])
+                MCMInstallLinkWithFailureLogging(apps, identifier, 2, NO, NO);
+        MCMLogExpectedIdentifierCoverage(@"App Data links",
+            [NSSet setWithArray:[fm contentsOfDirectoryAtPath:apps error:nil] ?: @[]]);
         NSMutableOrderedSet *groupIdentifiers = [NSMutableOrderedSet orderedSetWithArray:
             MCMDynamicIdentifiers(7)];
+        [groupIdentifiers addObjectsFromArray:@[
+            @"group.com.apple.notes",
+            @"group.com.apple.safari",
+            @"group.com.apple.weather",
+            @"group.com.apple.stocks",
+        ]];
         for (id value in [custom[@"AppGroups"] isKindOfClass:NSArray.class] ? custom[@"AppGroups"] : @[])
             if ([value isKindOfClass:NSString.class] && MCMSafeIdentifier(value))
                 [groupIdentifiers addObject:value];
@@ -1171,10 +1372,13 @@ void MCMFilzaStart(void)
             @{@"Directory": serviceData, @"Class": @10, @"Group": @(NO),
               @"CustomKey": @"ServiceData", @"Fallback": @[
                   @"com.apple.swcd", @"com.apple.familycircled",
-                  @"com.apple.locationd"]},
+                  @"com.apple.locationd", @"com.apple.installd",
+                  @"com.apple.accountsd", @"com.apple.itunescloudd",
+                  @"com.apple.nanonewscd"]},
             @{@"Directory": systemData, @"Class": @12, @"Group": @(NO),
               @"CustomKey": @"SystemData", @"Fallback": @[
-                  @"com.apple.eligibilityd", @"com.apple.geod"]},
+                  @"com.apple.eligibilityd", @"com.apple.geod",
+                  @"com.apple.springboard"]},
             @{@"Directory": systemGroups, @"Class": @13, @"Group": @(YES),
               @"CustomKey": @"SystemGroups", @"Fallback": @[
                   @"systemgroup.com.apple.configurationprofiles",

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ com.apple.mobile.MobileHouseArrest
 
 Changing it disables the MobileHouseArrest path.
 
+## iOS 26 app discovery
+
+iOS 26 can hide third-party apps from the normal ContainerManager and
+LaunchServices enumeration APIs. FilzaSlop now reads the device-local
+LaunchServices store through the accessible `com.apple.lsd` service container.
+It extracts bundle identifier candidates and confirms each candidate with a
+direct class-2 ContainerManager lookup. The release IPA does not need a device
+catalog.
+
+`MCMIdentifiers.plist` remains an optional manual fallback. You can generate
+one with `scripts/refresh_device_catalog.sh` and pass it as the third release
+build argument.
+
 ## Build
 
 ```sh
@@ -87,6 +100,14 @@ make package FINALPACKAGE=1
 ```
 
 Inject `FilzaApplySandboxExt.dylib` into Filza and sign the app.
+
+To build the unsigned release IPA:
+
+```sh
+./scripts/build_release_ipa.sh \
+  FilzaSlop-v1.0.0-unsigned.ipa \
+  FilzaSlop-v1.0.1-unsigned.ipa
+```
 
 ## PoCs
 

--- a/Tweak.m
+++ b/Tweak.m
@@ -609,7 +609,7 @@ static void hook_activationViewDidLoad(id self, SEL _cmd) {
     NSLog(@"[Tweak] Suppressed activation nag");
 }
 
-#pragma mark - MCM-aware local paste
+#pragma mark - MCM-aware local file operations
 
 static void setPastePOSIXError(NSError **error, int code,
                                NSString *operation, NSString *path) {
@@ -807,6 +807,119 @@ static void showPasteFailure(UIViewController *controller, NSArray<NSError *> *e
     [controller presentViewController:alert animated:YES completion:nil];
 }
 
+static NSArray *selectedFileItems(id controller, NSArray *indexPaths) {
+    SEL fileListSelector = NSSelectorFromString(@"fileList");
+    NSArray *fileList = [controller respondsToSelector:fileListSelector]
+        ? ((id(*)(id, SEL))objc_msgSend)(controller, fileListSelector) : nil;
+    if (![fileList isKindOfClass:NSArray.class] ||
+        ![indexPaths isKindOfClass:NSArray.class]) return @[];
+
+    NSMutableArray *items = [NSMutableArray array];
+    for (id value in indexPaths) {
+        if (![value isKindOfClass:NSIndexPath.class]) continue;
+        NSInteger row = [(NSIndexPath *)value row];
+        if (row >= 0 && (NSUInteger)row < fileList.count)
+            [items addObject:fileList[(NSUInteger)row]];
+    }
+    return items;
+}
+
+static NSString *fileItemPath(id item) {
+    SEL selector = NSSelectorFromString(@"filePath");
+    id value = [item respondsToSelector:selector]
+        ? ((id(*)(id, SEL))objc_msgSend)(item, selector) : nil;
+    return [value isKindOfClass:NSString.class] ? value : nil;
+}
+
+static void showDeleteFailure(UIViewController *controller,
+                              NSArray<NSError *> *errors) {
+    if (errors.count == 0 || ![controller isKindOfClass:UIViewController.class]) return;
+    NSString *message = errors.firstObject.localizedDescription ?: @"Delete failed";
+    if (errors.count > 1)
+        message = [NSString stringWithFormat:@"%lu items failed.\n%@",
+            (unsigned long)errors.count, message];
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Delete failed"
+        message:message preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK"
+        style:UIAlertActionStyleDefault handler:nil]];
+    [controller presentViewController:alert animated:YES completion:nil];
+}
+
+static IMP orig_fileSystemPageDeleteAction = NULL;
+static IMP orig_fileSystemDeleteSelectedItems = NULL;
+static IMP orig_fileSystemDoEraseSelectedItems = NULL;
+static IMP parentFileSystemAskDeleteItems = NULL;
+
+// Filza's jailed filesystem subclass replaces delete, trash, and erase with
+// no-ops. Use the normal permanent-delete UI for paths backed by an active MCM
+// lease, then perform the operation in this process instead of the root helper.
+static NSUInteger hook_fileSystemPageDeleteAction(id self, SEL _cmd) {
+    SEL selector = NSSelectorFromString(@"currentPath");
+    NSString *path = [self respondsToSelector:selector]
+        ? ((id(*)(id, SEL))objc_msgSend)(self, selector) : nil;
+    if (MCMFilzaPathHasActiveLease(path)) return 0x8000;
+    return orig_fileSystemPageDeleteAction
+        ? ((NSUInteger(*)(id, SEL))orig_fileSystemPageDeleteAction)(self, _cmd)
+        : 0x8000;
+}
+
+static void hook_fileSystemDeleteSelectedItems(id self, SEL _cmd) {
+    SEL currentPathSelector = NSSelectorFromString(@"currentPath");
+    NSString *path = [self respondsToSelector:currentPathSelector]
+        ? ((id(*)(id, SEL))objc_msgSend)(self, currentPathSelector) : nil;
+    if (!MCMFilzaPathHasActiveLease(path)) {
+        if (orig_fileSystemDeleteSelectedItems)
+            ((void(*)(id, SEL))orig_fileSystemDeleteSelectedItems)(self, _cmd);
+        return;
+    }
+    SEL selectedSelector = NSSelectorFromString(@"indexPathsForSelectedItemsOrMenu");
+    NSArray *indexPaths = [self respondsToSelector:selectedSelector]
+        ? ((id(*)(id, SEL))objc_msgSend)(self, selectedSelector) : nil;
+    SEL askSelector = NSSelectorFromString(@"askDeleteItems:");
+    if ([self respondsToSelector:askSelector])
+        ((void(*)(id, SEL, id))objc_msgSend)(self, askSelector, indexPaths ?: @[]);
+}
+
+static void hook_fileSystemAskDeleteItems(id self, SEL _cmd, NSArray *indexPaths) {
+    if (parentFileSystemAskDeleteItems)
+        ((void(*)(id, SEL, id))parentFileSystemAskDeleteItems)(
+            self, _cmd, indexPaths ?: @[]);
+}
+
+static void hook_fileSystemDoEraseSelectedItems(id self, SEL _cmd,
+                                                 NSArray *indexPaths,
+                                                 void (^completion)(NSArray *)) {
+    MCMFilzaStart();
+    NSArray *items = selectedFileItems(self, indexPaths);
+    if (items.count == 0) {
+        if (orig_fileSystemDoEraseSelectedItems)
+            ((void(*)(id, SEL, id, id))orig_fileSystemDoEraseSelectedItems)(
+                self, _cmd, indexPaths, completion);
+        return;
+    }
+
+    NSMutableArray *deleted = [NSMutableArray array];
+    NSMutableArray<NSError *> *errors = [NSMutableArray array];
+    for (id item in items) {
+        NSString *path = fileItemPath(item);
+        NSError *error = nil;
+        if (!path.length || !MCMFilzaPathHasActiveLease(path)) {
+            setPastePOSIXError(&error, EACCES, @"delete", path ?: @"(unknown)");
+        } else if ([NSFileManager.defaultManager removeItemAtPath:path error:&error]) {
+            [deleted addObject:item];
+            NSLog(@"[ContainerDelete] deleted %@", path);
+        }
+        if (error) {
+            [errors addObject:error];
+            NSLog(@"[ContainerDelete] failed path=%@ error=%@", path, error);
+        }
+    }
+    if (completion) completion(deleted);
+    showDeleteFailure(self, errors);
+    NSLog(@"[ContainerDelete] complete deleted=%lu failed=%lu",
+          (unsigned long)deleted.count, (unsigned long)errors.count);
+}
+
 static dispatch_queue_t pasteCopyQueue(void) {
     static dispatch_queue_t queue;
     static dispatch_once_t onceToken;
@@ -934,6 +1047,48 @@ static void installHooks(void) {
                     (IMP)hook_fileSystemUpdateEditableUI, types))
                 method_setImplementation(updateEditableUI,
                     (IMP)hook_fileSystemUpdateEditableUI);
+        }
+
+        SEL pageDeleteSelector = NSSelectorFromString(@"pageDeleteAction");
+        Method pageDeleteAction = class_getInstanceMethod(fileSystemController,
+            pageDeleteSelector);
+        if (pageDeleteAction) {
+            orig_fileSystemPageDeleteAction = method_getImplementation(pageDeleteAction);
+            const char *types = method_getTypeEncoding(pageDeleteAction);
+            if (!class_addMethod(fileSystemController, pageDeleteSelector,
+                    (IMP)hook_fileSystemPageDeleteAction, types))
+                method_setImplementation(pageDeleteAction,
+                    (IMP)hook_fileSystemPageDeleteAction);
+        }
+
+        SEL deleteSelectedSelector = NSSelectorFromString(@"deleteSelectedItems");
+        Method deleteSelected = class_getInstanceMethod(fileSystemController,
+            deleteSelectedSelector);
+        if (deleteSelected) {
+            orig_fileSystemDeleteSelectedItems = method_getImplementation(deleteSelected);
+            method_setImplementation(deleteSelected,
+                (IMP)hook_fileSystemDeleteSelectedItems);
+        }
+
+        SEL askDeleteSelector = NSSelectorFromString(@"askDeleteItems:");
+        Method askDelete = class_getInstanceMethod(fileSystemController,
+            askDeleteSelector);
+        Method parentAskDelete = class_getInstanceMethod(
+            class_getSuperclass(fileSystemController), askDeleteSelector);
+        if (askDelete && parentAskDelete) {
+            parentFileSystemAskDeleteItems = method_getImplementation(parentAskDelete);
+            method_setImplementation(askDelete,
+                (IMP)hook_fileSystemAskDeleteItems);
+        }
+
+        SEL eraseSelector = NSSelectorFromString(
+            @"doEraseSelectedIndexPaths:completion:");
+        Method eraseSelected = class_getInstanceMethod(fileSystemController,
+            eraseSelector);
+        if (eraseSelected) {
+            orig_fileSystemDoEraseSelectedItems = method_getImplementation(eraseSelected);
+            method_setImplementation(eraseSelected,
+                (IMP)hook_fileSystemDoEraseSelectedItems);
         }
     }
 

--- a/scripts/build_release_ipa.sh
+++ b/scripts/build_release_ipa.sh
@@ -1,0 +1,69 @@
+#!/bin/zsh
+set -euo pipefail
+
+if (( $# < 2 || $# > 3 )); then
+  echo "usage: $0 <base-unsigned.ipa> <output.ipa> [MCMIdentifiers.plist]" >&2
+  exit 64
+fi
+
+BASE_IPA="${1:A}"
+OUTPUT_IPA="${2:A}"
+CATALOG="${3:-}"
+if [[ -n "$CATALOG" ]]; then
+  CATALOG="${CATALOG:A}"
+fi
+
+REPO_ROOT="${0:A:h:h}"
+THEOS="${THEOS:-$HOME/theos}"
+export THEOS
+
+[[ -f "$BASE_IPA" ]] || { echo "base IPA not found: $BASE_IPA" >&2; exit 66; }
+if [[ -n "$CATALOG" ]]; then
+  [[ -f "$CATALOG" ]] || { echo "catalog not found: $CATALOG" >&2; exit 66; }
+  plutil -lint "$CATALOG" >/dev/null
+  plutil -extract AppData xml1 -o /dev/null "$CATALOG"
+fi
+
+cd "$REPO_ROOT"
+make clean
+make package FINALPACKAGE=1
+
+DYLIB="$REPO_ROOT/.theos/obj/FilzaApplySandboxExt.dylib"
+[[ -f "$DYLIB" ]] || { echo "built dylib not found: $DYLIB" >&2; exit 70; }
+
+STAGE_ROOT="$(mktemp -d /tmp/FilzaSlop-release.XXXXXX)"
+trap 'trash "$STAGE_ROOT"' EXIT
+unzip -q "$BASE_IPA" -d "$STAGE_ROOT/stage"
+
+APP="$(find "$STAGE_ROOT/stage/Payload" -maxdepth 1 -type d -name '*.app' -print -quit)"
+[[ -n "$APP" ]] || { echo "Payload app not found" >&2; exit 65; }
+
+BUNDLE_ID="$(plutil -extract CFBundleIdentifier raw -o - "$APP/Info.plist")"
+[[ "$BUNDLE_ID" == "com.apple.mobile.MobileHouseArrest" ]] || {
+  echo "unexpected bundle identifier: $BUNDLE_ID" >&2
+  exit 65
+}
+
+if codesign -d "$APP" >/dev/null 2>&1; then
+  echo "base app is signed; use an unsigned base IPA" >&2
+  exit 65
+fi
+
+cp "$DYLIB" "$APP/Frameworks/FilzaApplySandboxExt.dylib"
+codesign --remove-signature "$APP/Frameworks/FilzaApplySandboxExt.dylib"
+
+if [[ -n "$CATALOG" ]]; then
+  cp "$CATALOG" "$APP/MCMIdentifiers.plist"
+elif [[ -e "$APP/MCMIdentifiers.plist" ]]; then
+  trash "$APP/MCMIdentifiers.plist"
+fi
+
+if [[ -e "$OUTPUT_IPA" ]]; then
+  trash "$OUTPUT_IPA"
+fi
+(
+  cd "$STAGE_ROOT/stage"
+  zip -qry "$OUTPUT_IPA" Payload
+)
+
+shasum -a 256 "$OUTPUT_IPA"


### PR DESCRIPTION
Sync the two upstream FilzaSlop fixes missing from this fork while preserving the fork's existing iOS 27 research changes.

Upstream commits:
- 583fc091fe337924a771bb82d32d519343516d05 — Fix iOS 26 third-party app discovery
- b7abe0da54062f049041979249f539fa6c0b47d0 — Fix container delete action

The app-discovery fix is directly relevant to incomplete Apps Manager/container visibility: it adds LaunchServices store discovery, bundleIdentifier fallback, and changes MCM activation to validate the returned directory path before rejecting a failed token activation. The delete fix adds MCM-aware delete handling for leased paths.

## Summary by Sourcery

Improve iOS 26 app discovery and container-backed file deletion handling while preserving existing research behavior and adding release build support.

New Features:
- Add LaunchServices store scanning as an additional source of app bundle identifiers when standard enumeration is incomplete.
- Introduce environment-controlled testing hooks for app link resets and expected identifier coverage logging.

Bug Fixes:
- Ensure container activation on iOS 26 validates the returned directory path and falls back to direct opens when sandbox token activation is rejected.
- Fix third-party app discovery by falling back from applicationIdentifier to bundleIdentifier and seeding known first-party identifiers and groups.
- Restore functional delete operations for files backed by active MCM leases by bypassing Filza’s jailed no-op delete path and performing removal locally with user feedback.

Enhancements:
- Expand default research identifier sets and system service fallbacks to improve overall container visibility and robustness.
- Allow ignoring custom identifier catalogs via an environment flag to simplify testing configurations.

Build:
- Add a release IPA build script that injects the Filza sandbox extension dylib into an unsigned base IPA and optionally bundles an MCMIdentifiers.plist catalog.

Documentation:
- Document the iOS 26 app discovery behavior and the new LaunchServices-based discovery approach in the README.
- Update README with instructions for building unsigned release IPAs using the new helper script.