### PR TITLE
Fix live app metadata and make embedded ByeTunes startup inert

### DIFF
--- a/AppIconResourceProxyFix.m
+++ b/AppIconResourceProxyFix.m
@@ -1,0 +1,191 @@
+@import Foundation;
+@import UIKit;
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+static IMP gIconResourcePreviousSetAppProxy = NULL;
+static IMP gIconResourcePreviousReload = NULL;
+static BOOL gIconResourceHooksInstalled = NO;
+static const void *kIconResourceRetryKey = &kIconResourceRetryKey;
+
+static id FZIconObjectSelector(id object, NSString *selectorName)
+{
+    if (!object || !selectorName.length) return nil;
+    SEL selector = NSSelectorFromString(selectorName);
+    if (![object respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+}
+
+static NSString *FZIconIdentifier(id item)
+{
+    id value = FZIconObjectSelector(item, @"bundleId");
+    if ([value isKindOfClass:NSString.class] && [value length]) return value;
+    id proxy = FZIconObjectSelector(item, @"appProxy");
+    for (NSString *selectorName in @[@"applicationIdentifier", @"bundleIdentifier"]) {
+        value = FZIconObjectSelector(proxy, selectorName);
+        if ([value isKindOfClass:NSString.class] && [value length]) return value;
+    }
+    return nil;
+}
+
+static NSString *FZIconSafeComponent(NSString *identifier)
+{
+    NSCharacterSet *allowed = [NSCharacterSet characterSetWithCharactersInString:
+        @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_"];
+    NSMutableString *result = [NSMutableString stringWithCapacity:identifier.length];
+    for (NSUInteger index = 0; index < identifier.length; index++) {
+        unichar value = [identifier characterAtIndex:index];
+        [result appendString:[allowed characterIsMember:value]
+            ? [NSString stringWithCharacters:&value length:1] : @"_"];
+    }
+    return result.length ? result : @"unknown";
+}
+
+static BOOL FZIconPathAlreadyUsable(id item)
+{
+    id path = FZIconObjectSelector(item, @"iconPath");
+    return [path isKindOfClass:NSString.class] && [path length] &&
+        [NSFileManager.defaultManager fileExistsAtPath:path];
+}
+
+static UIImage *FZIconFromResourceProxy(id proxy)
+{
+    if (!proxy) return nil;
+    SEL selector = NSSelectorFromString(@"_iconForResourceProxy:variant:variantsScale:");
+    if (![UIImage respondsToSelector:selector]) return nil;
+
+    // SafariPlus uses variant 19 for a resource proxy and documents 26/36 as
+    // additional valid variants. Try those exact observed values only.
+    const int variants[] = {19, 26, 36};
+    CGFloat scale = UIScreen.mainScreen.scale ?: 2.0;
+    for (NSUInteger index = 0; index < sizeof(variants) / sizeof(variants[0]); index++) {
+        UIImage *image = nil;
+        @try {
+            image = ((id (*)(id, SEL, id, int, float))objc_msgSend)(
+                UIImage.class, selector, proxy, variants[index], (float)scale);
+        } @catch (__unused NSException *exception) {
+            image = nil;
+        }
+        if ([image isKindOfClass:UIImage.class] && image.size.width > 0 && image.size.height > 0) {
+            NSLog(@"[AppIconResourceProxyFix] resource-proxy icon variant=%d", variants[index]);
+            return image;
+        }
+    }
+    return nil;
+}
+
+static UIImage *FZIconFromBundleIdentifier(NSString *identifier)
+{
+    if (!identifier.length) return nil;
+    SEL selector = NSSelectorFromString(@"_applicationIconImageForBundleIdentifier:format:scale:");
+    if (![UIImage respondsToSelector:selector]) return nil;
+    CGFloat scale = UIScreen.mainScreen.scale ?: 2.0;
+    UIImage *image = nil;
+    @try {
+        image = ((id (*)(id, SEL, id, int, double))objc_msgSend)(
+            UIImage.class, selector, identifier, 10, (double)scale);
+    } @catch (__unused NSException *exception) {
+        image = nil;
+    }
+    return [image isKindOfClass:UIImage.class] ? image : nil;
+}
+
+static BOOL FZInstallResourceProxyIcon(id item)
+{
+    if (!item || FZIconPathAlreadyUsable(item)) return YES;
+    id proxy = FZIconObjectSelector(item, @"appProxy");
+    NSString *identifier = FZIconIdentifier(item);
+    if (!proxy || !identifier.length) return NO;
+
+    UIImage *image = FZIconFromResourceProxy(proxy) ?: FZIconFromBundleIdentifier(identifier);
+    NSData *png = image ? UIImagePNGRepresentation(image) : nil;
+    if (!png.length) return NO;
+
+    NSString *cache = NSSearchPathForDirectoriesInDomains(NSCachesDirectory,
+        NSUserDomainMask, YES).firstObject ?: NSTemporaryDirectory();
+    NSString *directory = [cache stringByAppendingPathComponent:@"FilzaAppIconsResourceProxy"];
+    [NSFileManager.defaultManager createDirectoryAtPath:directory
+                            withIntermediateDirectories:YES attributes:nil error:nil];
+    NSString *path = [[directory stringByAppendingPathComponent:FZIconSafeComponent(identifier)]
+        stringByAppendingPathExtension:@"png"];
+    if (![png writeToFile:path atomically:YES]) return NO;
+
+    SEL setter = NSSelectorFromString(@"setIconPath:");
+    if (![item respondsToSelector:setter]) return NO;
+    ((void (*)(id, SEL, id))objc_msgSend)(item, setter, path);
+    NSLog(@"[AppIconResourceProxyFix] icon ready id=%@ path=%@", identifier, path);
+    return YES;
+}
+
+static void FZScheduleIconRetry(id item)
+{
+    if (!item || FZIconPathAlreadyUsable(item)) return;
+    NSUInteger retry = [objc_getAssociatedObject(item, kIconResourceRetryKey) unsignedIntegerValue];
+    if (retry >= 3) return;
+    objc_setAssociatedObject(item, kIconResourceRetryKey, @(retry + 1),
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    __weak id weakItem = item;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                 (int64_t)((0.4 + (0.6 * retry)) * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        id strongItem = weakItem;
+        if (!strongItem) return;
+        if (!FZInstallResourceProxyIcon(strongItem)) FZScheduleIconRetry(strongItem);
+    });
+}
+
+static void FZIconResourceSetAppProxy(id self, SEL _cmd, id proxy)
+{
+    if (gIconResourcePreviousSetAppProxy)
+        ((void (*)(id, SEL, id))gIconResourcePreviousSetAppProxy)(self, _cmd, proxy);
+    if (!FZInstallResourceProxyIcon(self)) FZScheduleIconRetry(self);
+}
+
+static void FZIconResourceReload(id self, SEL _cmd)
+{
+    if (gIconResourcePreviousReload)
+        ((void (*)(id, SEL))gIconResourcePreviousReload)(self, _cmd);
+    if (!FZInstallResourceProxyIcon(self)) FZScheduleIconRetry(self);
+}
+
+static IMP FZIconInstallHook(Class cls, SEL selector, IMP replacement)
+{
+    Method method = cls ? class_getInstanceMethod(cls, selector) : NULL;
+    if (!method) return NULL;
+    const char *types = method_getTypeEncoding(method);
+    IMP original = method_getImplementation(method);
+    if (class_addMethod(cls, selector, replacement, types)) return original;
+    method = class_getInstanceMethod(cls, selector);
+    if (!method) return NULL;
+    original = method_getImplementation(method);
+    if (original != replacement) method_setImplementation(method, replacement);
+    return original;
+}
+
+static void FZInstallIconResourceProxyFix(void)
+{
+    if (gIconResourceHooksInstalled) return;
+    Class item = NSClassFromString(@"ApplicationItem");
+    if (!item) return;
+
+    gIconResourcePreviousSetAppProxy = FZIconInstallHook(
+        item, NSSelectorFromString(@"setAppProxy:"), (IMP)FZIconResourceSetAppProxy);
+    gIconResourcePreviousReload = FZIconInstallHook(
+        item, NSSelectorFromString(@"reload"), (IMP)FZIconResourceReload);
+    if (!gIconResourcePreviousSetAppProxy && !gIconResourcePreviousReload) return;
+
+    gIconResourceHooksInstalled = YES;
+    NSLog(@"[AppIconResourceProxyFix] hooks installed proxy=%d reload=%d",
+          gIconResourcePreviousSetAppProxy != NULL,
+          gIconResourcePreviousReload != NULL);
+}
+
+__attribute__((constructor)) static void FZIconResourceProxyInit(void)
+{
+    // The existing presentation and metadata retry layers install first.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC),
+                   dispatch_get_main_queue(), ^{
+        FZInstallIconResourceProxyFix();
+    });
+}

--- a/AppMetadataRetryFix.m
+++ b/AppMetadataRetryFix.m
@@ -1,0 +1,199 @@
+@import Foundation;
+
+#import <dirent.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+#include <stdint.h>
+
+#import "AppsMusicFix.h"
+
+static IMP gMetadataRetryPreviousSetAppProxy = NULL;
+static IMP gMetadataRetryPreviousSetDocumentPath = NULL;
+static IMP gMetadataRetryPreviousReload = NULL;
+static BOOL gMetadataRetryHooksInstalled = NO;
+
+static const void *kMetadataRetryPendingKey = &kMetadataRetryPendingKey;
+static const void *kMetadataRetryCountKey = &kMetadataRetryCountKey;
+
+static id FZRetryObjectSelector(id object, NSString *selectorName)
+{
+    if (!object || !selectorName.length) return nil;
+    SEL selector = NSSelectorFromString(selectorName);
+    if (![object respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL))objc_msgSend)(object, selector);
+}
+
+static NSString *FZRetryIdentifier(id item)
+{
+    id value = FZRetryObjectSelector(item, @"bundleId");
+    if ([value isKindOfClass:NSString.class] && [value length]) return value;
+
+    id proxy = FZRetryObjectSelector(item, @"appProxy");
+    for (NSString *selectorName in @[@"applicationIdentifier", @"bundleIdentifier"]) {
+        value = FZRetryObjectSelector(proxy, selectorName);
+        if ([value isKindOfClass:NSString.class] && [value length]) return value;
+    }
+    return nil;
+}
+
+static BOOL FZRetryCanEnumerate(NSString *path)
+{
+    if (![path isKindOfClass:NSString.class] || !path.length || !path.isAbsolutePath) return NO;
+    DIR *directory = opendir(path.fileSystemRepresentation);
+    if (!directory) return NO;
+    errno = 0;
+    (void)readdir(directory);
+    int readError = errno;
+    closedir(directory);
+    return readError == 0;
+}
+
+static uint64_t FZRetryCurrentFileSize(id item)
+{
+    SEL selector = NSSelectorFromString(@"fileSize");
+    if (![item respondsToSelector:selector]) return 0;
+    return ((uint64_t (*)(id, SEL))objc_msgSend)(item, selector);
+}
+
+static void FZRetryResetCalculatedFlag(id item)
+{
+    Class cls = NSClassFromString(@"ApplicationItem");
+    Ivar ivar = cls ? class_getInstanceVariable(cls, "_calculatedDiskUsage") : NULL;
+    if (ivar) {
+        ptrdiff_t offset = ivar_getOffset(ivar);
+        uint8_t *bytes = (__bridge void *)item;
+        *((BOOL *)(bytes + offset)) = NO;
+    }
+
+    SEL sizeSetter = NSSelectorFromString(@"setFileSize:");
+    if ([item respondsToSelector:sizeSetter])
+        ((void (*)(id, SEL, uint64_t))objc_msgSend)(item, sizeSetter, 0);
+}
+
+static void FZScheduleMetadataRefresh(id item, NSTimeInterval delay)
+{
+    if (!item || [objc_getAssociatedObject(item, kMetadataRetryPendingKey) boolValue]) return;
+    objc_setAssociatedObject(item, kMetadataRetryPendingKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    __weak id weakItem = item;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        id strongItem = weakItem;
+        if (!strongItem) return;
+        objc_setAssociatedObject(strongItem, kMetadataRetryPendingKey, nil,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        if (FZRetryCurrentFileSize(strongItem) > 0) return;
+
+        NSString *identifier = FZRetryIdentifier(strongItem);
+        if (!identifier.length) return;
+
+        NSString *documentPath = FZRetryObjectSelector(strongItem, @"documentPath");
+        NSString *detail = nil;
+        if (![documentPath isKindOfClass:NSString.class] || !FZRetryCanEnumerate(documentPath)) {
+            NSString *resolved = FilzaEnsureVirtualAppDataPath(identifier, &detail);
+            if (resolved.length && FZRetryCanEnumerate(resolved)) {
+                SEL documentSetter = NSSelectorFromString(@"setDocumentPath:");
+                if ([strongItem respondsToSelector:documentSetter])
+                    ((void (*)(id, SEL, id))objc_msgSend)(strongItem, documentSetter, resolved);
+                documentPath = resolved;
+            }
+        }
+
+        if ([documentPath isKindOfClass:NSString.class] && FZRetryCanEnumerate(documentPath)) {
+            FZRetryResetCalculatedFlag(strongItem);
+            SEL calculate = NSSelectorFromString(@"calculateDiskUsage");
+            if ([strongItem respondsToSelector:calculate])
+                ((void (*)(id, SEL))objc_msgSend)(strongItem, calculate);
+        }
+
+        // bad_query_list discovery is asynchronous. A zero-size result before
+        // the identifier->UUID map is ready must not become permanent UI state.
+        if (FZRetryCurrentFileSize(strongItem) == 0) {
+            NSUInteger retries = [objc_getAssociatedObject(strongItem, kMetadataRetryCountKey)
+                unsignedIntegerValue];
+            if (retries < 4) {
+                objc_setAssociatedObject(strongItem, kMetadataRetryCountKey, @(retries + 1),
+                                         OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                FZScheduleMetadataRefresh(strongItem, 1.0 + (0.5 * retries));
+            } else {
+                NSLog(@"[AppMetadataRetryFix] unresolved size id=%@ detail=%@",
+                      identifier, detail ?: @"no detail");
+            }
+        } else {
+            objc_setAssociatedObject(strongItem, kMetadataRetryCountKey, nil,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            NSLog(@"[AppMetadataRetryFix] live size refreshed id=%@ bytes=%llu",
+                  identifier, FZRetryCurrentFileSize(strongItem));
+        }
+    });
+}
+
+static void FZRetrySetAppProxy(id self, SEL _cmd, id proxy)
+{
+    if (gMetadataRetryPreviousSetAppProxy)
+        ((void (*)(id, SEL, id))gMetadataRetryPreviousSetAppProxy)(self, _cmd, proxy);
+    FZScheduleMetadataRefresh(self, 0.75);
+}
+
+static void FZRetrySetDocumentPath(id self, SEL _cmd, id path)
+{
+    if (gMetadataRetryPreviousSetDocumentPath)
+        ((void (*)(id, SEL, id))gMetadataRetryPreviousSetDocumentPath)(self, _cmd, path);
+    FZScheduleMetadataRefresh(self, 0.05);
+}
+
+static void FZRetryReload(id self, SEL _cmd)
+{
+    if (gMetadataRetryPreviousReload)
+        ((void (*)(id, SEL))gMetadataRetryPreviousReload)(self, _cmd);
+    if (FZRetryCurrentFileSize(self) == 0)
+        FZScheduleMetadataRefresh(self, 0.5);
+}
+
+static IMP FZRetryInstallHook(Class cls, SEL selector, IMP replacement)
+{
+    Method method = cls ? class_getInstanceMethod(cls, selector) : NULL;
+    if (!method) return NULL;
+    const char *types = method_getTypeEncoding(method);
+    IMP original = method_getImplementation(method);
+    if (class_addMethod(cls, selector, replacement, types)) return original;
+    method = class_getInstanceMethod(cls, selector);
+    if (!method) return NULL;
+    original = method_getImplementation(method);
+    if (original != replacement) method_setImplementation(method, replacement);
+    return original;
+}
+
+static void FZInstallAppMetadataRetryFix(void)
+{
+    if (gMetadataRetryHooksInstalled) return;
+    Class item = NSClassFromString(@"ApplicationItem");
+    if (!item) return;
+
+    gMetadataRetryPreviousSetAppProxy = FZRetryInstallHook(
+        item, NSSelectorFromString(@"setAppProxy:"), (IMP)FZRetrySetAppProxy);
+    gMetadataRetryPreviousSetDocumentPath = FZRetryInstallHook(
+        item, NSSelectorFromString(@"setDocumentPath:"), (IMP)FZRetrySetDocumentPath);
+    gMetadataRetryPreviousReload = FZRetryInstallHook(
+        item, NSSelectorFromString(@"reload"), (IMP)FZRetryReload);
+
+    if (!gMetadataRetryPreviousSetAppProxy && !gMetadataRetryPreviousSetDocumentPath &&
+        !gMetadataRetryPreviousReload) return;
+
+    gMetadataRetryHooksInstalled = YES;
+    NSLog(@"[AppMetadataRetryFix] live metadata retry hooks installed proxy=%d path=%d reload=%d",
+          gMetadataRetryPreviousSetAppProxy != NULL,
+          gMetadataRetryPreviousSetDocumentPath != NULL,
+          gMetadataRetryPreviousReload != NULL);
+}
+
+__attribute__((constructor)) static void FZAppMetadataRetryInit(void)
+{
+    // Install after the existing AppsManagerPresentationFix hooks so this layer
+    // wraps them instead of replacing their icon/size behavior.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1500 * NSEC_PER_MSEC),
+                   dispatch_get_main_queue(), ^{
+        FZInstallAppMetadataRetryFix();
+    });
+}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BAD_QUERY_ROOT := ThirdParty/bad_query
 # TGMusicLibraryViewController contents in-place with the real ByeTunes SwiftUI
 # root; the older custom table and modal full-app launcher are intentionally not
 # linked anymore.
-FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m VirtualBackendFix.m SystemPathDiagnostics.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
+FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m VirtualBackendFix.m SystemPathDiagnostics.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 
 # Pinned upstream bad_query is used only as a per-container fallback when the
 # MobileHouseArrest class-2 lease resolves a foreign app root but cannot issue
@@ -76,6 +76,7 @@ before-FilzaApplySandboxExt-all::
 	@test -f "$(BAD_QUERY_ROOT)/bad_query/bad_query.c" || (echo "Missing pinned bad_query submodule. Run: git submodule update --init --recursive" >&2; exit 1)
 	@test -f "$(BAD_QUERY_ROOT)/bad_query/bad_query.h" || (echo "Incomplete bad_query submodule" >&2; exit 1)
 	@test -f "AppProxyMetadataFix.m" || (echo "Missing AppProxyMetadataFix.m" >&2; exit 1)
+	@test -f "AppMetadataRetryFix.m" || (echo "Missing AppMetadataRetryFix.m" >&2; exit 1)
 	@test -f "VirtualBackendFix.m" || (echo "Missing VirtualBackendFix.m" >&2; exit 1)
 	@test -f "SystemPathDiagnostics.m" || (echo "Missing SystemPathDiagnostics.m" >&2; exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,12 @@ BAD_QUERY_ROOT := ThirdParty/bad_query
 # TGMusicLibraryViewController contents in-place with the real ByeTunes SwiftUI
 # root; the older custom table and modal full-app launcher are intentionally not
 # linked anymore.
-FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
+FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 
-# Pinned upstream bad_query is used only as a per-container fallback when the
-# MobileHouseArrest class-2 lease resolves a foreign app root but cannot issue
-# a usable sandbox extension. Keep the upstream implementation unmodified.
+# Pinned upstream bad_query backs the verified foreign-container and system-root
+# probes. Every exposed path is still accepted only after a real opendir/readdir
+# check in this process; a returned extension handle by itself is not treated as
+# access.
 FilzaApplySandboxExt_FILES += $(BAD_QUERY_ROOT)/bad_query/bad_query.c
 
 # The original jailed Filza kernel path is used only by the exact iOS 18.5
@@ -80,5 +81,6 @@ before-FilzaApplySandboxExt-all::
 	@test -f "AppIconResourceProxyFix.m" || (echo "Missing AppIconResourceProxyFix.m" >&2; exit 1)
 	@test -f "VirtualBackendFix.m" || (echo "Missing VirtualBackendFix.m" >&2; exit 1)
 	@test -f "SystemPathDiagnostics.m" || (echo "Missing SystemPathDiagnostics.m" >&2; exit 1)
+	@test -f "BadQuerySystemProbe.m" || (echo "Missing BadQuerySystemProbe.m" >&2; exit 1)
 
 include $(THEOS_MAKE_PATH)/tweak.mk

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BAD_QUERY_ROOT := ThirdParty/bad_query
 # TGMusicLibraryViewController contents in-place with the real ByeTunes SwiftUI
 # root; the older custom table and modal full-app launcher are intentionally not
 # linked anymore.
-FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m VirtualBackendFix.m SystemPathDiagnostics.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
+FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 
 # Pinned upstream bad_query is used only as a per-container fallback when the
 # MobileHouseArrest class-2 lease resolves a foreign app root but cannot issue
@@ -77,6 +77,7 @@ before-FilzaApplySandboxExt-all::
 	@test -f "$(BAD_QUERY_ROOT)/bad_query/bad_query.h" || (echo "Incomplete bad_query submodule" >&2; exit 1)
 	@test -f "AppProxyMetadataFix.m" || (echo "Missing AppProxyMetadataFix.m" >&2; exit 1)
 	@test -f "AppMetadataRetryFix.m" || (echo "Missing AppMetadataRetryFix.m" >&2; exit 1)
+	@test -f "AppIconResourceProxyFix.m" || (echo "Missing AppIconResourceProxyFix.m" >&2; exit 1)
 	@test -f "VirtualBackendFix.m" || (echo "Missing VirtualBackendFix.m" >&2; exit 1)
 	@test -f "SystemPathDiagnostics.m" || (echo "Missing SystemPathDiagnostics.m" >&2; exit 1)
 

--- a/scripts/patch-byetunes-embedded.sh
+++ b/scripts/patch-byetunes-embedded.sh
@@ -14,59 +14,81 @@ device = Path(sys.argv[1])
 content = Path(sys.argv[2])
 
 ds = device.read_text()
-old_logger = '''        let logPath = FileManager.default.temporaryDirectory.appendingPathComponent("idevice-logs.txt").path
-        let cString = strdup(logPath)
-        defer { free(cString) }
-        idevice_init_logger(Info, Disabled, cString)
-'''
-new_logger = '''        // Filza owns this process. Do not initialize idevice's process-global
-        // tracing/FFI logger while SwiftUI is still constructing the embedded root.
-        // Transport initialization remains available from the explicit pairing/import flow.
-        Logger.shared.log("[DeviceManager] Filza embed: deferred idevice logger initialization")
-'''
-if old_logger in ds:
-    ds = ds.replace(old_logger, new_logger, 1)
-elif new_logger not in ds:
-    raise SystemExit('embedded DeviceManager logger patch anchor not found')
 init_start = ds.find("    private init() {")
 if init_start < 0:
     raise SystemExit('DeviceManager private init not found')
 init_end = ds.find("\n    private func ", init_start)
 if init_end < 0:
-    init_end = len(ds)
-init_block = ds[init_start:init_end]
-old_refresh = "        refreshExpectedPairingFileState()\n"
-new_refresh = '''        hasValidExpectedPairingFile = false
-        Logger.shared.log("[DeviceManager] Filza embed: pairing validation deferred until explicit import")
-'''
-if old_refresh in init_block:
-    init_block = init_block.replace(old_refresh, new_refresh, 1)
-    ds = ds[:init_start] + init_block + ds[init_end:]
-elif 'pairing validation deferred until explicit import' not in init_block:
-    raise SystemExit('DeviceManager init refresh anchor not found')
+    raise SystemExit('DeviceManager private init end not found')
 
+# Filza owns the process. DeviceManager.shared is created while SwiftUI builds
+# ContentView, so its embedded initializer must not touch process-global FFI,
+# app-group storage, pairing files, sockets, or tunnel state. Those operations
+# stay in the existing explicit import/connect methods and begin only after the
+# user presses the pairing-file import action.
+safe_init = '''    private init() {
+        Logger.shared.log("===========================================")
+        Logger.shared.log("[DeviceManager] BUILD VERSION: \\(BUILD_VERSION)")
+        Logger.shared.log("===========================================")
+        Logger.shared.log("[DeviceManager] Filza embed: inert startup initialized")
+        hasValidExpectedPairingFile = false
+        heartbeatReady = false
+        connectionStatus = "Disconnected"
+        Logger.shared.log("[DeviceManager] Filza embed: all pairing/transport/storage work deferred until explicit import")
+    }
+'''
+ds = ds[:init_start] + safe_init + ds[init_end:]
 device.write_text(ds)
 
 cs = content.read_text()
-old_startup = '''            manager.refreshExpectedPairingFileState()
+old_appear = '''        .onAppear {
+            cleanupLegacyImportedAudioFiles()
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showSplash = false
+                }
+            }
+            manager.refreshExpectedPairingFileState()
             hasCompletedOnboarding = manager.hasValidExpectedPairingFile || manager.needsRPPairingFileUpgrade
             if manager.hasValidExpectedPairingFile {
                 manager.startHeartbeat()
             }
+            
+            
+            checkPendingInjections()
+            checkForAppUpdate()
+        }
 '''
-new_startup = '''            // Filza embed: mount the full ByeTunes UI before touching idevice/RP FFI.
-            // The existing onboarding/import action remains the explicit transport entry point.
+new_appear = '''        .onAppear {
+            // Filza embed: rendering this view must be side-effect free. In the
+            // standalone app these startup helpers touch app-group storage,
+            // pairing parsers, network transport and update state. None of that
+            // is required to draw the UI, and a failure in any one subsystem
+            // previously took down Filza with it.
+            Logger.shared.log("[ContentView] Filza embed: safe onAppear entered")
             hasCompletedOnboarding = false
-            Logger.shared.log("[ContentView] Filza embed: transport startup deferred until explicit pairing import")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                withAnimation(.easeOut(duration: 0.5)) {
+                    showSplash = false
+                }
+                Logger.shared.log("[ContentView] Filza embed: splash completed; waiting for explicit pairing import")
+            }
+        }
 '''
-if old_startup in cs:
-    cs = cs.replace(old_startup, new_startup, 1)
-elif new_startup not in cs:
-    raise SystemExit('embedded ContentView startup patch anchor not found')
+if old_appear not in cs:
+    raise SystemExit('embedded ContentView onAppear anchor not found')
+cs = cs.replace(old_appear, new_appear, 1)
 content.write_text(cs)
 PY
 
-grep -Fq 'Filza embed: deferred idevice logger initialization' "$DEVICE"
-grep -Fq 'Filza embed: transport startup deferred until explicit pairing import' "$CONTENT"
-grep -Fq 'Filza embed: pairing validation deferred until explicit import' "$DEVICE"
-! grep -A12 -F 'private init() {' "$DEVICE" | grep -Fq 'idevice_init_logger('
+grep -Fq 'Filza embed: inert startup initialized' "$DEVICE"
+grep -Fq 'all pairing/transport/storage work deferred until explicit import' "$DEVICE"
+grep -Fq 'Filza embed: safe onAppear entered' "$CONTENT"
+! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'idevice_init_logger('
+! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'regularPairingFile'
+! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'refreshExpectedPairingFileState()'
+# The explicit import/connect paths must remain present; this patch only removes
+# automatic startup work.
+grep -Fq 'func importPairingFile(from url: URL) throws' "$DEVICE"
+grep -Fq 'func startHeartbeat(forceReconnect: Bool = false' "$DEVICE"


### PR DESCRIPTION
Fixes the observed iOS 27 behavior without inventing access that the process does not have:

- retries app disk usage after the foreign data-container bad_query mapping becomes available instead of leaving an early 0-byte result permanent
- retries after ApplicationItem gains its real document path
- adds a UIKit resource-proxy icon fallback using the observed `_iconForResourceProxy:variant:variantsScale:` path and variants used by open-source iOS tooling
- makes embedded ByeTunes `DeviceManager` construction side-effect free: no idevice logger, app-group storage, pairing parse, socket/tunnel, heartbeat, pending injection, or update request during initial SwiftUI mount
- keeps pairing/transport work behind the existing explicit import/connect actions
- actually links the existing `BadQuerySystemProbe.m` into the shipped dylib; it tests the requested system roots and only creates a Filza link after a real post-extension `opendir/readdir` succeeds

The system-root path remains evidence-driven: a returned bad_query handle is never treated as proof of access, and denied roots remain denied.