### PR TITLE
Require publishing the generated IPA artifact

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -172,7 +172,6 @@ jobs:
           cp .theos/obj/FilzaApplySandboxExt.dylib "$APP/Frameworks/FilzaApplySandboxExt.dylib"
           codesign --remove-signature "$APP/Frameworks/FilzaApplySandboxExt.dylib" >/dev/null 2>&1 || true
 
-          # SignatureSolver and the embedded SwiftUI UI resolve these from Bundle.main.
           cp .theos/byetunes-resources/meriyah.umd.js "$APP/meriyah.umd.js"
           cp .theos/byetunes-resources/astring.umd.js "$APP/astring.umd.js"
           cp .theos/byetunes-resources/yt_ejs_helper.js "$APP/yt_ejs_helper.js"
@@ -183,16 +182,10 @@ jobs:
             cp -R .theos/byetunes-appintents/Metadata.appintents "$APP/Metadata.appintents"
           fi
 
-          # Make the Gestalt entry visible from the Home Screen even before the
-          # runtime-generated shortcut has had a chance to persist.
           plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Manager","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
-
-          # Preserve the document-facing pieces needed by the embedded music tools.
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
 
-          # The base executable must already load the replacement dylib. Failing
-          # this check means the output would silently be an old app again.
           otool -L "$APP/$EXECUTABLE" | grep -F 'FilzaApplySandboxExt.dylib'
           test -s "$APP/Frameworks/FilzaApplySandboxExt.dylib"
           test -s "$APP/meriyah.umd.js"
@@ -220,4 +213,6 @@ jobs:
             .theos/obj/FilzaApplySandboxExt.dylib
             .theos/byetunes-resources/**
             .theos/byetunes-appintents/Metadata.appintents/**
+          if-no-files-found: error
+          include-hidden-files: true
           retention-days: 14


### PR DESCRIPTION
Makes the installable IPA upload mandatory. Hidden `.theos` outputs are now included and the workflow fails if no artifact files are found, so a green build can no longer mean “IPA built but nothing downloadable.”

## Summary by Sourcery

Require successful builds to upload installable IPA artifacts and associated hidden outputs.

Build:
- Update GitHub Actions workflow to treat missing IPA artifacts as an error and include hidden .theos outputs in uploaded artifacts.

Chores:
- Remove non-essential inline comments from the verify-safe-fixes workflow steps.