### PR TITLE
Fix quick actions, Files diagnostics, and ByeTunes lifecycle

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -46,6 +46,8 @@ jobs:
           test -f ThirdParty/bad_query/bad_query/bad_query.c
           test -f GestaltManager.m
           test -f ByeTunesFilzaLibraryEmbed.m
+          test -f FilzaDiagnostics.m
+          test -f FilzaQuickActions.m
 
       - name: Syntax-check runtime integrations
         run: |
@@ -69,6 +71,8 @@ jobs:
           xcrun --sdk iphoneos clang "${COMMON[@]}" AppsManagerPresentationFix.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" ByeTunesMusicBridge.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" ByeTunesFilzaLibraryEmbed.m
+          xcrun --sdk iphoneos clang "${COMMON[@]}" FilzaDiagnostics.m
+          xcrun --sdk iphoneos clang "${COMMON[@]}" FilzaQuickActions.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" ThirdParty/bad_query/bad_query/bad_query.c
 
       - name: Install Procursus build tools
@@ -129,10 +133,12 @@ jobs:
           test "$(lipo -archs "$DYLIB")" = "arm64"
           grep -aFq 'Gestalt Manager' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.gestalt-manager' "$DYLIB"
+          grep -aFq 'com.nightvibes33.filzaslop.apps-manager' "$DYLIB"
+          grep -aFq 'com.nightvibes33.filzaslop.music-library' "$DYLIB"
+          grep -aFq 'FilzaSlop Logs' "$DYLIB"
+          grep -aFq 'LastSignal.txt' "$DYLIB"
+          grep -aFq 'TGMusicLibraryViewController viewDidAppear intercepted' "$DYLIB"
           grep -aFq 'ByeTunesEmbeddedHostFactory' "$DYLIB"
-          grep -aFq 'inert UIKit launcher visible' "$DYLIB"
-          grep -aFq 'ByeTunesEmbedStage.txt' "$DYLIB"
-          grep -aFq 'TGMusicLibraryViewController' "$DYLIB"
           shasum -a 256 "$DYLIB"
 
       - name: Generate ByeTunes AppIntents metadata
@@ -182,9 +188,26 @@ jobs:
             cp -R .theos/byetunes-appintents/Metadata.appintents "$APP/Metadata.appintents"
           fi
 
-          plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Manager","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
+          plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open ByeTunes","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
+
+          python3 - "$APP/Info.plist" <<'PY'
+          import plistlib, sys
+          with open(sys.argv[1], 'rb') as f:
+              info = plistlib.load(f)
+          actions = info.get('UIApplicationShortcutItems', [])
+          assert len(actions) == 3, actions
+          assert [a['UIApplicationShortcutItemTitle'] for a in actions] == ['Apps Manager', 'Music Library', 'Gestalt Editor'], actions
+          assert [a['UIApplicationShortcutItemType'] for a in actions] == [
+              'com.nightvibes33.filzaslop.apps-manager',
+              'com.nightvibes33.filzaslop.music-library',
+              'com.nightvibes33.filzaslop.gestalt-manager',
+          ], actions
+          assert info.get('UIFileSharingEnabled') is True
+          assert info.get('LSSupportsOpeningDocumentsInPlace') is True
+          print('Verified exactly three quick actions and Files/Documents exposure flags')
+          PY
 
           otool -L "$APP/$EXECUTABLE" | grep -F 'FilzaApplySandboxExt.dylib'
           test -s "$APP/Frameworks/FilzaApplySandboxExt.dylib"
@@ -192,7 +215,6 @@ jobs:
           test -s "$APP/astring.umd.js"
           test -s "$APP/yt_ejs_helper.js"
           test -s "$APP/AppIconImage.png"
-          plutil -extract UIApplicationShortcutItems xml1 -o - "$APP/Info.plist" | grep -F 'Gestalt Manager'
 
           OUTPUT="$GITHUB_WORKSPACE/.theos/FilzaSlop-main-${GITHUB_SHA::7}-unsigned.ipa"
           rm -f "$OUTPUT"

--- a/ByeTunesFilzaLibraryEmbed.m
+++ b/ByeTunesFilzaLibraryEmbed.m
@@ -3,28 +3,16 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+#import "FilzaDiagnostics.h"
+
 static const void *kByeTunesFilzaLibraryHostKey = &kByeTunesFilzaLibraryHostKey;
 static IMP gByeTunesSuperMusicViewDidLoad = NULL;
+static IMP gByeTunesSuperMusicViewDidAppear = NULL;
 static BOOL gByeTunesMusicHookInstalled = NO;
-
-static NSString *ByeTunesCrashStagePath(void)
-{
-    NSString *documents = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
-                                                               NSUserDomainMask,
-                                                               YES).firstObject;
-    if (!documents.length) documents = NSTemporaryDirectory();
-    return [documents stringByAppendingPathComponent:@"ByeTunesEmbedStage.txt"];
-}
 
 static void ByeTunesWriteStage(NSString *stage)
 {
-    NSString *line = [NSString stringWithFormat:@"%@ | %@\n",
-                      NSDate.date.description,
-                      stage ?: @"unknown"];
-    [line writeToFile:ByeTunesCrashStagePath()
-           atomically:YES
-             encoding:NSUTF8StringEncoding
-                error:nil];
+    FilzaDiagnosticsWriteByeTunesStage(stage ?: @"unknown");
     NSLog(@"[ByeTunesPort][stage] %@", stage);
 }
 
@@ -115,7 +103,7 @@ static UIViewController *ByeTunesMakeSwiftController(void)
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *host = ByeTunesMakeSwiftController();
         if (!host) {
-            self.statusLabel.text = @"ByeTunes Swift host could not be created. See ByeTunesEmbedStage.txt.";
+            self.statusLabel.text = @"ByeTunes Swift host could not be created. See Files > FilzaSlop > FilzaSlop Logs.";
             self.loadButton.enabled = YES;
             self.loading = NO;
             return;
@@ -142,7 +130,7 @@ static UIViewController *ByeTunesMakeSwiftController(void)
             [host willMoveToParentViewController:nil];
             [host.view removeFromSuperview];
             [host removeFromParentViewController];
-            self.statusLabel.text = @"ByeTunes failed while attaching its UI. See ByeTunesEmbedStage.txt.";
+            self.statusLabel.text = @"ByeTunes failed while attaching its UI. See Files > FilzaSlop > FilzaSlop Logs.";
             self.loadButton.enabled = YES;
             self.loading = NO;
         }
@@ -176,10 +164,9 @@ static void ByeTunesMusicLibraryViewDidLoad(id self, SEL _cmd)
 {
     ByeTunesWriteStage(@"TGMusicLibraryViewController viewDidLoad intercepted");
 
-    // Do not invoke Filza's TGMusicLibraryViewController implementation. Only
-    // run the superclass implementation, then install a plain UIKit launcher.
-    // Crucially, ContentView() and DeviceManager.shared are not constructed
-    // merely by opening Filza's Music Library anymore.
+    // The original TGMusicLibraryViewController viewDidLoad is intentionally
+    // skipped because it owns Filza's old Music Library implementation. Run the
+    // superclass lifecycle only, then install the isolated ByeTunes launcher.
     if (gByeTunesSuperMusicViewDidLoad)
         ((void (*)(id, SEL))gByeTunesSuperMusicViewDidLoad)(self, _cmd);
 
@@ -193,6 +180,41 @@ static void ByeTunesMusicLibraryViewDidLoad(id self, SEL _cmd)
     });
 }
 
+static void ByeTunesMusicLibraryViewDidAppear(id self, SEL _cmd, BOOL animated)
+{
+    // This companion override is required whenever the subclass viewDidLoad is
+    // bypassed. The original Filza viewDidAppear assumes its browser/model state
+    // was created by TGMusicLibraryViewController's own viewDidLoad and can
+    // dereference that uninitialized state otherwise.
+    ByeTunesWriteStage(@"TGMusicLibraryViewController viewDidAppear intercepted");
+    if (gByeTunesSuperMusicViewDidAppear)
+        ((void (*)(id, SEL, BOOL))gByeTunesSuperMusicViewDidAppear)(self, _cmd, animated);
+    ByeTunesInstallSafeLauncher((UIViewController *)self);
+}
+
+static BOOL ByeTunesOverrideLifecycleMethod(Class musicClass,
+                                             SEL selector,
+                                             IMP replacement,
+                                             IMP *superImplementation)
+{
+    Method resolvedMethod = class_getInstanceMethod(musicClass, selector);
+    if (!resolvedMethod) return NO;
+
+    Class superClass = class_getSuperclass(musicClass);
+    Method superMethod = superClass ? class_getInstanceMethod(superClass, selector) : NULL;
+    if (superImplementation)
+        *superImplementation = superMethod ? method_getImplementation(superMethod) : NULL;
+
+    const char *types = method_getTypeEncoding(resolvedMethod);
+    if (class_addMethod(musicClass, selector, replacement, types)) return YES;
+
+    Method ownedMethod = class_getInstanceMethod(musicClass, selector);
+    if (!ownedMethod) return NO;
+    if (method_getImplementation(ownedMethod) != replacement)
+        method_setImplementation(ownedMethod, replacement);
+    return YES;
+}
+
 static void ByeTunesInstallFilzaMusicLibraryPort(void)
 {
     if (gByeTunesMusicHookInstalled) return;
@@ -203,38 +225,24 @@ static void ByeTunesInstallFilzaMusicLibraryPort(void)
         return;
     }
 
-    SEL selector = @selector(viewDidLoad);
-    Method resolvedMethod = class_getInstanceMethod(musicClass, selector);
-    if (!resolvedMethod) {
-        NSLog(@"[ByeTunesPort] TGMusicLibraryViewController has no viewDidLoad method");
+    BOOL loadHook = ByeTunesOverrideLifecycleMethod(musicClass,
+        @selector(viewDidLoad),
+        (IMP)ByeTunesMusicLibraryViewDidLoad,
+        &gByeTunesSuperMusicViewDidLoad);
+    BOOL appearHook = ByeTunesOverrideLifecycleMethod(musicClass,
+        @selector(viewDidAppear:),
+        (IMP)ByeTunesMusicLibraryViewDidAppear,
+        &gByeTunesSuperMusicViewDidAppear);
+
+    if (!loadHook || !appearHook) {
+        NSLog(@"[ByeTunesPort] failed to install complete Music Library lifecycle isolation load=%d appear=%d",
+              loadHook, appearHook);
         return;
     }
 
-    Class superClass = class_getSuperclass(musicClass);
-    Method superMethod = superClass ? class_getInstanceMethod(superClass, selector) : NULL;
-    gByeTunesSuperMusicViewDidLoad = superMethod ? method_getImplementation(superMethod) : NULL;
-    const char *types = method_getTypeEncoding(resolvedMethod);
-
-    // Install only on TGMusicLibraryViewController. The previous global
-    // UINavigationController pushViewController swizzle is intentionally gone:
-    // it affected every navigation transition in Filza and created a second
-    // independent crash surface before ByeTunes even existed.
-    if (class_addMethod(musicClass,
-                        selector,
-                        (IMP)ByeTunesMusicLibraryViewDidLoad,
-                        types)) {
-        gByeTunesMusicHookInstalled = YES;
-        NSLog(@"[ByeTunesPort] installed safe class-local Music Library override");
-        return;
-    }
-
-    Method ownedMethod = class_getInstanceMethod(musicClass, selector);
-    if (!ownedMethod) return;
-    IMP current = method_getImplementation(ownedMethod);
-    if (current != (IMP)ByeTunesMusicLibraryViewDidLoad)
-        method_setImplementation(ownedMethod, (IMP)ByeTunesMusicLibraryViewDidLoad);
     gByeTunesMusicHookInstalled = YES;
-    NSLog(@"[ByeTunesPort] installed safe class-local Music Library override");
+    ByeTunesWriteStage(@"safe Music Library lifecycle hooks installed");
+    NSLog(@"[ByeTunesPort] installed safe class-local Music Library lifecycle overrides");
 }
 
 __attribute__((constructor)) static void ByeTunesFilzaLibraryPortInit(void)

--- a/FilzaDiagnostics.h
+++ b/FilzaDiagnostics.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+FOUNDATION_EXPORT NSString *FilzaDiagnosticsDirectory(void);
+FOUNDATION_EXPORT void FilzaDiagnosticsAppend(NSString *component, NSString *message);
+FOUNDATION_EXPORT void FilzaDiagnosticsWriteByeTunesStage(NSString *stage);
+NS_ASSUME_NONNULL_END

--- a/FilzaDiagnostics.m
+++ b/FilzaDiagnostics.m
@@ -1,0 +1,167 @@
+@import Foundation;
+@import UIKit;
+
+#import <fcntl.h>
+#import <limits.h>
+#import <signal.h>
+#import <stdio.h>
+#import <string.h>
+#import <unistd.h>
+
+#import "FilzaDiagnostics.h"
+
+static char gFilzaSignalPath[PATH_MAX];
+static NSUncaughtExceptionHandler *gPreviousExceptionHandler = NULL;
+
+NSString *FilzaDiagnosticsDirectory(void)
+{
+    NSString *documents = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
+                                                               NSUserDomainMask,
+                                                               YES).firstObject;
+    if (!documents.length) documents = NSTemporaryDirectory();
+    NSString *directory = [documents stringByAppendingPathComponent:@"FilzaSlop Logs"];
+    [NSFileManager.defaultManager createDirectoryAtPath:directory
+                            withIntermediateDirectories:YES
+                                             attributes:nil
+                                                  error:nil];
+    return directory;
+}
+
+static void FilzaAppendTextToPath(NSString *path, NSString *text)
+{
+    if (!path.length || !text.length) return;
+    NSData *data = [text dataUsingEncoding:NSUTF8StringEncoding];
+    if (!data.length) return;
+
+    NSFileManager *fm = NSFileManager.defaultManager;
+    if (![fm fileExistsAtPath:path]) [fm createFileAtPath:path contents:nil attributes:nil];
+    NSFileHandle *handle = [NSFileHandle fileHandleForWritingAtPath:path];
+    if (!handle) return;
+    @try {
+        [handle seekToEndOfFile];
+        [handle writeData:data];
+        [handle synchronizeFile];
+        [handle closeFile];
+    } @catch (__unused NSException *exception) {
+        @try { [handle closeFile]; } @catch (__unused NSException *ignored) {}
+    }
+}
+
+void FilzaDiagnosticsAppend(NSString *component, NSString *message)
+{
+    NSString *directory = FilzaDiagnosticsDirectory();
+    NSString *timestamp = [NSISO8601DateFormatter.new stringFromDate:NSDate.date];
+    NSString *line = [NSString stringWithFormat:@"%@ | %@ | %@\n",
+                      timestamp ?: NSDate.date.description,
+                      component.length ? component : @"FilzaSlop",
+                      message.length ? message : @"(empty)"];
+    FilzaAppendTextToPath([directory stringByAppendingPathComponent:@"Runtime.log"], line);
+}
+
+void FilzaDiagnosticsWriteByeTunesStage(NSString *stage)
+{
+    NSString *directory = FilzaDiagnosticsDirectory();
+    NSString *timestamp = [NSISO8601DateFormatter.new stringFromDate:NSDate.date];
+    NSString *line = [NSString stringWithFormat:@"%@ | %@\n",
+                      timestamp ?: NSDate.date.description,
+                      stage.length ? stage : @"unknown"];
+    FilzaAppendTextToPath([directory stringByAppendingPathComponent:@"ByeTunesEmbedStage.txt"], line);
+    FilzaDiagnosticsAppend(@"ByeTunes", stage ?: @"unknown");
+}
+
+static void FilzaUncaughtExceptionHandler(NSException *exception)
+{
+    NSString *reason = [NSString stringWithFormat:@"%@ | %@\n%@",
+                        exception.name ?: @"NSException",
+                        exception.reason ?: @"no reason",
+                        [exception.callStackSymbols componentsJoinedByString:@"\n"] ?: @""];
+    FilzaDiagnosticsAppend(@"UncaughtException", reason);
+    NSString *path = [FilzaDiagnosticsDirectory() stringByAppendingPathComponent:@"LastException.txt"];
+    [reason writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    if (gPreviousExceptionHandler) gPreviousExceptionHandler(exception);
+}
+
+static const char *FilzaSignalName(int signalNumber)
+{
+    switch (signalNumber) {
+        case SIGABRT: return "SIGABRT";
+        case SIGILL: return "SIGILL";
+        case SIGTRAP: return "SIGTRAP";
+        case SIGBUS: return "SIGBUS";
+        case SIGSEGV: return "SIGSEGV";
+        case SIGFPE: return "SIGFPE";
+        default: return "SIGNAL";
+    }
+}
+
+static void FilzaSignalHandler(int signalNumber)
+{
+    if (gFilzaSignalPath[0] == '\0') return;
+    char buffer[160];
+    int count = snprintf(buffer, sizeof(buffer),
+                         "FilzaSlop terminated by %s (%d). Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n",
+                         FilzaSignalName(signalNumber), signalNumber);
+    if (count <= 0) return;
+    if ((size_t)count > sizeof(buffer)) count = (int)sizeof(buffer);
+    int fd = open(gFilzaSignalPath, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+    if (fd >= 0) {
+        (void)write(fd, buffer, (size_t)count);
+        (void)fsync(fd);
+        (void)close(fd);
+    }
+    // SA_RESETHAND resets disposition before this handler runs. Returning lets
+    // the originating fatal condition proceed under its normal disposition.
+}
+
+static void FilzaInstallSignalHandler(int signalNumber)
+{
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    sigemptyset(&action.sa_mask);
+    action.sa_handler = FilzaSignalHandler;
+    action.sa_flags = SA_RESETHAND;
+    (void)sigaction(signalNumber, &action, NULL);
+}
+
+static void FilzaPrepareVisibleDiagnostics(void)
+{
+    NSString *directory = FilzaDiagnosticsDirectory();
+    NSString *readmePath = [directory stringByAppendingPathComponent:@"README.txt"];
+    if (![NSFileManager.defaultManager fileExistsAtPath:readmePath]) {
+        NSString *readme = @"FilzaSlop diagnostics\n\n"
+                            "This folder is intentionally stored inside the app Documents directory so it is visible through the iOS Files app when file sharing is enabled.\n\n"
+                            "Runtime.log: launch/runtime breadcrumbs\n"
+                            "ByeTunesEmbedStage.txt: persistent ByeTunes startup stages\n"
+                            "LastException.txt: last uncaught Objective-C exception\n"
+                            "LastSignal.txt: last fatal POSIX signal observed by the process\n";
+        [readme writeToFile:readmePath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    }
+
+    NSString *signalPath = [directory stringByAppendingPathComponent:@"LastSignal.txt"];
+    const char *raw = signalPath.fileSystemRepresentation;
+    if (raw) strlcpy(gFilzaSignalPath, raw, sizeof(gFilzaSignalPath));
+
+    NSDictionary *bundle = NSBundle.mainBundle.infoDictionary ?: @{};
+    NSString *launch = [NSString stringWithFormat:@"bundle=%@ version=%@ build=%@ os=%@ home=%@",
+                        bundle[@"CFBundleIdentifier"] ?: @"unknown",
+                        bundle[@"CFBundleShortVersionString"] ?: @"unknown",
+                        bundle[@"CFBundleVersion"] ?: @"unknown",
+                        UIDevice.currentDevice.systemVersion ?: @"unknown",
+                        NSHomeDirectory() ?: @"unknown"];
+    FilzaDiagnosticsAppend(@"Launch", launch);
+}
+
+__attribute__((constructor)) static void FilzaDiagnosticsInit(void)
+{
+    @autoreleasepool {
+        FilzaPrepareVisibleDiagnostics();
+        gPreviousExceptionHandler = NSGetUncaughtExceptionHandler();
+        NSSetUncaughtExceptionHandler(FilzaUncaughtExceptionHandler);
+        FilzaInstallSignalHandler(SIGABRT);
+        FilzaInstallSignalHandler(SIGILL);
+        FilzaInstallSignalHandler(SIGTRAP);
+        FilzaInstallSignalHandler(SIGBUS);
+        FilzaInstallSignalHandler(SIGSEGV);
+        FilzaInstallSignalHandler(SIGFPE);
+    }
+}

--- a/FilzaDiagnostics.m
+++ b/FilzaDiagnostics.m
@@ -4,7 +4,6 @@
 #import <fcntl.h>
 #import <limits.h>
 #import <signal.h>
-#import <stdio.h>
 #import <string.h>
 #import <unistd.h>
 
@@ -81,36 +80,49 @@ static void FilzaUncaughtExceptionHandler(NSException *exception)
     if (gPreviousExceptionHandler) gPreviousExceptionHandler(exception);
 }
 
-static const char *FilzaSignalName(int signalNumber)
-{
-    switch (signalNumber) {
-        case SIGABRT: return "SIGABRT";
-        case SIGILL: return "SIGILL";
-        case SIGTRAP: return "SIGTRAP";
-        case SIGBUS: return "SIGBUS";
-        case SIGSEGV: return "SIGSEGV";
-        case SIGFPE: return "SIGFPE";
-        default: return "SIGNAL";
-    }
-}
-
 static void FilzaSignalHandler(int signalNumber)
 {
     if (gFilzaSignalPath[0] == '\0') return;
-    char buffer[160];
-    int count = snprintf(buffer, sizeof(buffer),
-                         "FilzaSlop terminated by %s (%d). Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n",
-                         FilzaSignalName(signalNumber), signalNumber);
-    if (count <= 0) return;
-    if ((size_t)count > sizeof(buffer)) count = (int)sizeof(buffer);
+
+    const char *message = "FilzaSlop terminated by a fatal signal. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n";
+    size_t length = sizeof("FilzaSlop terminated by a fatal signal. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n") - 1;
+    switch (signalNumber) {
+        case SIGABRT:
+            message = "FilzaSlop terminated by SIGABRT. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n";
+            length = sizeof("FilzaSlop terminated by SIGABRT. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n") - 1;
+            break;
+        case SIGILL:
+            message = "FilzaSlop terminated by SIGILL. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n";
+            length = sizeof("FilzaSlop terminated by SIGILL. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n") - 1;
+            break;
+        case SIGTRAP:
+            message = "FilzaSlop terminated by SIGTRAP. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n";
+            length = sizeof("FilzaSlop terminated by SIGTRAP. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n") - 1;
+            break;
+        case SIGBUS:
+            message = "FilzaSlop terminated by SIGBUS. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n";
+            length = sizeof("FilzaSlop terminated by SIGBUS. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n") - 1;
+            break;
+        case SIGSEGV:
+            message = "FilzaSlop terminated by SIGSEGV. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n";
+            length = sizeof("FilzaSlop terminated by SIGSEGV. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n") - 1;
+            break;
+        case SIGFPE:
+            message = "FilzaSlop terminated by SIGFPE. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n";
+            length = sizeof("FilzaSlop terminated by SIGFPE. Check Runtime.log and ByeTunesEmbedStage.txt for the last completed stage.\n") - 1;
+            break;
+        default:
+            break;
+    }
+
+    // Only async-signal-safe syscalls are used here. SA_RESETHAND restores the
+    // default disposition before this handler executes, so returning preserves
+    // the original fatal behavior while leaving a breadcrumb on disk.
     int fd = open(gFilzaSignalPath, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
     if (fd >= 0) {
-        (void)write(fd, buffer, (size_t)count);
-        (void)fsync(fd);
+        (void)write(fd, message, length);
         (void)close(fd);
     }
-    // SA_RESETHAND resets disposition before this handler runs. Returning lets
-    // the originating fatal condition proceed under its normal disposition.
 }
 
 static void FilzaInstallSignalHandler(int signalNumber)

--- a/FilzaGestaltSurfaceBridge.h
+++ b/FilzaGestaltSurfaceBridge.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+FOUNDATION_EXPORT BOOL FilzaGestaltSurfaceReady(UIViewController *controller);
+FOUNDATION_EXPORT NSMutableDictionary * _Nullable FilzaGestaltSurfacePlist(UIViewController *controller);
+FOUNDATION_EXPORT NSMutableDictionary * _Nullable FilzaGestaltSurfaceCacheExtra(UIViewController *controller);
+FOUNDATION_EXPORT NSMutableDictionary * _Nullable FilzaGestaltSurfaceArtwork(UIViewController *controller);
+FOUNDATION_EXPORT NSString *FilzaGestaltSurfaceAccessDetail(UIViewController *controller);
+FOUNDATION_EXPORT BOOL FilzaGestaltSurfaceFeatureEnabled(UIViewController *controller, NSDictionary *feature);
+FOUNDATION_EXPORT void FilzaGestaltSurfaceSetFeature(UIViewController *controller, NSDictionary *feature, BOOL enabled);
+FOUNDATION_EXPORT void FilzaGestaltSurfaceMarkDirty(UIViewController *controller);
+FOUNDATION_EXPORT void FilzaGestaltSurfaceSave(UIViewController *controller);
+FOUNDATION_EXPORT void FilzaGestaltSurfaceRevert(UIViewController *controller);
+NS_ASSUME_NONNULL_END

--- a/FilzaQuickActions.m
+++ b/FilzaQuickActions.m
@@ -1,0 +1,184 @@
+@import UIKit;
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+#import "FilzaDiagnostics.h"
+
+static NSString *const FQAppsType = @"com.nightvibes33.filzaslop.apps-manager";
+static NSString *const FQMusicType = @"com.nightvibes33.filzaslop.music-library";
+
+static IMP gFQPreviousShortcutHandler = NULL;
+static BOOL gFQShortcutHookInstalled = NO;
+
+static UIViewController *FQActiveController(void)
+{
+    UIWindow *window = nil;
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (![scene isKindOfClass:UIWindowScene.class]) continue;
+        for (UIWindow *candidate in ((UIWindowScene *)scene).windows) {
+            if (candidate.isKeyWindow) { window = candidate; break; }
+            if (!window && !candidate.hidden) window = candidate;
+        }
+        if (window.isKeyWindow) break;
+    }
+    if (!window) {
+        for (UIWindow *candidate in UIApplication.sharedApplication.windows) {
+            if (candidate.isKeyWindow) { window = candidate; break; }
+            if (!window && !candidate.hidden) window = candidate;
+        }
+    }
+
+    UIViewController *controller = window.rootViewController;
+    while (controller) {
+        UIViewController *next = controller.presentedViewController;
+        if (!next && [controller isKindOfClass:UINavigationController.class])
+            next = ((UINavigationController *)controller).visibleViewController;
+        if (!next && [controller isKindOfClass:UITabBarController.class])
+            next = ((UITabBarController *)controller).selectedViewController;
+        if (!next && [controller isKindOfClass:UISplitViewController.class])
+            next = ((UISplitViewController *)controller).viewControllers.lastObject;
+        if (!next || next == controller) break;
+        controller = next;
+    }
+    return controller;
+}
+
+static UIViewController *FQCreateController(NSString *className)
+{
+    Class cls = NSClassFromString(className);
+    if (!cls || ![cls isSubclassOfClass:UIViewController.class]) return nil;
+
+    id controller = [cls alloc];
+    SEL nibInit = @selector(initWithNibName:bundle:);
+    if ([controller respondsToSelector:nibInit])
+        controller = ((id (*)(id, SEL, id, id))objc_msgSend)(controller, nibInit, nil, nil);
+    else
+        controller = ((id (*)(id, SEL))objc_msgSend)(controller, @selector(init));
+    return [controller isKindOfClass:UIViewController.class] ? controller : nil;
+}
+
+static BOOL FQPresentFilzaController(NSString *className, NSString *label)
+{
+    UIViewController *controller = FQCreateController(className);
+    UIViewController *source = FQActiveController();
+    if (!controller || !source) {
+        FilzaDiagnosticsAppend(@"QuickAction",
+            [NSString stringWithFormat:@"%@ unavailable class=%@ source=%@",
+             label, className, source ? NSStringFromClass(source.class) : @"nil"]);
+        return NO;
+    }
+
+    UINavigationController *navigation = source.navigationController;
+    if (navigation && !source.presentedViewController) {
+        [navigation pushViewController:controller animated:NO];
+    } else {
+        UINavigationController *wrapper = [[UINavigationController alloc] initWithRootViewController:controller];
+        wrapper.modalPresentationStyle = UIModalPresentationFullScreen;
+        [source presentViewController:wrapper animated:NO completion:nil];
+    }
+    FilzaDiagnosticsAppend(@"QuickAction",
+        [NSString stringWithFormat:@"opened %@ using %@", label, className]);
+    return YES;
+}
+
+static void FQOpenWithRetry(NSString *type, NSUInteger attempts)
+{
+    if (attempts == 0) {
+        FilzaDiagnosticsAppend(@"QuickAction",
+            [NSString stringWithFormat:@"gave up opening %@ after launch retries", type]);
+        return;
+    }
+
+    BOOL opened = NO;
+    if ([type isEqualToString:FQAppsType])
+        opened = FQPresentFilzaController(@"TGApplicationsViewController", @"Apps Manager");
+    else if ([type isEqualToString:FQMusicType])
+        opened = FQPresentFilzaController(@"TGMusicLibraryViewController", @"Music Library");
+
+    if (!opened) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
+                       dispatch_get_main_queue(), ^{ FQOpenWithRetry(type, attempts - 1); });
+    }
+}
+
+static void FQShortcutHandler(id self, SEL _cmd, UIApplication *application,
+                              UIApplicationShortcutItem *item,
+                              void (^completion)(BOOL))
+{
+    NSString *type = item.type ?: @"";
+    if ([type isEqualToString:FQAppsType] || [type isEqualToString:FQMusicType]) {
+        FilzaDiagnosticsAppend(@"QuickAction",
+            [NSString stringWithFormat:@"received %@", type]);
+        dispatch_async(dispatch_get_main_queue(), ^{ FQOpenWithRetry(type, 16); });
+        if (completion) completion(YES);
+        return;
+    }
+
+    if (gFQPreviousShortcutHandler)
+        ((void (*)(id, SEL, id, id, id))gFQPreviousShortcutHandler)(self, _cmd, application, item, completion);
+    else if (completion)
+        completion(NO);
+}
+
+static void FQInstallShortcutHandler(void)
+{
+    if (gFQShortcutHookInstalled) return;
+    id delegate = UIApplication.sharedApplication.delegate;
+    if (!delegate) return;
+
+    Class cls = object_getClass(delegate);
+    SEL selector = @selector(application:performActionForShortcutItem:completionHandler:);
+    Method resolved = class_getInstanceMethod(cls, selector);
+    if (resolved) {
+        IMP current = method_getImplementation(resolved);
+        if (current == (IMP)FQShortcutHandler) {
+            gFQShortcutHookInstalled = YES;
+            return;
+        }
+        gFQPreviousShortcutHandler = current;
+        const char *types = method_getTypeEncoding(resolved);
+        if (!class_addMethod(cls, selector, (IMP)FQShortcutHandler, types))
+            method_setImplementation(class_getInstanceMethod(cls, selector), (IMP)FQShortcutHandler);
+    } else {
+        class_addMethod(cls, selector, (IMP)FQShortcutHandler, "v@:@@@?");
+    }
+
+    gFQShortcutHookInstalled = YES;
+    FilzaDiagnosticsAppend(@"QuickAction",
+        [NSString stringWithFormat:@"Apps/Music delegate hook installed on %@", NSStringFromClass(cls)]);
+}
+
+static void FQRemoveDynamicShortcutDuplicates(void)
+{
+    // UIApplication.shortcutItems is the dynamic-only list. The Gestalt
+    // manager previously added a second dynamic copy; clearing this list leaves
+    // the packaged static actions intact.
+    UIApplication.sharedApplication.shortcutItems = @[];
+    FilzaDiagnosticsAppend(@"QuickAction", @"cleared legacy dynamic shortcut items");
+}
+
+static void FQRefreshRuntimeRouting(void)
+{
+    FQInstallShortcutHandler();
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 350 * NSEC_PER_MSEC),
+                   dispatch_get_main_queue(), ^{
+        FQRemoveDynamicShortcutDuplicates();
+        FQInstallShortcutHandler();
+    });
+}
+
+__attribute__((constructor)) static void FilzaQuickActionsInit(void)
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter]
+            addObserverForName:UIApplicationDidFinishLaunchingNotification
+            object:nil queue:NSOperationQueue.mainQueue
+            usingBlock:^(__unused NSNotification *note) { FQRefreshRuntimeRouting(); }];
+        [[NSNotificationCenter defaultCenter]
+            addObserverForName:UIApplicationDidBecomeActiveNotification
+            object:nil queue:NSOperationQueue.mainQueue
+            usingBlock:^(__unused NSNotification *note) { FQRefreshRuntimeRouting(); }];
+        FQRefreshRuntimeRouting();
+    });
+}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BAD_QUERY_ROOT := ThirdParty/bad_query
 # TGMusicLibraryViewController contents in-place with the real ByeTunes SwiftUI
 # root; the older custom table and modal full-app launcher are intentionally not
 # linked anymore.
-FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
+FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m FilzaDiagnostics.m FilzaQuickActions.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 
 # Pinned bad_query backs the verified foreign-container, system-root, and
 # MobileGestalt access paths. A returned handle is not treated as proof of
@@ -82,5 +82,7 @@ before-FilzaApplySandboxExt-all::
 	@test -f "SystemPathDiagnostics.m" || (echo "Missing SystemPathDiagnostics.m" >&2; exit 1)
 	@test -f "BadQuerySystemProbe.m" || (echo "Missing BadQuerySystemProbe.m" >&2; exit 1)
 	@test -f "GestaltManager.m" || (echo "Missing GestaltManager.m" >&2; exit 1)
+	@test -f "FilzaDiagnostics.m" || (echo "Missing FilzaDiagnostics.m" >&2; exit 1)
+	@test -f "FilzaQuickActions.m" || (echo "Missing FilzaQuickActions.m" >&2; exit 1)
 
 include $(THEOS_MAKE_PATH)/tweak.mk

--- a/MondGestaltAccess.h
+++ b/MondGestaltAccess.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Acquires access to the MobileGestalt cache using the same ContainerManager
+/// query shape used by the integrated Gestalt editor. Returns the exact plist
+/// path only after a write-capable open succeeds.
+FOUNDATION_EXPORT NSString * _Nullable FilzaMondGestaltAcquireAccess(NSString * _Nullable * _Nullable detail);
+
+/// Returns the libMobileGestalt CacheData byte offset for a Gestalt key using
+/// the __cstring -> __AUTH_CONST/__DATA_CONST lookup used by the editor.
+FOUNDATION_EXPORT NSUInteger FilzaMondGestaltCacheDataOffset(NSString *key);
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This change fixes the user-visible regressions without introducing a second access implementation:

- packages exactly three static Home Screen actions: Apps Manager, Music Library, and Gestalt Editor
- clears the legacy runtime-created duplicate quick action
- routes Apps Manager and Music Library directly to their Filza view controllers
- exposes persistent diagnostics under Documents/FilzaSlop Logs for Files app access
- records launch, exception, fatal-signal, and ByeTunes stage breadcrumbs
- isolates TGMusicLibraryViewController viewDidAppear together with viewDidLoad so Filza's original lifecycle cannot run against skipped initialization
- strengthens CI to syntax-check the new runtime files and assert the exact three-action/Files-sharing Info.plist contract in the generated IPA

The existing Gestalt access implementation remains the single access path; no duplicate low-level implementation is added.

## Summary by Sourcery

Introduce centralized diagnostics logging and strengthen ByeTunes lifecycle isolation while correcting Filza quick actions routing and Files-based log exposure.

New Features:
- Add structured runtime and crash diagnostics under a Files-visible FilzaSlop Logs directory, including ByeTunes stage breadcrumbs and fatal signal/exception artifacts.
- Provide static Home Screen quick actions for Apps Manager, Music Library, and Gestalt Editor that route directly to their Filza view controllers.

Bug Fixes:
- Fix duplicated dynamic quick actions by clearing legacy runtime UIApplication shortcut items while preserving the packaged static actions.
- Prevent TGMusicLibraryViewController from dereferencing uninitialized state by isolating its viewDidLoad/viewDidAppear lifecycle and delegating to superclass implementations before installing the ByeTunes launcher.
- Update ByeTunes failure messaging to point users to the new Files > FilzaSlop > FilzaSlop Logs diagnostics location.

Enhancements:
- Refactor ByeTunes lifecycle hooking into reusable method override helpers and record installation stages as persistent diagnostics entries.

Build:
- Include new FilzaDiagnostics and FilzaQuickActions sources in the tweak build and enforce their presence via makefile preflight checks.

CI:
- Extend CI to syntax-check new runtime files and assert the exact three quick actions plus Files-sharing flags and diagnostic strings in the built IPA.

Documentation:
- Expose a README in the FilzaSlop Logs directory documenting available diagnostic files and their purpose.