### PR TITLE
Remove duplicate Gestalt shortcut and isolate ByeTunes Swift startup

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -188,7 +188,9 @@ jobs:
             cp -R .theos/byetunes-appintents/Metadata.appintents "$APP/Metadata.appintents"
           fi
 
-          plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open ByeTunes","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
+          # Apps and Music are static. GestaltManager owns its one dynamic
+          # shortcut, so packaging a second static Gestalt item would duplicate it.
+          plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open ByeTunes","UIApplicationShortcutItemIconSymbolName":"music.note.list"}]' "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
 
@@ -197,16 +199,15 @@ jobs:
           with open(sys.argv[1], 'rb') as f:
               info = plistlib.load(f)
           actions = info.get('UIApplicationShortcutItems', [])
-          assert len(actions) == 3, actions
-          assert [a['UIApplicationShortcutItemTitle'] for a in actions] == ['Apps Manager', 'Music Library', 'Gestalt Editor'], actions
+          assert len(actions) == 2, actions
+          assert [a['UIApplicationShortcutItemTitle'] for a in actions] == ['Apps Manager', 'Music Library'], actions
           assert [a['UIApplicationShortcutItemType'] for a in actions] == [
               'com.nightvibes33.filzaslop.apps-manager',
               'com.nightvibes33.filzaslop.music-library',
-              'com.nightvibes33.filzaslop.gestalt-manager',
           ], actions
           assert info.get('UIFileSharingEnabled') is True
           assert info.get('LSSupportsOpeningDocumentsInPlace') is True
-          print('Verified exactly three quick actions and Files/Documents exposure flags')
+          print('Verified two static Apps/Music actions; Gestalt remains runtime-owned by GestaltManager')
           PY
 
           otool -L "$APP/$EXECUTABLE" | grep -F 'FilzaApplySandboxExt.dylib'

--- a/ByeTunesEmbeddedHost.swift
+++ b/ByeTunesEmbeddedHost.swift
@@ -7,29 +7,82 @@ private final class ByeTunesEmbeddedNavigationController: UINavigationController
     }
 }
 
-/// Hosts the complete ByeTunes SwiftUI application inside Filza's process.
-/// `makeLibraryViewController()` is the actual Filza Music Library port: it
-/// returns the unmodified ByeTunes ContentView without wrapping/presenting a
-/// second app-style modal controller.
+private final class ByeTunesDeferredHostController: UIViewController {
+    private var hasStarted = false
+    private var hostedController: UIViewController?
+    private let statusLabel = UILabel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        FilzaDiagnosticsWriteByeTunesStage("deferred Swift host UIKit shell viewDidLoad")
+        view.backgroundColor = .systemGroupedBackground
+
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.text = "Starting ByeTunes…"
+        statusLabel.textAlignment = .center
+        statusLabel.numberOfLines = 0
+        statusLabel.textColor = .secondaryLabel
+        view.addSubview(statusLabel)
+        NSLayoutConstraint.activate([
+            statusLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            statusLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            statusLabel.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor)
+        ])
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        guard !hasStarted else { return }
+        hasStarted = true
+        FilzaDiagnosticsWriteByeTunesStage("deferred Swift host viewDidAppear")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            FilzaDiagnosticsWriteByeTunesStage("before ContentView construction")
+            let root = ContentView()
+            FilzaDiagnosticsWriteByeTunesStage("ContentView constructed")
+
+            let host = UIHostingController(rootView: root)
+            FilzaDiagnosticsWriteByeTunesStage("UIHostingController constructed")
+            host.view.backgroundColor = .systemGroupedBackground
+
+            self.addChild(host)
+            FilzaDiagnosticsWriteByeTunesStage("before ByeTunes Swift host view materialization")
+            let hostedView = host.view!
+            FilzaDiagnosticsWriteByeTunesStage("ByeTunes Swift host view materialized")
+            hostedView.translatesAutoresizingMaskIntoConstraints = false
+            self.view.addSubview(hostedView)
+            NSLayoutConstraint.activate([
+                hostedView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                hostedView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+                hostedView.topAnchor.constraint(equalTo: self.view.topAnchor),
+                hostedView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+            ])
+            host.didMove(toParent: self)
+            self.hostedController = host
+            self.statusLabel.removeFromSuperview()
+            FilzaDiagnosticsWriteByeTunesStage("ByeTunes Swift host attached successfully")
+        }
+    }
+}
+
 @objc(ByeTunesEmbeddedHostFactory)
 public final class ByeTunesEmbeddedHostFactory: NSObject {
     @objc(makeLibraryViewController)
     public static func makeLibraryViewController() -> UIViewController {
-        let host = UIHostingController(rootView: ContentView())
-        host.view.backgroundColor = .systemGroupedBackground
-        return host
+        FilzaDiagnosticsWriteByeTunesStage("Swift ByeTunes factory entered")
+        let controller = ByeTunesDeferredHostController()
+        FilzaDiagnosticsWriteByeTunesStage("Swift ByeTunes factory returned deferred UIKit host")
+        return controller
     }
 
-    /// Retained for callers that intentionally need a standalone presentation,
-    /// such as a future shortcut/fallback route. Filza's Music Library itself
-    /// uses `makeLibraryViewController()` and embeds the returned controller.
     @objc(makeViewController)
     public static func makeViewController() -> UIViewController {
-        let host = UIHostingController(rootView: ContentView())
-        host.title = "ByeTunes"
-
-        let navigation = ByeTunesEmbeddedNavigationController(rootViewController: host)
-        host.navigationItem.leftBarButtonItem = UIBarButtonItem(
+        FilzaDiagnosticsWriteByeTunesStage("standalone ByeTunes factory entered")
+        let deferred = ByeTunesDeferredHostController()
+        deferred.title = "ByeTunes"
+        let navigation = ByeTunesEmbeddedNavigationController(rootViewController: deferred)
+        deferred.navigationItem.leftBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .close,
             target: navigation,
             action: #selector(ByeTunesEmbeddedNavigationController.closeEmbeddedByeTunes)

--- a/ByeTunesFilzaLibraryEmbed.h
+++ b/ByeTunesFilzaLibraryEmbed.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+FOUNDATION_EXPORT void ByeTunesPresentSafeLauncherFromController(UIViewController * _Nullable source);
+NS_ASSUME_NONNULL_END

--- a/FilzaApplySandboxExt-Bridging-Header.h
+++ b/FilzaApplySandboxExt-Bridging-Header.h
@@ -1,5 +1,4 @@
 #pragma once
 
-// Full ByeTunes embeds its original Swift DeviceManager, which talks to the
-// same pinned idevice FFI static library already used by the Filza bridge.
 #import "idevice.h"
+#import "FilzaDiagnostics.h"


### PR DESCRIPTION
Fixes the two regressions directly supported by the on-device logs:

- packages only Apps Manager + Music Library as static quick actions so the existing GestaltManager runtime shortcut is not duplicated
- preserves Files/Documents sharing
- defers ByeTunes ContentView construction until a UIKit host reaches viewDidAppear
- writes persistent stage markers immediately before/after ContentView construction, UIHostingController creation, Swift view materialization, and final attachment

The attempted new mond build surface is intentionally not included here because that repository mutation was blocked; this PR stays clean and buildable.

## Summary by Sourcery

Defer ByeTunes SwiftUI startup to a UIKit host controller and remove the duplicate Gestalt quick action while preserving Files/Documents sharing and diagnostics.

New Features:
- Introduce a deferred UIKit host controller that initializes and attaches the ByeTunes SwiftUI ContentView only after view appearance, with visible startup status messaging.

Bug Fixes:
- Remove the static Gestalt Editor home screen quick action to avoid duplicating the dynamic shortcut provided by GestaltManager.
- Ensure ByeTunes embedding in Filza uses the deferred host controller for both library and standalone presentations to prevent early SwiftUI construction regressions.

Enhancements:
- Add detailed Filza diagnostics stage markers around ByeTunes SwiftUI host lifecycle events for improved on-device investigation.

Build:
- Update the safe-fixes verification workflow to assert only the Apps Manager and Music Library static shortcuts and retain Files/Documents exposure flags.

CI:
- Refine CI shortcut validation messaging to reflect the new static quick action set owned by the main app.