### PR TITLE
Integrate complete Gestalt Editor and ByeTunes into Filza

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -49,8 +49,14 @@ jobs:
           test -f FilzaMainToolbarGestalt.m
           test -f MondGestaltView.swift
           test -f ByeTunesFilzaLibraryEmbed.m
+          test -f ByeTunesFullAppLauncher.m
+          test -f ByeTunesFullAppLauncher.h
           test -f FilzaDiagnostics.m
           test -f FilzaQuickActions.m
+          test -f WebDAVRuntimeFix.m
+          test -f ThirdParty/GCDWebServer/GCDWebDAVServer/GCDWebDAVServer.m
+          test -f ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServer.m
+          test -f ThirdParty/GCDWebServer/LICENSE
 
       - name: Syntax-check runtime integrations
         run: |
@@ -66,6 +72,11 @@ jobs:
             -include errno.h
             -I.
             -IThirdParty/bad_query/bad_query
+            -IThirdParty/GCDWebServer/GCDWebServer/Core
+            -IThirdParty/GCDWebServer/GCDWebServer/Requests
+            -IThirdParty/GCDWebServer/GCDWebServer/Responses
+            -IThirdParty/GCDWebServer/GCDWebDAVServer
+            -I"$SDK/usr/include/libxml2"
             -Wno-deprecated-declarations
             -Wno-arc-performSelector-leaks
           )
@@ -76,8 +87,13 @@ jobs:
           xcrun --sdk iphoneos clang "${COMMON[@]}" AppsManagerPresentationFix.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" ByeTunesMusicBridge.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" ByeTunesFilzaLibraryEmbed.m
+          xcrun --sdk iphoneos clang "${COMMON[@]}" ByeTunesFullAppLauncher.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" FilzaDiagnostics.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" FilzaQuickActions.m
+          xcrun --sdk iphoneos clang "${COMMON[@]}" WebDAVRuntimeFix.m
+          while IFS= read -r source; do
+            xcrun --sdk iphoneos clang "${COMMON[@]}" "$source"
+          done < <(find ThirdParty/GCDWebServer/GCDWebServer ThirdParty/GCDWebServer/GCDWebDAVServer -type f -name '*.m' -print | sort)
           xcrun --sdk iphoneos clang "${COMMON[@]}" ThirdParty/bad_query/bad_query/bad_query.c
 
       - name: Install Procursus build tools
@@ -136,10 +152,11 @@ jobs:
           DYLIB=".theos/obj/FilzaApplySandboxExt.dylib"
           test -s "$DYLIB"
           test "$(lipo -archs "$DYLIB")" = "arm64"
-          grep -aFq 'Gestalt Manager' "$DYLIB"
+          grep -aFq 'Gestalt Editor' "$DYLIB"
           grep -aFq 'MondGestaltHostFactory' "$DYLIB"
           grep -aFq 'Gestalt Editor toolbar hooks installed' "$DYLIB"
-          grep -aFq 'presented complete Gestalt editor' "$DYLIB"
+          grep -aFq 'presented visible Gestalt loading screen immediately' "$DYLIB"
+          grep -aFq 'inserted in-app Gestalt Editor row beside Apps/Music' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.gestalt-manager' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.apps-manager' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.music-library' "$DYLIB"
@@ -147,8 +164,15 @@ jobs:
           grep -aFq 'LastSignal.txt' "$DYLIB"
           grep -aFq 'TGMusicLibraryViewController viewDidAppear intercepted' "$DYLIB"
           grep -aFq 'ByeTunesEmbeddedHostFactory' "$DYLIB"
+          grep -aFq 'TGMainView direct full ByeTunes route installed' "$DYLIB"
+          grep -aFq 'opened complete ByeTunes directly' "$DYLIB"
           grep -aFq 'complete ByeTunes host attached directly to Music Library' "$DYLIB"
           grep -aFq 'before ContentView construction' "$DYLIB"
+          grep -aFq 'jailed in-process WebDAV lifecycle hook installed' "$DYLIB"
+          grep -aFq 'server did not report listening; rebuilding the in-process server once' "$DYLIB"
+          grep -aFq 'GCDWebDAVServer' "$DYLIB"
+          grep -aFq 'PROPFIND' "$DYLIB"
+          grep -aFq 'UNLOCK' "$DYLIB"
           ! grep -aFq 'inert UIKit launcher visible' "$DYLIB"
           shasum -a 256 "$DYLIB"
 
@@ -200,10 +224,12 @@ jobs:
           fi
 
           plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open ByeTunes","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
-          plutil -replace CFBundleShortVersionString -string "4.1" "$APP/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "4.2" "$APP/Info.plist"
           plutil -replace CFBundleVersion -string "${GITHUB_RUN_NUMBER}" "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
+          plutil -replace NSLocalNetworkUsageDescription -string "FilzaSlop uses your local network when you enable its WebDAV server." "$APP/Info.plist"
+          plutil -replace NSBonjourServices -json '["_http._tcp"]' "$APP/Info.plist"
 
           python3 - "$APP/Info.plist" <<'PY'
           import plistlib, sys
@@ -219,7 +245,9 @@ jobs:
           ], actions
           assert info.get('UIFileSharingEnabled') is True
           assert info.get('LSSupportsOpeningDocumentsInPlace') is True
-          assert info.get('CFBundleShortVersionString') == '4.1'
+          assert info.get('NSLocalNetworkUsageDescription')
+          assert info.get('NSBonjourServices') == ['_http._tcp']
+          assert info.get('CFBundleShortVersionString') == '4.2'
           assert str(info.get('CFBundleVersion', '')).isdigit()
           print('Verified exactly three quick actions and Files/Documents exposure flags')
           PY
@@ -230,6 +258,8 @@ jobs:
           test -s "$APP/astring.umd.js"
           test -s "$APP/yt_ejs_helper.js"
           test -s "$APP/AppIconImage.png"
+          test -x "$APP/helpers/FilzaWebDAVServer"
+          test -s "$APP/com.tigisoftware.filza.webdavserver.plist"
 
           OUTPUT="$GITHUB_WORKSPACE/.theos/FilzaSlop-main-${GITHUB_SHA::7}-unsigned.ipa"
           rm -f "$OUTPUT"

--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -45,6 +45,9 @@ jobs:
           test -f ByeTunes/MusicManager/YouTubeKit/Resources/meriyah.umd.js
           test -f ThirdParty/bad_query/bad_query/bad_query.c
           test -f GestaltManager.m
+          test -f FilzaMondBridge.m
+          test -f FilzaMainToolbarGestalt.m
+          test -f MondGestaltView.swift
           test -f ByeTunesFilzaLibraryEmbed.m
           test -f FilzaDiagnostics.m
           test -f FilzaQuickActions.m
@@ -67,6 +70,8 @@ jobs:
             -Wno-arc-performSelector-leaks
           )
           xcrun --sdk iphoneos clang "${COMMON[@]}" GestaltManager.m
+          xcrun --sdk iphoneos clang "${COMMON[@]}" FilzaMondBridge.m
+          xcrun --sdk iphoneos clang "${COMMON[@]}" FilzaMainToolbarGestalt.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" AppsMusicFix.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" AppsManagerPresentationFix.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" ByeTunesMusicBridge.m
@@ -132,6 +137,9 @@ jobs:
           test -s "$DYLIB"
           test "$(lipo -archs "$DYLIB")" = "arm64"
           grep -aFq 'Gestalt Manager' "$DYLIB"
+          grep -aFq 'MondGestaltHostFactory' "$DYLIB"
+          grep -aFq 'Gestalt Editor toolbar hooks installed' "$DYLIB"
+          grep -aFq 'presented complete Gestalt editor' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.gestalt-manager' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.apps-manager' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.music-library' "$DYLIB"
@@ -139,6 +147,9 @@ jobs:
           grep -aFq 'LastSignal.txt' "$DYLIB"
           grep -aFq 'TGMusicLibraryViewController viewDidAppear intercepted' "$DYLIB"
           grep -aFq 'ByeTunesEmbeddedHostFactory' "$DYLIB"
+          grep -aFq 'complete ByeTunes host attached directly to Music Library' "$DYLIB"
+          grep -aFq 'before ContentView construction' "$DYLIB"
+          ! grep -aFq 'inert UIKit launcher visible' "$DYLIB"
           shasum -a 256 "$DYLIB"
 
       - name: Generate ByeTunes AppIntents metadata
@@ -189,6 +200,8 @@ jobs:
           fi
 
           plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open ByeTunes","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "4.1" "$APP/Info.plist"
+          plutil -replace CFBundleVersion -string "${GITHUB_RUN_NUMBER}" "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
 
@@ -206,6 +219,8 @@ jobs:
           ], actions
           assert info.get('UIFileSharingEnabled') is True
           assert info.get('LSSupportsOpeningDocumentsInPlace') is True
+          assert info.get('CFBundleShortVersionString') == '4.1'
+          assert str(info.get('CFBundleVersion', '')).isdigit()
           print('Verified exactly three quick actions and Files/Documents exposure flags')
           PY
 

--- a/ByeTunesEmbeddedHost.swift
+++ b/ByeTunesEmbeddedHost.swift
@@ -7,29 +7,91 @@ private final class ByeTunesEmbeddedNavigationController: UINavigationController
     }
 }
 
-/// Hosts the complete ByeTunes SwiftUI application inside Filza's process.
-/// `makeLibraryViewController()` is the actual Filza Music Library port: it
-/// returns the unmodified ByeTunes ContentView without wrapping/presenting a
-/// second app-style modal controller.
+private final class ByeTunesDeferredHostController: UIViewController {
+    private var hasStarted = false
+    private var hostedController: UIViewController?
+    private let statusLabel = UILabel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        FilzaDiagnosticsWriteByeTunesStage("deferred Swift host UIKit shell viewDidLoad")
+        view.backgroundColor = .systemGroupedBackground
+
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.text = "Starting ByeTunes…"
+        statusLabel.textAlignment = .center
+        statusLabel.numberOfLines = 0
+        statusLabel.textColor = .secondaryLabel
+        view.addSubview(statusLabel)
+        NSLayoutConstraint.activate([
+            statusLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            statusLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            statusLabel.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor)
+        ])
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        startEmbeddedContentIfNeeded()
+    }
+
+    @objc(startEmbeddedContentIfNeeded)
+    func startEmbeddedContentIfNeeded() {
+        guard !hasStarted else { return }
+        hasStarted = true
+        FilzaDiagnosticsWriteByeTunesStage("complete ByeTunes ContentView startup scheduled")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            FilzaDiagnosticsWriteByeTunesStage("before ContentView construction")
+            let root = ContentView()
+            FilzaDiagnosticsWriteByeTunesStage("ContentView constructed")
+
+            let host = UIHostingController(rootView: root)
+            FilzaDiagnosticsWriteByeTunesStage("UIHostingController constructed")
+            host.view.backgroundColor = .systemGroupedBackground
+
+            self.addChild(host)
+            FilzaDiagnosticsWriteByeTunesStage("before ByeTunes Swift host view materialization")
+            let hostedView = host.view!
+            FilzaDiagnosticsWriteByeTunesStage("ByeTunes Swift host view materialized")
+            hostedView.translatesAutoresizingMaskIntoConstraints = false
+            self.view.addSubview(hostedView)
+            NSLayoutConstraint.activate([
+                hostedView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+                hostedView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+                hostedView.topAnchor.constraint(equalTo: self.view.topAnchor),
+                hostedView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
+            ])
+            host.didMove(toParent: self)
+            self.hostedController = host
+            self.statusLabel.removeFromSuperview()
+            FilzaDiagnosticsWriteByeTunesStage("ByeTunes Swift host attached successfully")
+        }
+    }
+}
+
+/// Hosts the complete ByeTunes application inside Filza without constructing
+/// ContentView inside the Objective-C factory call. The UIKit shell is attached
+/// first; ContentView and DeviceManager.shared are entered only after the shell
+/// reaches viewDidAppear, with a persistent breadcrumb at every boundary.
 @objc(ByeTunesEmbeddedHostFactory)
 public final class ByeTunesEmbeddedHostFactory: NSObject {
     @objc(makeLibraryViewController)
     public static func makeLibraryViewController() -> UIViewController {
-        let host = UIHostingController(rootView: ContentView())
-        host.view.backgroundColor = .systemGroupedBackground
-        return host
+        FilzaDiagnosticsWriteByeTunesStage("Swift ByeTunes factory entered")
+        let controller = ByeTunesDeferredHostController()
+        FilzaDiagnosticsWriteByeTunesStage("Swift ByeTunes factory returned deferred UIKit host")
+        return controller
     }
 
-    /// Retained for callers that intentionally need a standalone presentation,
-    /// such as a future shortcut/fallback route. Filza's Music Library itself
-    /// uses `makeLibraryViewController()` and embeds the returned controller.
     @objc(makeViewController)
     public static func makeViewController() -> UIViewController {
-        let host = UIHostingController(rootView: ContentView())
-        host.title = "ByeTunes"
-
-        let navigation = ByeTunesEmbeddedNavigationController(rootViewController: host)
-        host.navigationItem.leftBarButtonItem = UIBarButtonItem(
+        FilzaDiagnosticsWriteByeTunesStage("standalone ByeTunes factory entered")
+        let deferred = ByeTunesDeferredHostController()
+        deferred.title = "ByeTunes"
+        let navigation = ByeTunesEmbeddedNavigationController(rootViewController: deferred)
+        deferred.navigationItem.leftBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .close,
             target: navigation,
             action: #selector(ByeTunesEmbeddedNavigationController.closeEmbeddedByeTunes)

--- a/ByeTunesFilzaLibraryEmbed.m
+++ b/ByeTunesFilzaLibraryEmbed.m
@@ -18,155 +18,107 @@ static void ByeTunesWriteStage(NSString *stage)
 
 static UIViewController *ByeTunesMakeSwiftController(void)
 {
-    ByeTunesWriteStage(@"before Swift host factory");
+    ByeTunesWriteStage(@"before complete ByeTunes host factory");
     Class factory = NSClassFromString(@"ByeTunesEmbeddedHostFactory");
     SEL selector = NSSelectorFromString(@"makeLibraryViewController");
     if (!factory || ![factory respondsToSelector:selector]) {
-        ByeTunesWriteStage(@"Swift host factory unavailable");
+        ByeTunesWriteStage(@"complete ByeTunes host factory unavailable");
         return nil;
     }
 
     @try {
         UIViewController *controller =
             ((UIViewController *(*)(id, SEL))objc_msgSend)(factory, selector);
-        ByeTunesWriteStage(controller ? @"Swift factory returned controller"
-                                        : @"Swift factory returned nil");
+        ByeTunesWriteStage(controller ? @"complete ByeTunes factory returned controller"
+                                      : @"complete ByeTunes factory returned nil");
         return controller;
     } @catch (NSException *exception) {
-        ByeTunesWriteStage([NSString stringWithFormat:@"Objective-C exception in Swift factory: %@",
-                            exception.reason ?: exception.name]);
+        ByeTunesWriteStage([NSString stringWithFormat:
+            @"Objective-C exception in complete ByeTunes factory: %@",
+            exception.reason ?: exception.name]);
         return nil;
     }
 }
 
-@interface ByeTunesSafeLaunchController : UIViewController
-@property(nonatomic, strong) UILabel *statusLabel;
-@property(nonatomic, strong) UIButton *loadButton;
-@property(nonatomic, assign) BOOL loading;
-@end
-
-@implementation ByeTunesSafeLaunchController
-
-- (void)viewDidLoad
+static void ByeTunesShowFailure(UIViewController *legacy, NSString *message)
 {
-    [super viewDidLoad];
-    ByeTunesWriteStage(@"inert UIKit launcher visible");
-
-    self.view.backgroundColor = UIColor.systemBackgroundColor;
-    self.title = @"ByeTunes";
-
-    UILabel *title = [[UILabel alloc] initWithFrame:CGRectZero];
-    title.translatesAutoresizingMaskIntoConstraints = NO;
-    title.text = @"ByeTunes";
-    title.font = [UIFont preferredFontForTextStyle:UIFontTextStyleLargeTitle];
-    title.textAlignment = NSTextAlignmentCenter;
-
-    UILabel *status = [[UILabel alloc] initWithFrame:CGRectZero];
-    status.translatesAutoresizingMaskIntoConstraints = NO;
-    status.text = @"Startup isolation active. Tap Load ByeTunes to enter the Swift UI.";
-    status.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    status.textColor = UIColor.secondaryLabelColor;
-    status.numberOfLines = 0;
-    status.textAlignment = NSTextAlignmentCenter;
-    self.statusLabel = status;
-
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
-    button.translatesAutoresizingMaskIntoConstraints = NO;
-    [button setTitle:@"Load ByeTunes" forState:UIControlStateNormal];
-    button.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
-    [button addTarget:self action:@selector(loadByeTunes:) forControlEvents:UIControlEventTouchUpInside];
-    self.loadButton = button;
-
-    UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[title, status, button]];
-    stack.translatesAutoresizingMaskIntoConstraints = NO;
-    stack.axis = UILayoutConstraintAxisVertical;
-    stack.alignment = UIStackViewAlignmentFill;
-    stack.spacing = 18.0;
-    [self.view addSubview:stack];
-
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = message;
+    label.numberOfLines = 0;
+    label.textAlignment = NSTextAlignmentCenter;
+    label.textColor = UIColor.secondaryLabelColor;
+    [legacy.view addSubview:label];
     [NSLayoutConstraint activateConstraints:@[
-        [stack.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor constant:24.0],
-        [stack.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor constant:-24.0],
-        [stack.centerYAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.centerYAnchor],
-        [button.heightAnchor constraintGreaterThanOrEqualToConstant:48.0],
+        [label.leadingAnchor constraintEqualToAnchor:legacy.view.safeAreaLayoutGuide.leadingAnchor constant:24.0],
+        [label.trailingAnchor constraintEqualToAnchor:legacy.view.safeAreaLayoutGuide.trailingAnchor constant:-24.0],
+        [label.centerYAnchor constraintEqualToAnchor:legacy.view.safeAreaLayoutGuide.centerYAnchor],
     ]];
 }
 
-- (void)loadByeTunes:(__unused id)sender
+static void ByeTunesStartEmbeddedContent(UIViewController *host)
 {
-    if (self.loading || objc_getAssociatedObject(self, kByeTunesFilzaLibraryHostKey)) return;
-    self.loading = YES;
-    self.loadButton.enabled = NO;
-    self.statusLabel.text = @"Loading ByeTunes…";
-    ByeTunesWriteStage(@"user requested Swift UI");
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        UIViewController *host = ByeTunesMakeSwiftController();
-        if (!host) {
-            self.statusLabel.text = @"ByeTunes Swift host could not be created. See Files > FilzaSlop > FilzaSlop Logs.";
-            self.loadButton.enabled = YES;
-            self.loading = NO;
-            return;
-        }
-
-        @try {
-            [self addChildViewController:host];
-            ByeTunesWriteStage(@"before Swift host view materialization");
-            UIView *hostView = host.view;
-            ByeTunesWriteStage(@"Swift host view materialized");
-            hostView.frame = self.view.bounds;
-            hostView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-            [self.view addSubview:hostView];
-            [host didMoveToParentViewController:self];
-            objc_setAssociatedObject(self,
-                                     kByeTunesFilzaLibraryHostKey,
-                                     host,
-                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            ByeTunesWriteStage(@"Swift host attached successfully");
-            self.loading = NO;
-        } @catch (NSException *exception) {
-            ByeTunesWriteStage([NSString stringWithFormat:@"UIKit attach exception: %@",
-                                exception.reason ?: exception.name]);
-            [host willMoveToParentViewController:nil];
-            [host.view removeFromSuperview];
-            [host removeFromParentViewController];
-            self.statusLabel.text = @"ByeTunes failed while attaching its UI. See Files > FilzaSlop > FilzaSlop Logs.";
-            self.loadButton.enabled = YES;
-            self.loading = NO;
-        }
-    });
+    SEL start = NSSelectorFromString(@"startEmbeddedContentIfNeeded");
+    if ([host respondsToSelector:start]) {
+        ((void (*)(id, SEL))objc_msgSend)(host, start);
+        ByeTunesWriteStage(@"requested complete ByeTunes ContentView startup");
+    }
 }
 
-@end
-
-static void ByeTunesInstallSafeLauncher(UIViewController *legacy)
+static void ByeTunesAttachCompleteHost(UIViewController *legacy)
 {
     if (!legacy || objc_getAssociatedObject(legacy, kByeTunesFilzaLibraryHostKey)) return;
 
-    ByeTunesSafeLaunchController *launcher = [ByeTunesSafeLaunchController new];
-    [legacy addChildViewController:launcher];
-    launcher.view.frame = legacy.view.bounds;
-    launcher.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    [legacy.view addSubview:launcher.view];
-    [launcher didMoveToParentViewController:legacy];
-    legacy.navigationItem.title = @"ByeTunes";
-    legacy.navigationItem.titleView = nil;
-    legacy.navigationItem.searchController = nil;
-    legacy.navigationItem.rightBarButtonItem = nil;
-    objc_setAssociatedObject(legacy,
-                             kByeTunesFilzaLibraryHostKey,
-                             launcher,
-                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ByeTunesWriteStage(@"safe launcher attached to Filza Music Library");
+    UIViewController *host = ByeTunesMakeSwiftController();
+    if (!host) {
+        ByeTunesShowFailure(legacy,
+            @"ByeTunes could not be created. See Files > FilzaSlop > FilzaSlop Logs.");
+        return;
+    }
+
+    @try {
+        [legacy addChildViewController:host];
+        ByeTunesWriteStage(@"before complete ByeTunes host view materialization");
+        UIView *hostView = host.view;
+        ByeTunesWriteStage(@"complete ByeTunes host view materialized");
+        hostView.frame = legacy.view.bounds;
+        hostView.autoresizingMask =
+            UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        [legacy.view addSubview:hostView];
+        [host didMoveToParentViewController:legacy];
+        objc_setAssociatedObject(legacy,
+                                 kByeTunesFilzaLibraryHostKey,
+                                 host,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+        legacy.navigationItem.title = @"Music Library";
+        legacy.navigationItem.titleView = nil;
+        legacy.navigationItem.searchController = nil;
+        legacy.navigationItem.rightBarButtonItem = nil;
+        ByeTunesWriteStage(@"complete ByeTunes host attached directly to Music Library");
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            ByeTunesStartEmbeddedContent(host);
+        });
+    } @catch (NSException *exception) {
+        ByeTunesWriteStage([NSString stringWithFormat:
+            @"UIKit exception attaching complete ByeTunes host: %@",
+            exception.reason ?: exception.name]);
+        [host willMoveToParentViewController:nil];
+        [host.view removeFromSuperview];
+        [host removeFromParentViewController];
+        ByeTunesShowFailure(legacy,
+            @"ByeTunes failed while attaching. See Files > FilzaSlop > FilzaSlop Logs.");
+    }
 }
 
 static void ByeTunesMusicLibraryViewDidLoad(id self, SEL _cmd)
 {
     ByeTunesWriteStage(@"TGMusicLibraryViewController viewDidLoad intercepted");
 
-    // The original TGMusicLibraryViewController viewDidLoad is intentionally
-    // skipped because it owns Filza's old Music Library implementation. Run the
-    // superclass lifecycle only, then install the isolated ByeTunes launcher.
+    // Filza's legacy Music Library assumes state that is unavailable in this
+    // jailed build. Run the superclass lifecycle and replace its contents with
+    // the complete embedded ByeTunes application.
     if (gByeTunesSuperMusicViewDidLoad)
         ((void (*)(id, SEL))gByeTunesSuperMusicViewDidLoad)(self, _cmd);
 
@@ -176,20 +128,21 @@ static void ByeTunesMusicLibraryViewDidLoad(id self, SEL _cmd)
     legacy.view.backgroundColor = UIColor.systemBackgroundColor;
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        ByeTunesInstallSafeLauncher(legacy);
+        ByeTunesAttachCompleteHost(legacy);
     });
 }
 
 static void ByeTunesMusicLibraryViewDidAppear(id self, SEL _cmd, BOOL animated)
 {
-    // This companion override is required whenever the subclass viewDidLoad is
-    // bypassed. The original Filza viewDidAppear assumes its browser/model state
-    // was created by TGMusicLibraryViewController's own viewDidLoad and can
-    // dereference that uninitialized state otherwise.
     ByeTunesWriteStage(@"TGMusicLibraryViewController viewDidAppear intercepted");
     if (gByeTunesSuperMusicViewDidAppear)
         ((void (*)(id, SEL, BOOL))gByeTunesSuperMusicViewDidAppear)(self, _cmd, animated);
-    ByeTunesInstallSafeLauncher((UIViewController *)self);
+
+    UIViewController *legacy = (UIViewController *)self;
+    ByeTunesAttachCompleteHost(legacy);
+    UIViewController *host =
+        objc_getAssociatedObject(legacy, kByeTunesFilzaLibraryHostKey);
+    ByeTunesStartEmbeddedContent(host);
 }
 
 static BOOL ByeTunesOverrideLifecycleMethod(Class musicClass,
@@ -225,24 +178,21 @@ static void ByeTunesInstallFilzaMusicLibraryPort(void)
         return;
     }
 
-    BOOL loadHook = ByeTunesOverrideLifecycleMethod(musicClass,
-        @selector(viewDidLoad),
-        (IMP)ByeTunesMusicLibraryViewDidLoad,
-        &gByeTunesSuperMusicViewDidLoad);
-    BOOL appearHook = ByeTunesOverrideLifecycleMethod(musicClass,
-        @selector(viewDidAppear:),
-        (IMP)ByeTunesMusicLibraryViewDidAppear,
-        &gByeTunesSuperMusicViewDidAppear);
+    BOOL loadHook = ByeTunesOverrideLifecycleMethod(
+        musicClass, @selector(viewDidLoad),
+        (IMP)ByeTunesMusicLibraryViewDidLoad, &gByeTunesSuperMusicViewDidLoad);
+    BOOL appearHook = ByeTunesOverrideLifecycleMethod(
+        musicClass, @selector(viewDidAppear:),
+        (IMP)ByeTunesMusicLibraryViewDidAppear, &gByeTunesSuperMusicViewDidAppear);
 
     if (!loadHook || !appearHook) {
-        NSLog(@"[ByeTunesPort] failed to install complete Music Library lifecycle isolation load=%d appear=%d",
+        NSLog(@"[ByeTunesPort] failed to install complete Music Library lifecycle route load=%d appear=%d",
               loadHook, appearHook);
         return;
     }
 
     gByeTunesMusicHookInstalled = YES;
-    ByeTunesWriteStage(@"safe Music Library lifecycle hooks installed");
-    NSLog(@"[ByeTunesPort] installed safe class-local Music Library lifecycle overrides");
+    ByeTunesWriteStage(@"complete ByeTunes Music Library lifecycle hooks installed");
 }
 
 __attribute__((constructor)) static void ByeTunesFilzaLibraryPortInit(void)
@@ -258,7 +208,7 @@ __attribute__((constructor)) static void ByeTunesFilzaLibraryPortInit(void)
                 ByeTunesInstallFilzaMusicLibraryPort();
             }];
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC),
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC),
                        dispatch_get_main_queue(), ^{
             ByeTunesInstallFilzaMusicLibraryPort();
         });

--- a/ByeTunesFullAppLauncher.h
+++ b/ByeTunesFullAppLauncher.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Presents the complete embedded ByeTunes application. Returns NO only when
+/// no presenter or linked Swift host is available yet, allowing callers to
+/// retry during cold launch.
+FOUNDATION_EXPORT BOOL FilzaByeTunesPresentFromController(UIViewController * _Nullable presenter);
+FOUNDATION_EXPORT void FilzaByeTunesInstallDirectRoutes(void);
+
+NS_ASSUME_NONNULL_END

--- a/ByeTunesFullAppLauncher.m
+++ b/ByeTunesFullAppLauncher.m
@@ -3,11 +3,11 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
-static const void *kByeTunesFullPresentedKey = &kByeTunesFullPresentedKey;
-static IMP gByeTunesOriginalMusicViewDidAppear = NULL;
-static IMP gByeTunesOriginalShortcutHandler = NULL;
+#import "ByeTunesFullAppLauncher.h"
+#import "FilzaDiagnostics.h"
 
-typedef void (*ByeTunesShortcutIMP)(id, SEL, UIApplication *, UIApplicationShortcutItem *, void (^)(BOOL));
+static IMP gByeTunesOriginalOpenMusicLibrary = NULL;
+static BOOL gByeTunesDirectRouteInstalled = NO;
 
 static UIViewController *ByeTunesTopController(void)
 {
@@ -40,19 +40,34 @@ static UIViewController *ByeTunesTopController(void)
 
 static UIViewController *ByeTunesMakeFullController(void)
 {
+    FilzaDiagnosticsWriteByeTunesStage(@"direct route entered full ByeTunes factory");
     Class factory = NSClassFromString(@"ByeTunesEmbeddedHostFactory");
     SEL selector = NSSelectorFromString(@"makeViewController");
     if (!factory || ![factory respondsToSelector:selector]) {
-        NSLog(@"[ByeTunesFull] Swift host factory unavailable");
+        FilzaDiagnosticsWriteByeTunesStage(@"direct route Swift host factory unavailable");
         return nil;
     }
-    return ((UIViewController *(*)(id, SEL))objc_msgSend)(factory, selector);
+    @try {
+        UIViewController *controller =
+            ((UIViewController *(*)(id, SEL))objc_msgSend)(factory, selector);
+        FilzaDiagnosticsWriteByeTunesStage(controller
+            ? @"direct route factory returned complete ByeTunes controller"
+            : @"direct route factory returned nil");
+        return controller;
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsWriteByeTunesStage([NSString stringWithFormat:
+            @"direct route factory exception: %@", exception.reason ?: exception.name]);
+        return nil;
+    }
 }
 
-static BOOL ByeTunesPresentFullApp(UIViewController *presenter)
+BOOL FilzaByeTunesPresentFromController(UIViewController *presenter)
 {
     UIViewController *host = presenter ?: ByeTunesTopController();
-    if (!host) return NO;
+    if (!host) {
+        FilzaDiagnosticsWriteByeTunesStage(@"direct route has no active presenter yet");
+        return NO;
+    }
 
     UIViewController *full = ByeTunesMakeFullController();
     if (!full) return NO;
@@ -60,64 +75,58 @@ static BOOL ByeTunesPresentFullApp(UIViewController *presenter)
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *target = host;
         while (target.presentedViewController) target = target.presentedViewController;
-        [target presentViewController:full animated:YES completion:nil];
-        NSLog(@"[ByeTunesFull] presented complete ByeTunes ContentView inside Filza");
+        FilzaDiagnosticsWriteByeTunesStage([NSString stringWithFormat:
+            @"direct route presenting from %@", NSStringFromClass(target.class)]);
+        @try {
+            [target presentViewController:full animated:YES completion:^{
+                FilzaDiagnosticsWriteByeTunesStage(
+                    @"direct route presented complete ByeTunes screen");
+            }];
+        } @catch (NSException *exception) {
+            FilzaDiagnosticsWriteByeTunesStage([NSString stringWithFormat:
+                @"direct route presentation exception: %@",
+                exception.reason ?: exception.name]);
+        }
     });
     return YES;
 }
 
-static void ByeTunesMusicViewDidAppear(id self, SEL _cmd, BOOL animated)
+static void ByeTunesOpenMusicLibrary(id self, SEL _cmd)
 {
-    if (gByeTunesOriginalMusicViewDidAppear)
-        ((void (*)(id, SEL, BOOL))gByeTunesOriginalMusicViewDidAppear)(self, _cmd, animated);
+    FilzaDiagnosticsWriteByeTunesStage(@"TGMainView openMusicLib intercepted by direct route");
+    UIViewController *presenter = [self isKindOfClass:UIViewController.class]
+        ? (UIViewController *)self : ByeTunesTopController();
+    if (FilzaByeTunesPresentFromController(presenter))
+        return;
 
-    if (objc_getAssociatedObject(self, kByeTunesFullPresentedKey)) return;
-    objc_setAssociatedObject(self, kByeTunesFullPresentedKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    ByeTunesPresentFullApp((UIViewController *)self);
+    // Preserve Filza's legacy route only if the full embedded host could not be
+    // constructed. This keeps the button useful in a partially linked build.
+    FilzaDiagnosticsWriteByeTunesStage(@"direct route unavailable; invoking legacy openMusicLib fallback");
+    if (gByeTunesOriginalOpenMusicLibrary)
+        ((void (*)(id, SEL))gByeTunesOriginalOpenMusicLibrary)(self, _cmd);
 }
 
-static BOOL ByeTunesShortcutIsMusic(UIApplicationShortcutItem *item)
+void FilzaByeTunesInstallDirectRoutes(void)
 {
-    if (![item isKindOfClass:UIApplicationShortcutItem.class]) return NO;
-    if ([item.localizedTitle caseInsensitiveCompare:@"Music Library"] == NSOrderedSame) return YES;
-    if ([item.localizedTitle rangeOfString:@"ByeTunes" options:NSCaseInsensitiveSearch].location != NSNotFound) return YES;
-    return [item.type rangeOfString:@"music" options:NSCaseInsensitiveSearch].location != NSNotFound;
-}
-
-static void ByeTunesFullShortcutHandler(id self, SEL _cmd, UIApplication *application,
-                                        UIApplicationShortcutItem *item, void (^completion)(BOOL))
-{
-    if (ByeTunesShortcutIsMusic(item) && ByeTunesPresentFullApp(nil)) {
-        if (completion) completion(YES);
+    if (gByeTunesDirectRouteInstalled) return;
+    Class mainClass = NSClassFromString(@"TGMainView");
+    SEL selector = NSSelectorFromString(@"openMusicLib");
+    Method resolved = mainClass ? class_getInstanceMethod(mainClass, selector) : NULL;
+    if (!resolved) {
+        FilzaDiagnosticsWriteByeTunesStage(@"TGMainView openMusicLib not available yet");
         return;
     }
 
-    if (gByeTunesOriginalShortcutHandler)
-        ((ByeTunesShortcutIMP)gByeTunesOriginalShortcutHandler)(self, _cmd, application, item, completion);
-    else if (completion)
-        completion(NO);
-}
-
-static void ByeTunesInstallFullAppHooks(void)
-{
-    Class musicClass = NSClassFromString(@"TGMusicLibraryViewController");
-    SEL appear = @selector(viewDidAppear:);
-    Method appearMethod = musicClass ? class_getInstanceMethod(musicClass, appear) : NULL;
-    if (appearMethod && method_getImplementation(appearMethod) != (IMP)ByeTunesMusicViewDidAppear) {
-        gByeTunesOriginalMusicViewDidAppear = method_getImplementation(appearMethod);
-        method_setImplementation(appearMethod, (IMP)ByeTunesMusicViewDidAppear);
+    IMP current = method_getImplementation(resolved);
+    if (current != (IMP)ByeTunesOpenMusicLibrary) {
+        gByeTunesOriginalOpenMusicLibrary = current;
+        const char *types = method_getTypeEncoding(resolved);
+        if (!class_addMethod(mainClass, selector, (IMP)ByeTunesOpenMusicLibrary, types))
+            method_setImplementation(class_getInstanceMethod(mainClass, selector),
+                                     (IMP)ByeTunesOpenMusicLibrary);
     }
-
-    id delegate = UIApplication.sharedApplication.delegate;
-    Class delegateClass = delegate ? [delegate class] : Nil;
-    SEL shortcut = @selector(application:performActionForShortcutItem:completionHandler:);
-    Method shortcutMethod = delegateClass ? class_getInstanceMethod(delegateClass, shortcut) : NULL;
-    if (shortcutMethod && method_getImplementation(shortcutMethod) != (IMP)ByeTunesFullShortcutHandler) {
-        gByeTunesOriginalShortcutHandler = method_getImplementation(shortcutMethod);
-        method_setImplementation(shortcutMethod, (IMP)ByeTunesFullShortcutHandler);
-    }
-
-    NSLog(@"[ByeTunesFull] complete app hooks installed");
+    gByeTunesDirectRouteInstalled = YES;
+    FilzaDiagnosticsWriteByeTunesStage(@"TGMainView direct full ByeTunes route installed");
 }
 
 __attribute__((constructor)) static void ByeTunesFullAppInit(void)
@@ -127,17 +136,13 @@ __attribute__((constructor)) static void ByeTunesFullAppInit(void)
             addObserverForName:UIApplicationDidFinishLaunchingNotification
             object:nil queue:NSOperationQueue.mainQueue
             usingBlock:^(__unused NSNotification *note) {
-                // FilzaByeTunesUI installs its compatibility hook at launch.
-                // Install the complete-app route immediately afterwards so it
-                // owns the Music Library shortcut while preserving the old
-                // implementation as a fallback for unrelated shortcuts.
+                FilzaByeTunesInstallDirectRoutes();
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 750 * NSEC_PER_MSEC),
-                               dispatch_get_main_queue(), ^{ ByeTunesInstallFullAppHooks(); });
+                               dispatch_get_main_queue(), ^{ FilzaByeTunesInstallDirectRoutes(); });
             }];
 
-        if (UIApplication.sharedApplication.delegate) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 750 * NSEC_PER_MSEC),
-                           dispatch_get_main_queue(), ^{ ByeTunesInstallFullAppHooks(); });
-        }
+        FilzaByeTunesInstallDirectRoutes();
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC),
+                       dispatch_get_main_queue(), ^{ FilzaByeTunesInstallDirectRoutes(); });
     });
 }

--- a/CompatibilityDiagnostics.m
+++ b/CompatibilityDiagnostics.m
@@ -78,6 +78,14 @@ static void CDWriteCompatibilityReport(void) {
                 @[@"browserView:didSelectItemAtIndexPath:"]),
             @"TGMusicLibraryViewController": CDClassStatus(@"TGMusicLibraryViewController",
                 @[@"viewDidLoad"]),
+            @"TGMainView": CDClassStatus(@"TGMainView",
+                @[@"openMusicLib", @"createMainToolBar"]),
+            @"ByeTunesEmbeddedHostFactory": CDClassStatus(@"ByeTunesEmbeddedHostFactory",
+                @[@"makeViewController", @"makeLibraryViewController"]),
+            @"MondGestaltHostFactory": CDClassStatus(@"MondGestaltHostFactory",
+                @[@"makeViewControllerWithPath:"]),
+            @"GCDWebDAVServer": CDClassStatus(@"GCDWebDAVServer",
+                @[@"initWithUploadDirectory:", @"startWithOptions:error:"]),
             @"GestaltManagerController": CDClassStatus(@"GestaltManagerController", @[@"viewDidLoad"]),
             @"TGPageViewController": CDClassStatus(@"TGPageViewController",
                 @[@"copyFilesAndDirectoryFromPasteboard"]),
@@ -89,7 +97,10 @@ static void CDWriteCompatibilityReport(void) {
         @"paths": @{
             @"virtualRoot": CDPathStatus(virtualRoot),
             @"documents": CDPathStatus(documents),
-            @"byeTunesStage": CDPathStatus([documents stringByAppendingPathComponent:@"ByeTunesEmbedStage.txt"]),
+            @"byeTunesStage": CDPathStatus([[documents stringByAppendingPathComponent:@"FilzaSlop Logs"]
+                stringByAppendingPathComponent:@"ByeTunesEmbedStage.txt"]),
+            @"webDAVStatus": CDPathStatus([[documents stringByAppendingPathComponent:@"FilzaSlop Logs"]
+                stringByAppendingPathComponent:@"WebDAVStatus.txt"]),
         },
     };
 

--- a/FilzaApplySandboxExt-Bridging-Header.h
+++ b/FilzaApplySandboxExt-Bridging-Header.h
@@ -3,3 +3,7 @@
 // Full ByeTunes embeds its original Swift DeviceManager, which talks to the
 // same pinned idevice FFI static library already used by the Filza bridge.
 #import "idevice.h"
+
+// Shared persistent diagnostics used by the embedded ByeTunes and mond hosts.
+#import "FilzaDiagnostics.h"
+#import "GestaltManager.h"

--- a/FilzaDiagnostics.m
+++ b/FilzaDiagnostics.m
@@ -144,6 +144,7 @@ static void FilzaPrepareVisibleDiagnostics(void)
                             "This folder is intentionally stored inside the app Documents directory so it is visible through the iOS Files app when file sharing is enabled.\n\n"
                             "Runtime.log: launch/runtime breadcrumbs\n"
                             "ByeTunesEmbedStage.txt: persistent ByeTunes startup stages\n"
+                            "WebDAVStatus.txt: latest listener, URL, port, authentication, and root status\n"
                             "LastException.txt: last uncaught Objective-C exception\n"
                             "LastSignal.txt: last fatal POSIX signal observed by the process\n";
         [readme writeToFile:readmePath atomically:YES encoding:NSUTF8StringEncoding error:nil];

--- a/FilzaMainToolbarGestalt.m
+++ b/FilzaMainToolbarGestalt.m
@@ -1,0 +1,134 @@
+@import UIKit;
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+#import "FilzaDiagnostics.h"
+#import "FilzaMondBridge.h"
+
+static IMP gFMTOriginalCreateMainToolBar = NULL;
+static IMP gFMTOriginalViewDidAppear = NULL;
+static BOOL gFMTHooksInstalled = NO;
+
+static NSString *const FMTGestaltIdentifier = @"com.nightvibes33.filzaslop.toolbar.gestalt";
+
+static UIToolbar *FMTToolbar(id mainView)
+{
+    SEL selector = NSSelectorFromString(@"toolBar");
+    if (![mainView respondsToSelector:selector]) return nil;
+    id value = ((id (*)(id, SEL))objc_msgSend)(mainView, selector);
+    return [value isKindOfClass:UIToolbar.class] ? value : nil;
+}
+
+static BOOL FMTIsGestaltItem(UIBarButtonItem *item)
+{
+    return [item.accessibilityIdentifier isEqualToString:FMTGestaltIdentifier] ||
+           item.action == NSSelectorFromString(@"fz_openMondGestalt");
+}
+
+static void FMTOpenMond(id self, SEL _cmd)
+{
+    UIViewController *controller = [self isKindOfClass:UIViewController.class] ? self : nil;
+    FilzaDiagnosticsAppend(@"Toolbar", @"Gestalt button tapped");
+    FilzaMondPresentFromController(controller);
+}
+
+static void FMTEnsureGestaltItem(id mainView)
+{
+    UIToolbar *toolbar = FMTToolbar(mainView);
+    if (!toolbar) return;
+
+    NSMutableArray<UIBarButtonItem *> *items = [NSMutableArray arrayWithArray:toolbar.items ?: @[]];
+    for (UIBarButtonItem *item in items) if (FMTIsGestaltItem(item)) return;
+
+    NSInteger appsIndex = NSNotFound;
+    NSInteger musicIndex = NSNotFound;
+    for (NSInteger index = 0; index < (NSInteger)items.count; index++) {
+        UIBarButtonItem *item = items[index];
+        NSString *action = item.action ? NSStringFromSelector(item.action) : @"";
+        NSString *title = item.title.lowercaseString ?: @"";
+        NSString *label = item.accessibilityLabel.lowercaseString ?: @"";
+        if ([action isEqualToString:@"openApps"] ||
+            [title containsString:@"apps"] || [label containsString:@"apps"])
+            appsIndex = index;
+        if ([action isEqualToString:@"openMusicLib"] ||
+            [title containsString:@"music"] || [label containsString:@"music"])
+            musicIndex = index;
+    }
+
+    UIBarButtonItem *gestalt = [[UIBarButtonItem alloc]
+        initWithTitle:@"Gestalt Editor"
+        style:UIBarButtonItemStylePlain
+        target:mainView
+        action:NSSelectorFromString(@"fz_openMondGestalt")];
+    gestalt.accessibilityIdentifier = FMTGestaltIdentifier;
+    gestalt.accessibilityLabel = @"Gestalt Editor";
+
+    NSInteger insertion = items.count;
+    if (appsIndex != NSNotFound || musicIndex != NSNotFound) {
+        NSInteger last = MAX(appsIndex == NSNotFound ? -1 : appsIndex,
+                             musicIndex == NSNotFound ? -1 : musicIndex);
+        insertion = MIN((NSInteger)items.count, last + 1);
+    }
+    [items insertObject:gestalt atIndex:(NSUInteger)insertion];
+    [toolbar setItems:items animated:NO];
+
+    FilzaDiagnosticsAppend(@"Toolbar",
+        [NSString stringWithFormat:@"inserted Gestalt item appsIndex=%ld musicIndex=%ld insertion=%ld",
+         (long)appsIndex, (long)musicIndex, (long)insertion]);
+}
+
+static void FMTCreateMainToolBar(id self, SEL _cmd)
+{
+    if (gFMTOriginalCreateMainToolBar)
+        ((void (*)(id, SEL))gFMTOriginalCreateMainToolBar)(self, _cmd);
+    FMTEnsureGestaltItem(self);
+}
+
+static void FMTViewDidAppear(id self, SEL _cmd, BOOL animated)
+{
+    if (gFMTOriginalViewDidAppear)
+        ((void (*)(id, SEL, BOOL))gFMTOriginalViewDidAppear)(self, _cmd, animated);
+    FMTEnsureGestaltItem(self);
+}
+
+static IMP FMTHook(Class cls, SEL selector, IMP replacement)
+{
+    Method method = class_getInstanceMethod(cls, selector);
+    if (!method) return NULL;
+    IMP original = method_getImplementation(method);
+    const char *types = method_getTypeEncoding(method);
+    if (class_addMethod(cls, selector, replacement, types)) return original;
+    Method owned = class_getInstanceMethod(cls, selector);
+    original = method_getImplementation(owned);
+    if (original != replacement) method_setImplementation(owned, replacement);
+    return original;
+}
+
+static void FMTInstallHooks(void)
+{
+    if (gFMTHooksInstalled) return;
+    Class cls = NSClassFromString(@"TGMainView");
+    if (!cls) return;
+
+    class_addMethod(cls, NSSelectorFromString(@"fz_openMondGestalt"), (IMP)FMTOpenMond, "v@:");
+    gFMTOriginalCreateMainToolBar = FMTHook(cls, NSSelectorFromString(@"createMainToolBar"), (IMP)FMTCreateMainToolBar);
+    gFMTOriginalViewDidAppear = FMTHook(cls, @selector(viewDidAppear:), (IMP)FMTViewDidAppear);
+    gFMTHooksInstalled = gFMTOriginalCreateMainToolBar || gFMTOriginalViewDidAppear;
+
+    if (gFMTHooksInstalled)
+        FilzaDiagnosticsAppend(@"Toolbar", @"TGMainView Gestalt Editor toolbar hooks installed");
+}
+
+__attribute__((constructor)) static void FilzaMainToolbarGestaltInit(void)
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        FMTInstallHooks();
+        [[NSNotificationCenter defaultCenter]
+            addObserverForName:UIApplicationDidFinishLaunchingNotification
+            object:nil queue:NSOperationQueue.mainQueue
+            usingBlock:^(__unused NSNotification *note) { FMTInstallHooks(); }];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC),
+                       dispatch_get_main_queue(), ^{ FMTInstallHooks(); });
+    });
+}

--- a/FilzaMondBridge.h
+++ b/FilzaMondBridge.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+FOUNDATION_EXPORT void FilzaMondPresent(void);
+FOUNDATION_EXPORT void FilzaMondPresentFromController(UIViewController * _Nullable source);
+NS_ASSUME_NONNULL_END

--- a/FilzaMondBridge.m
+++ b/FilzaMondBridge.m
@@ -1,0 +1,122 @@
+@import UIKit;
+
+#import <objc/message.h>
+
+#import "FilzaDiagnostics.h"
+#import "FilzaMondBridge.h"
+#import "GestaltManager.h"
+
+static UIViewController *FMActiveController(void)
+{
+    UIWindow *window = nil;
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if (![scene isKindOfClass:UIWindowScene.class]) continue;
+        for (UIWindow *candidate in ((UIWindowScene *)scene).windows) {
+            if (candidate.isKeyWindow) { window = candidate; break; }
+            if (!window && !candidate.hidden) window = candidate;
+        }
+        if (window.isKeyWindow) break;
+    }
+    if (!window) {
+        for (UIWindow *candidate in UIApplication.sharedApplication.windows) {
+            if (candidate.isKeyWindow) { window = candidate; break; }
+            if (!window && !candidate.hidden) window = candidate;
+        }
+    }
+
+    UIViewController *controller = window.rootViewController;
+    while (controller) {
+        UIViewController *next = controller.presentedViewController;
+        if (!next && [controller isKindOfClass:UINavigationController.class])
+            next = ((UINavigationController *)controller).visibleViewController;
+        if (!next && [controller isKindOfClass:UITabBarController.class])
+            next = ((UITabBarController *)controller).selectedViewController;
+        if (!next && [controller isKindOfClass:UISplitViewController.class])
+            next = ((UISplitViewController *)controller).viewControllers.lastObject;
+        if (!next || next == controller) break;
+        controller = next;
+    }
+    return controller;
+}
+
+static void FMShowUnavailable(UIViewController *source, NSString *message)
+{
+    UIAlertController *alert = [UIAlertController
+        alertControllerWithTitle:@"Gestalt Editor unavailable"
+        message:message
+        preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK"
+        style:UIAlertActionStyleDefault handler:nil]];
+    [source presentViewController:alert animated:YES completion:nil];
+}
+
+static void FMPresentHost(UIViewController *source, NSString *path)
+{
+    Class factory = NSClassFromString(@"MondGestaltHostFactory");
+    SEL selector = NSSelectorFromString(@"makeViewControllerWithPath:");
+    if (!factory || ![factory respondsToSelector:selector]) {
+        FilzaDiagnosticsAppend(@"Gestalt", @"complete embedded Gestalt host factory unavailable");
+        FMShowUnavailable(source,
+            @"The complete embedded Gestalt editor was not linked into this build.");
+        return;
+    }
+
+    UIViewController *controller =
+        ((id (*)(id, SEL, id))objc_msgSend)(factory, selector, path);
+    if (![controller isKindOfClass:UIViewController.class]) {
+        FilzaDiagnosticsAppend(@"Gestalt", @"complete embedded Gestalt host returned no controller");
+        FMShowUnavailable(source, @"The complete Gestalt editor could not be created.");
+        return;
+    }
+
+    UINavigationController *navigation = source.navigationController;
+    if (navigation && !source.presentedViewController) {
+        [navigation pushViewController:controller animated:YES];
+    } else {
+        UINavigationController *wrapper =
+            [[UINavigationController alloc] initWithRootViewController:controller];
+        wrapper.modalPresentationStyle = UIModalPresentationFullScreen;
+        [source presentViewController:wrapper animated:YES completion:nil];
+    }
+    FilzaDiagnosticsAppend(@"Gestalt",
+        [NSString stringWithFormat:@"presented complete Gestalt editor using %@", path]);
+}
+
+void FilzaMondPresentFromController(UIViewController *source)
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *presenter = source ?: FMActiveController();
+        if (!presenter) {
+            FilzaDiagnosticsAppend(@"Gestalt", @"no presenter available");
+            return;
+        }
+
+        FilzaDiagnosticsAppend(@"Gestalt", @"requesting verified MobileGestalt access");
+        __weak UIViewController *weakPresenter = presenter;
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            NSString *detail = nil;
+            NSString *path = FilzaGestaltResolvePath(&detail);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                UIViewController *resolvedPresenter = weakPresenter ?: FMActiveController();
+                if (!resolvedPresenter) return;
+                if (!path.length) {
+                    FilzaDiagnosticsAppend(@"Gestalt",
+                        [NSString stringWithFormat:@"MobileGestalt access failed: %@",
+                         detail ?: @"no detail"]);
+                    FMShowUnavailable(resolvedPresenter, detail ?:
+                        @"The MobileGestalt property list could not be opened.");
+                    return;
+                }
+                FilzaDiagnosticsAppend(@"Gestalt",
+                    [NSString stringWithFormat:@"verified MobileGestalt access: %@",
+                     detail ?: path]);
+                FMPresentHost(resolvedPresenter, path);
+            });
+        });
+    });
+}
+
+void FilzaMondPresent(void)
+{
+    FilzaMondPresentFromController(FMActiveController());
+}

--- a/FilzaMondBridge.m
+++ b/FilzaMondBridge.m
@@ -39,47 +39,172 @@ static UIViewController *FMActiveController(void)
     return controller;
 }
 
-static void FMShowUnavailable(UIViewController *source, NSString *message)
-{
-    UIAlertController *alert = [UIAlertController
-        alertControllerWithTitle:@"Gestalt Editor unavailable"
-        message:message
-        preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:@"OK"
-        style:UIAlertActionStyleDefault handler:nil]];
-    [source presentViewController:alert animated:YES completion:nil];
-}
-
-static void FMPresentHost(UIViewController *source, NSString *path)
+static UIViewController *FMCreateHost(NSString *path)
 {
     Class factory = NSClassFromString(@"MondGestaltHostFactory");
     SEL selector = NSSelectorFromString(@"makeViewControllerWithPath:");
     if (!factory || ![factory respondsToSelector:selector]) {
         FilzaDiagnosticsAppend(@"Gestalt", @"complete embedded Gestalt host factory unavailable");
-        FMShowUnavailable(source,
-            @"The complete embedded Gestalt editor was not linked into this build.");
-        return;
+        return nil;
     }
 
     UIViewController *controller =
         ((id (*)(id, SEL, id))objc_msgSend)(factory, selector, path);
     if (![controller isKindOfClass:UIViewController.class]) {
         FilzaDiagnosticsAppend(@"Gestalt", @"complete embedded Gestalt host returned no controller");
-        FMShowUnavailable(source, @"The complete Gestalt editor could not be created.");
-        return;
+        return nil;
     }
+    return controller;
+}
+
+@interface FMDeferredGestaltController : UIViewController
+@property(nonatomic) BOOL resolutionStarted;
+@property(nonatomic, strong) UILabel *statusLabel;
+@property(nonatomic, strong) UIActivityIndicatorView *spinner;
+@property(nonatomic, strong) UIButton *retryButton;
+@property(nonatomic, strong) UIViewController *embeddedHost;
+@end
+
+@implementation FMDeferredGestaltController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    self.title = @"Gestalt Editor";
+    self.view.backgroundColor = UIColor.systemGroupedBackgroundColor;
+
+    self.spinner = [[UIActivityIndicatorView alloc]
+        initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+    self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.spinner startAnimating];
+
+    self.statusLabel = [UILabel new];
+    self.statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    self.statusLabel.text = @"Opening the complete Gestalt Editor…";
+    self.statusLabel.textAlignment = NSTextAlignmentCenter;
+    self.statusLabel.numberOfLines = 0;
+    self.statusLabel.textColor = UIColor.secondaryLabelColor;
+
+    self.retryButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    self.retryButton.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.retryButton setTitle:@"Retry" forState:UIControlStateNormal];
+    self.retryButton.hidden = YES;
+    [self.retryButton addTarget:self action:@selector(fm_retry)
+               forControlEvents:UIControlEventTouchUpInside];
+
+    [self.view addSubview:self.spinner];
+    [self.view addSubview:self.statusLabel];
+    [self.view addSubview:self.retryButton];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.spinner.centerXAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.centerXAnchor],
+        [self.spinner.bottomAnchor constraintEqualToAnchor:self.statusLabel.topAnchor constant:-18.0],
+        [self.statusLabel.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor constant:24.0],
+        [self.statusLabel.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor constant:-24.0],
+        [self.statusLabel.centerYAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.centerYAnchor],
+        [self.retryButton.topAnchor constraintEqualToAnchor:self.statusLabel.bottomAnchor constant:18.0],
+        [self.retryButton.centerXAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.centerXAnchor],
+    ]];
+    FilzaDiagnosticsAppend(@"Gestalt", @"visible Gestalt loading screen attached");
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self fm_startResolution];
+}
+
+- (void)fm_close
+{
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)fm_retry
+{
+    self.resolutionStarted = NO;
+    self.retryButton.hidden = YES;
+    self.statusLabel.text = @"Retrying MobileGestalt access…";
+    [self.spinner startAnimating];
+    [self fm_startResolution];
+}
+
+- (void)fm_startResolution
+{
+    if (self.resolutionStarted || self.embeddedHost) return;
+    self.resolutionStarted = YES;
+    FilzaDiagnosticsAppend(@"Gestalt", @"visible screen requesting verified MobileGestalt access");
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSString *detail = nil;
+        NSString *path = FilzaGestaltResolvePath(&detail);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            FMDeferredGestaltController *strongSelf = weakSelf;
+            if (!strongSelf) return;
+
+            if (!path.length) {
+                NSString *reason = detail ?: @"The MobileGestalt property list could not be opened.";
+                FilzaDiagnosticsAppend(@"Gestalt",
+                    [NSString stringWithFormat:@"MobileGestalt access failed on visible screen: %@", reason]);
+                [strongSelf.spinner stopAnimating];
+                strongSelf.statusLabel.text = [NSString stringWithFormat:
+                    @"Gestalt Editor could not access MobileGestalt.\n\n%@", reason];
+                strongSelf.retryButton.hidden = NO;
+                strongSelf.resolutionStarted = NO;
+                return;
+            }
+
+            FilzaDiagnosticsAppend(@"Gestalt",
+                [NSString stringWithFormat:@"verified MobileGestalt access: %@", detail ?: path]);
+            UIViewController *host = FMCreateHost(path);
+            if (!host) {
+                [strongSelf.spinner stopAnimating];
+                strongSelf.statusLabel.text =
+                    @"The complete embedded Gestalt Editor was not linked into this build.";
+                strongSelf.retryButton.hidden = NO;
+                strongSelf.resolutionStarted = NO;
+                return;
+            }
+
+            [strongSelf addChildViewController:host];
+            UIView *hostView = host.view;
+            hostView.translatesAutoresizingMaskIntoConstraints = NO;
+            [strongSelf.view addSubview:hostView];
+            [NSLayoutConstraint activateConstraints:@[
+                [hostView.leadingAnchor constraintEqualToAnchor:strongSelf.view.leadingAnchor],
+                [hostView.trailingAnchor constraintEqualToAnchor:strongSelf.view.trailingAnchor],
+                [hostView.topAnchor constraintEqualToAnchor:strongSelf.view.topAnchor],
+                [hostView.bottomAnchor constraintEqualToAnchor:strongSelf.view.bottomAnchor],
+            ]];
+            [host didMoveToParentViewController:strongSelf];
+            strongSelf.embeddedHost = host;
+            [strongSelf.spinner removeFromSuperview];
+            [strongSelf.statusLabel removeFromSuperview];
+            [strongSelf.retryButton removeFromSuperview];
+            FilzaDiagnosticsAppend(@"Gestalt",
+                [NSString stringWithFormat:@"attached complete Gestalt editor using %@", path]);
+        });
+    });
+}
+
+@end
+
+static void FMPresentDeferredHost(UIViewController *source)
+{
+    FMDeferredGestaltController *controller = [FMDeferredGestaltController new];
 
     UINavigationController *navigation = source.navigationController;
     if (navigation && !source.presentedViewController) {
         [navigation pushViewController:controller animated:YES];
     } else {
+        controller.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
+            initWithBarButtonSystemItem:UIBarButtonSystemItemClose
+            target:controller action:@selector(fm_close)];
         UINavigationController *wrapper =
             [[UINavigationController alloc] initWithRootViewController:controller];
         wrapper.modalPresentationStyle = UIModalPresentationFullScreen;
         [source presentViewController:wrapper animated:YES completion:nil];
     }
-    FilzaDiagnosticsAppend(@"Gestalt",
-        [NSString stringWithFormat:@"presented complete Gestalt editor using %@", path]);
+    FilzaDiagnosticsAppend(@"Gestalt", @"presented visible Gestalt loading screen immediately");
 }
 
 void FilzaMondPresentFromController(UIViewController *source)
@@ -91,28 +216,7 @@ void FilzaMondPresentFromController(UIViewController *source)
             return;
         }
 
-        FilzaDiagnosticsAppend(@"Gestalt", @"requesting verified MobileGestalt access");
-        __weak UIViewController *weakPresenter = presenter;
-        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-            NSString *detail = nil;
-            NSString *path = FilzaGestaltResolvePath(&detail);
-            dispatch_async(dispatch_get_main_queue(), ^{
-                UIViewController *resolvedPresenter = weakPresenter ?: FMActiveController();
-                if (!resolvedPresenter) return;
-                if (!path.length) {
-                    FilzaDiagnosticsAppend(@"Gestalt",
-                        [NSString stringWithFormat:@"MobileGestalt access failed: %@",
-                         detail ?: @"no detail"]);
-                    FMShowUnavailable(resolvedPresenter, detail ?:
-                        @"The MobileGestalt property list could not be opened.");
-                    return;
-                }
-                FilzaDiagnosticsAppend(@"Gestalt",
-                    [NSString stringWithFormat:@"verified MobileGestalt access: %@",
-                     detail ?: path]);
-                FMPresentHost(resolvedPresenter, path);
-            });
-        });
+        FMPresentDeferredHost(presenter);
     });
 }
 

--- a/FilzaQuickActions.m
+++ b/FilzaQuickActions.m
@@ -3,6 +3,7 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+#import "ByeTunesFullAppLauncher.h"
 #import "FilzaDiagnostics.h"
 #import "FilzaMondBridge.h"
 
@@ -104,8 +105,11 @@ static void FQOpenWithRetry(NSString *type, NSUInteger attempts)
     BOOL opened = NO;
     if ([type isEqualToString:FQAppsType])
         opened = FQPresentFilzaController(@"TGApplicationsViewController", @"Apps Manager");
-    else if ([type isEqualToString:FQMusicType])
-        opened = FQPresentFilzaController(@"TGMusicLibraryViewController", @"Music Library");
+    else if ([type isEqualToString:FQMusicType]) {
+        opened = FilzaByeTunesPresentFromController(FQActiveController());
+        if (opened)
+            FilzaDiagnosticsAppend(@"QuickAction", @"opened complete ByeTunes directly");
+    }
     else if ([type isEqualToString:FQGestaltType]) {
         UIViewController *source = FQActiveController();
         if (source) {

--- a/FilzaQuickActions.m
+++ b/FilzaQuickActions.m
@@ -4,12 +4,23 @@
 #import <objc/runtime.h>
 
 #import "FilzaDiagnostics.h"
+#import "FilzaMondBridge.h"
 
 static NSString *const FQAppsType = @"com.nightvibes33.filzaslop.apps-manager";
 static NSString *const FQMusicType = @"com.nightvibes33.filzaslop.music-library";
+static NSString *const FQGestaltType = @"com.nightvibes33.filzaslop.gestalt-manager";
 
 static IMP gFQPreviousShortcutHandler = NULL;
+static IMP gFQPreviousSetShortcutItems = NULL;
 static BOOL gFQShortcutHookInstalled = NO;
+static BOOL gFQShortcutSetterHookInstalled = NO;
+
+static BOOL FQIsStaticShortcutType(NSString *type)
+{
+    return [type isEqualToString:FQAppsType] ||
+           [type isEqualToString:FQMusicType] ||
+           [type isEqualToString:FQGestaltType];
+}
 
 static UIViewController *FQActiveController(void)
 {
@@ -95,6 +106,14 @@ static void FQOpenWithRetry(NSString *type, NSUInteger attempts)
         opened = FQPresentFilzaController(@"TGApplicationsViewController", @"Apps Manager");
     else if ([type isEqualToString:FQMusicType])
         opened = FQPresentFilzaController(@"TGMusicLibraryViewController", @"Music Library");
+    else if ([type isEqualToString:FQGestaltType]) {
+        UIViewController *source = FQActiveController();
+        if (source) {
+            FilzaMondPresentFromController(source);
+            FilzaDiagnosticsAppend(@"QuickAction", @"opened complete Gestalt Editor");
+            opened = YES;
+        }
+    }
 
     if (!opened) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 250 * NSEC_PER_MSEC),
@@ -107,7 +126,7 @@ static void FQShortcutHandler(id self, SEL _cmd, UIApplication *application,
                               void (^completion)(BOOL))
 {
     NSString *type = item.type ?: @"";
-    if ([type isEqualToString:FQAppsType] || [type isEqualToString:FQMusicType]) {
+    if (FQIsStaticShortcutType(type)) {
         FilzaDiagnosticsAppend(@"QuickAction",
             [NSString stringWithFormat:@"received %@", type]);
         dispatch_async(dispatch_get_main_queue(), ^{ FQOpenWithRetry(type, 16); });
@@ -123,19 +142,19 @@ static void FQShortcutHandler(id self, SEL _cmd, UIApplication *application,
 
 static void FQInstallShortcutHandler(void)
 {
-    if (gFQShortcutHookInstalled) return;
     id delegate = UIApplication.sharedApplication.delegate;
     if (!delegate) return;
 
     Class cls = object_getClass(delegate);
     SEL selector = @selector(application:performActionForShortcutItem:completionHandler:);
     Method resolved = class_getInstanceMethod(cls, selector);
+    IMP current = resolved ? method_getImplementation(resolved) : NULL;
+    if (current == (IMP)FQShortcutHandler) {
+        gFQShortcutHookInstalled = YES;
+        return;
+    }
+
     if (resolved) {
-        IMP current = method_getImplementation(resolved);
-        if (current == (IMP)FQShortcutHandler) {
-            gFQShortcutHookInstalled = YES;
-            return;
-        }
         gFQPreviousShortcutHandler = current;
         const char *types = method_getTypeEncoding(resolved);
         if (!class_addMethod(cls, selector, (IMP)FQShortcutHandler, types))
@@ -146,25 +165,53 @@ static void FQInstallShortcutHandler(void)
 
     gFQShortcutHookInstalled = YES;
     FilzaDiagnosticsAppend(@"QuickAction",
-        [NSString stringWithFormat:@"Apps/Music delegate hook installed on %@", NSStringFromClass(cls)]);
+        [NSString stringWithFormat:@"three-action delegate hook installed on %@", NSStringFromClass(cls)]);
+}
+
+static void FQSetShortcutItems(id self, SEL _cmd, NSArray<UIApplicationShortcutItem *> *items)
+{
+    NSMutableArray *filtered = [NSMutableArray array];
+    for (UIApplicationShortcutItem *item in items ?: @[]) {
+        if (FQIsStaticShortcutType(item.type ?: @"")) {
+            FilzaDiagnosticsAppend(@"QuickAction",
+                [NSString stringWithFormat:@"blocked dynamic duplicate %@", item.type ?: @"unknown"]);
+            continue;
+        }
+        [filtered addObject:item];
+    }
+    if (gFQPreviousSetShortcutItems)
+        ((void (*)(id, SEL, id))gFQPreviousSetShortcutItems)(self, _cmd, filtered);
+}
+
+static void FQInstallShortcutSetterFilter(void)
+{
+    if (gFQShortcutSetterHookInstalled) return;
+    Class cls = UIApplication.class;
+    SEL selector = @selector(setShortcutItems:);
+    Method method = class_getInstanceMethod(cls, selector);
+    if (!method) return;
+    gFQPreviousSetShortcutItems = method_getImplementation(method);
+    if (gFQPreviousSetShortcutItems != (IMP)FQSetShortcutItems)
+        method_setImplementation(method, (IMP)FQSetShortcutItems);
+    gFQShortcutSetterHookInstalled = YES;
+    FilzaDiagnosticsAppend(@"QuickAction", @"dynamic shortcut duplicate filter installed");
 }
 
 static void FQRemoveDynamicShortcutDuplicates(void)
 {
-    // UIApplication.shortcutItems is the dynamic-only list. The Gestalt
-    // manager previously added a second dynamic copy; clearing this list leaves
-    // the packaged static actions intact.
     UIApplication.sharedApplication.shortcutItems = @[];
-    FilzaDiagnosticsAppend(@"QuickAction", @"cleared legacy dynamic shortcut items");
+    FilzaDiagnosticsAppend(@"QuickAction", @"cleared dynamic shortcut list");
 }
 
 static void FQRefreshRuntimeRouting(void)
 {
+    FQInstallShortcutSetterFilter();
     FQInstallShortcutHandler();
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 350 * NSEC_PER_MSEC),
+    FQRemoveDynamicShortcutDuplicates();
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 700 * NSEC_PER_MSEC),
                    dispatch_get_main_queue(), ^{
-        FQRemoveDynamicShortcutDuplicates();
         FQInstallShortcutHandler();
+        FQRemoveDynamicShortcutDuplicates();
     });
 }
 

--- a/GestaltManager.h
+++ b/GestaltManager.h
@@ -5,5 +5,8 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT void FilzaGestaltManagerInstall(void);
 FOUNDATION_EXPORT void FilzaGestaltManagerPresent(void);
 FOUNDATION_EXPORT void FilzaGestaltManagerPresentFromController(UIViewController * _Nullable controller);
+FOUNDATION_EXPORT NSString * _Nullable FilzaGestaltResolvePath(NSString * _Nullable * _Nullable detail);
+FOUNDATION_EXPORT NSError * _Nullable FilzaGestaltWritePlist(NSString *path, NSDictionary *plist);
+FOUNDATION_EXPORT NSError * _Nullable FilzaGestaltRestoreBackup(NSString *path);
 
 NS_ASSUME_NONNULL_END

--- a/GestaltManager.m
+++ b/GestaltManager.m
@@ -14,6 +14,8 @@
 #import <unistd.h>
 #import <xpc/xpc.h>
 
+#import "FilzaDiagnostics.h"
+#import "FilzaMondBridge.h"
 #import "GestaltManager.h"
 #include "bad_query.h"
 
@@ -25,9 +27,11 @@ static NSString *const GMShortcutType = @"com.nightvibes33.filzaslop.gestalt-man
 static NSString *gGMResolvedPath;
 static int64_t gGMBadQueryHandle = -1;
 static BOOL gGMMenuHooksInstalled = NO;
+static BOOL gGMMenuScanScheduled = NO;
 static BOOL gGMShortcutHookInstalled = NO;
 static Class gGMMenuDataSourceClass = Nil;
 static Class gGMMenuDelegateClass = Nil;
+static __weak UITableView *gGMMenuTable = nil;
 static NSInteger gGMMenuSection = NSNotFound;
 static NSInteger gGMMenuRow = NSNotFound;
 
@@ -1130,36 +1134,40 @@ static NSInteger GMMenuRows(id self, SEL _cmd, UITableView *tableView, NSInteger
 {
     NSInteger original = gGMOrigRows
         ? ((NSInteger (*)(id, SEL, id, NSInteger))gGMOrigRows)(self, _cmd, tableView, section) : 0;
-    return section == gGMMenuSection ? original + 1 : original;
+    return tableView == gGMMenuTable && section == gGMMenuSection ? original + 1 : original;
 }
 
 static UITableViewCell *GMMenuCell(id self, SEL _cmd, UITableView *tableView, NSIndexPath *indexPath)
 {
-    if (indexPath.section == gGMMenuSection && indexPath.row == gGMMenuRow) {
+    if (tableView == gGMMenuTable &&
+        indexPath.section == gGMMenuSection && indexPath.row == gGMMenuRow) {
         UITableViewCell *cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
-        cell.textLabel.text = @"Gestalt Manager";
+        cell.textLabel.text = @"Gestalt Editor";
         cell.imageView.image = [UIImage systemImageNamed:@"slider.horizontal.3"];
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         return cell;
     }
-    NSIndexPath *mapped = GMOriginalIndexPath(indexPath);
+    NSIndexPath *mapped = tableView == gGMMenuTable ? GMOriginalIndexPath(indexPath) : indexPath;
     return gGMOrigCell ? ((id (*)(id, SEL, id, id))gGMOrigCell)(self, _cmd, tableView, mapped) : [UITableViewCell new];
 }
 
 static void GMMenuSelected(id self, SEL _cmd, UITableView *tableView, NSIndexPath *indexPath)
 {
-    if (indexPath.section == gGMMenuSection && indexPath.row == gGMMenuRow) {
+    if (tableView == gGMMenuTable &&
+        indexPath.section == gGMMenuSection && indexPath.row == gGMMenuRow) {
         [tableView deselectRowAtIndexPath:indexPath animated:YES];
-        FilzaGestaltManagerPresentFromController(GMControllerForView(tableView));
+        FilzaDiagnosticsAppend(@"Gestalt", @"in-app manager row tapped");
+        FilzaMondPresentFromController(GMControllerForView(tableView));
         return;
     }
-    NSIndexPath *mapped = GMOriginalIndexPath(indexPath);
+    NSIndexPath *mapped = tableView == gGMMenuTable ? GMOriginalIndexPath(indexPath) : indexPath;
     if (gGMOrigSelect) ((void (*)(id, SEL, id, id))gGMOrigSelect)(self, _cmd, tableView, mapped);
 }
 
 static BOOL GMInstallMenuHooksForTable(UITableView *tableView)
 {
-    if (gGMMenuHooksInstalled || !tableView.dataSource) return gGMMenuHooksInstalled;
+    if (gGMMenuHooksInstalled || !tableView.dataSource || !tableView.delegate)
+        return gGMMenuHooksInstalled;
     id dataSource = tableView.dataSource;
     id delegate = tableView.delegate;
     NSInteger appsSection = NSNotFound, appsRow = NSNotFound;
@@ -1188,6 +1196,7 @@ static BOOL GMInstallMenuHooksForTable(UITableView *tableView)
     gGMMenuSection = musicSection;
     gGMMenuRow = musicRow + 1;
     if (appsSection == musicSection) gGMMenuRow = MAX(appsRow, musicRow) + 1;
+    gGMMenuTable = tableView;
 
     Class dsClass = object_getClass(dataSource);
     Class delegateClass = delegate ? object_getClass(delegate) : Nil;
@@ -1211,6 +1220,8 @@ static BOOL GMInstallMenuHooksForTable(UITableView *tableView)
             gGMOrigSelect = method_getImplementation(selectMethod);
             class_addMethod(delegateClass, selectSel, (IMP)GMMenuSelected, method_getTypeEncoding(selectMethod)) ||
                 (method_setImplementation(class_getInstanceMethod(delegateClass, selectSel), (IMP)GMMenuSelected), YES);
+        } else {
+            class_addMethod(delegateClass, selectSel, (IMP)GMMenuSelected, "v@:@@");
         }
     }
 
@@ -1219,6 +1230,9 @@ static BOOL GMInstallMenuHooksForTable(UITableView *tableView)
     gGMMenuHooksInstalled = YES;
     NSLog(@"[GestaltManager] inserted manager menu section=%ld row=%ld dataSource=%@ delegate=%@",
           (long)gGMMenuSection, (long)gGMMenuRow, NSStringFromClass(dsClass), NSStringFromClass(delegateClass));
+    FilzaDiagnosticsAppend(@"Gestalt", [NSString stringWithFormat:
+        @"inserted in-app Gestalt Editor row beside Apps/Music section=%ld row=%ld",
+        (long)gGMMenuSection, (long)gGMMenuRow]);
     [tableView reloadData];
     return YES;
 }
@@ -1235,13 +1249,19 @@ static void GMScanViewsForMenu(UIView *view)
 
 static void GMScheduleMenuScan(NSUInteger attempts)
 {
-    if (attempts == 0 || gGMMenuHooksInstalled) return;
+    if (attempts == 0 || gGMMenuHooksInstalled) {
+        gGMMenuScanScheduled = NO;
+        return;
+    }
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 350 * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
         for (UIWindow *window in UIApplication.sharedApplication.windows) {
             GMScanViewsForMenu(window);
             if (gGMMenuHooksInstalled) break;
         }
-        if (!gGMMenuHooksInstalled) GMScheduleMenuScan(attempts - 1);
+        if (!gGMMenuHooksInstalled)
+            GMScheduleMenuScan(attempts - 1);
+        else
+            gGMMenuScanScheduled = NO;
     });
 }
 
@@ -1300,10 +1320,14 @@ static void GMInstallShortcutDelegateHook(void)
 
 void FilzaGestaltManagerInstall(void)
 {
-    // Presentation is owned by the linked Mond surface and the unified
-    // three-action router. Keep this controller as the verified access and
-    // persistence provider without installing a second menu or shortcut.
-    NSLog(@"[GestaltManager] verified access provider ready");
+    // Scan repeatedly because Filza creates and populates its manager table
+    // after launch. The inserted row opens the exact same complete Mond surface
+    // as the static Home Screen quick action.
+    if (!gGMMenuHooksInstalled && !gGMMenuScanScheduled) {
+        gGMMenuScanScheduled = YES;
+        GMScheduleMenuScan(8);
+        FilzaDiagnosticsAppend(@"Gestalt", @"in-app manager-row discovery scheduled");
+    }
 }
 
 __attribute__((constructor)) static void GestaltManagerInit(void)

--- a/GestaltManager.m
+++ b/GestaltManager.m
@@ -424,6 +424,51 @@ static BOOL GMWriteValidatedPlist(NSString *path, NSMutableDictionary *plist, NS
     return NO;
 }
 
+NSString *FilzaGestaltResolvePath(NSString **detail)
+{
+    NSString *path = GMEnsureAccess(detail);
+    if (path.length) (void)GMEnsureBackup(path, nil);
+    return path;
+}
+
+NSError *FilzaGestaltWritePlist(NSString *path, NSDictionary *plist)
+{
+    if (!path.length || ![plist isKindOfClass:NSDictionary.class]) {
+        return [NSError errorWithDomain:@"GestaltManager" code:3 userInfo:@{
+            NSLocalizedDescriptionKey: @"MobileGestalt path or property list is invalid"
+        }];
+    }
+    NSError *error = nil;
+    NSMutableDictionary *mutable = [plist mutableCopy];
+    return GMWriteValidatedPlist(path, mutable, &error) ? nil : (error ?: [NSError
+        errorWithDomain:@"GestaltManager" code:4 userInfo:@{
+            NSLocalizedDescriptionKey: @"MobileGestalt write failed"
+        }]);
+}
+
+NSError *FilzaGestaltRestoreBackup(NSString *path)
+{
+    NSError *error = nil;
+    NSData *backup = [NSData dataWithContentsOfFile:GMBackupPath()
+                                            options:0
+                                              error:&error];
+    if (!backup.length) return error ?: [NSError errorWithDomain:@"GestaltManager"
+        code:5 userInfo:@{NSLocalizedDescriptionKey: @"No saved MobileGestalt backup exists"}];
+
+    id parsed = [NSPropertyListSerialization propertyListWithData:backup
+        options:0 format:nil error:&error];
+    if (![parsed isKindOfClass:NSDictionary.class]) return error ?: [NSError
+        errorWithDomain:@"GestaltManager" code:6 userInfo:@{
+            NSLocalizedDescriptionKey: @"Saved MobileGestalt backup is invalid"
+        }];
+    if (!GMDirectWrite(path, backup, &error)) return error;
+    if (!GMLoadMutablePlist(path, &error)) return error ?: [NSError
+        errorWithDomain:@"GestaltManager" code:7 userInfo:@{
+            NSLocalizedDescriptionKey: @"Restored MobileGestalt failed validation"
+        }];
+    return nil;
+}
+
 #pragma mark - Feature catalog
 
 static NSArray<NSDictionary *> *GMSoftwareFeatures(void)
@@ -1255,26 +1300,15 @@ static void GMInstallShortcutDelegateHook(void)
 
 void FilzaGestaltManagerInstall(void)
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        GMInstallShortcutItem();
-        GMInstallShortcutDelegateHook();
-        GMScheduleMenuScan(20);
-    });
+    // Presentation is owned by the linked Mond surface and the unified
+    // three-action router. Keep this controller as the verified access and
+    // persistence provider without installing a second menu or shortcut.
+    NSLog(@"[GestaltManager] verified access provider ready");
 }
 
 __attribute__((constructor)) static void GestaltManagerInit(void)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidFinishLaunchingNotification
-            object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
-                FilzaGestaltManagerInstall();
-            }];
-        [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
-            object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
-                GMInstallShortcutItem();
-                GMInstallShortcutDelegateHook();
-                if (!gGMMenuHooksInstalled) GMScheduleMenuScan(10);
-            }];
         FilzaGestaltManagerInstall();
     });
 }

--- a/Makefile
+++ b/Makefile
@@ -10,18 +10,25 @@ IDEVICE_VENDOR ?= $(PWD)/Vendor/idevice
 IDEVICE_STATIC := $(IDEVICE_VENDOR)/lib/libidevice_ffi.a
 BYETUNES_ROOT := ByeTunes/MusicManager
 BAD_QUERY_ROOT := ThirdParty/bad_query
+GCDWEBSERVER_ROOT := ThirdParty/GCDWebServer
 
 # Runtime/file-operation correctness layers that must actually ship with the
-# real tweak target. ByeTunesFilzaLibraryEmbed.m replaces Filza's existing
-# TGMusicLibraryViewController contents in-place with the real ByeTunes SwiftUI
-# root; the older custom table and modal full-app launcher are intentionally not
-# linked anymore.
-FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m FilzaMondBridge.m FilzaMainToolbarGestalt.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m FilzaDiagnostics.m FilzaQuickActions.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
+# real tweak target. The direct launcher intercepts TGMainView.openMusicLib and
+# presents the full ByeTunes SwiftUI root; the legacy controller embed remains
+# linked only as a compatibility fallback.
+FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m FilzaMondBridge.m FilzaMainToolbarGestalt.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ByeTunesFullAppLauncher.m FilzaDiagnostics.m FilzaQuickActions.m WebDAVRuntimeFix.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 
 # Pinned bad_query backs the verified foreign-container, system-root, and
 # MobileGestalt access paths. A returned handle is not treated as proof of
 # access; callers verify the requested file/directory operation in-process.
 FilzaApplySandboxExt_FILES += $(BAD_QUERY_ROOT)/bad_query/bad_query.c
+
+# Filza's binary still references GCDWebDAVServer for its foreground server,
+# but the jailed base only ships the separate jailbreak-era launchd helper.
+# Link the complete pinned class-1 / partial class-2 WebDAV implementation so
+# TGPreferences.createHttpServer has a real in-process class to instantiate.
+GCDWEBSERVER_OBJC_FILES := $(shell find $(GCDWEBSERVER_ROOT)/GCDWebServer $(GCDWEBSERVER_ROOT)/GCDWebDAVServer -type f -name '*.m' -print)
+FilzaApplySandboxExt_FILES += $(GCDWEBSERVER_OBJC_FILES)
 
 # The original jailed Filza kernel path is used only by the exact iOS 18.5
 # target gate in Tweak.m. Newer systems continue to use the MCM path.
@@ -43,6 +50,8 @@ FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift MondGestaltView.sw
 
 # --- Flags ---
 FilzaApplySandboxExt_CFLAGS = -I$(PWD)/compat -I$(PWD) -I$(PWD)/XPF/src -I$(PWD)/XPF/external/ChOma/include -I$(IDEVICE_VENDOR)/include -I$(PWD)/$(BAD_QUERY_ROOT)/bad_query \
+    -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Core -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Requests -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Responses -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebDAVServer \
+    -I$(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)/usr/include/libxml2 \
     -fobjc-arc -include errno.h -include math.h \
     -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable \
     -Wno-incompatible-pointer-types -Wno-incompatible-pointer-types-discards-qualifiers \
@@ -61,9 +70,9 @@ FilzaApplySandboxExt_LDFLAGS += $(IDEVICE_STATIC)
 
 # Framework coverage matches the complete ByeTunes source tree rather than the
 # old reduced music-library bridge.
-FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents
+FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents CFNetwork MobileCoreServices
 FilzaApplySandboxExt_PRIVATE_FRAMEWORKS = IOSurface
-FilzaApplySandboxExt_LIBRARIES = z sandbox sqlite3
+FilzaApplySandboxExt_LIBRARIES = z xml2 sandbox sqlite3
 
 FilzaApplySandboxExt_INSTALL_TARGET_PROCESSES = Filza
 
@@ -85,7 +94,11 @@ before-FilzaApplySandboxExt-all::
 	@test -f "FilzaMondBridge.m" || (echo "Missing FilzaMondBridge.m" >&2; exit 1)
 	@test -f "FilzaMainToolbarGestalt.m" || (echo "Missing FilzaMainToolbarGestalt.m" >&2; exit 1)
 	@test -f "MondGestaltView.swift" || (echo "Missing MondGestaltView.swift" >&2; exit 1)
+	@test -f "ByeTunesFullAppLauncher.m" || (echo "Missing ByeTunesFullAppLauncher.m" >&2; exit 1)
 	@test -f "FilzaDiagnostics.m" || (echo "Missing FilzaDiagnostics.m" >&2; exit 1)
 	@test -f "FilzaQuickActions.m" || (echo "Missing FilzaQuickActions.m" >&2; exit 1)
+	@test -f "WebDAVRuntimeFix.m" || (echo "Missing WebDAVRuntimeFix.m" >&2; exit 1)
+	@test -f "$(GCDWEBSERVER_ROOT)/GCDWebDAVServer/GCDWebDAVServer.m" || (echo "Missing pinned GCDWebDAVServer" >&2; exit 1)
+	@test -f "$(GCDWEBSERVER_ROOT)/LICENSE" || (echo "Missing GCDWebServer license" >&2; exit 1)
 
 include $(THEOS_MAKE_PATH)/tweak.mk

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BAD_QUERY_ROOT := ThirdParty/bad_query
 # TGMusicLibraryViewController contents in-place with the real ByeTunes SwiftUI
 # root; the older custom table and modal full-app launcher are intentionally not
 # linked anymore.
-FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m FilzaDiagnostics.m FilzaQuickActions.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
+FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m FilzaMondBridge.m FilzaMainToolbarGestalt.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m FilzaDiagnostics.m FilzaQuickActions.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 
 # Pinned bad_query backs the verified foreign-container, system-root, and
 # MobileGestalt access paths. A returned handle is not treated as proof of
@@ -39,7 +39,7 @@ FilzaApplySandboxExt_FILES += XPF/external/ChOma/src/arm64.c XPF/external/ChOma/
 # owns that lifecycle. ByeTunesEmbeddedHost.swift exposes ContentView() as a
 # child controller that is mounted directly inside Filza's Music Library.
 BYETUNES_SWIFT_FILES := $(shell find $(BYETUNES_ROOT) -type f -name '*.swift' ! -name 'MusicManagerApp.swift' -print)
-FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift $(BYETUNES_SWIFT_FILES)
+FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift MondGestaltView.swift $(BYETUNES_SWIFT_FILES)
 
 # --- Flags ---
 FilzaApplySandboxExt_CFLAGS = -I$(PWD)/compat -I$(PWD) -I$(PWD)/XPF/src -I$(PWD)/XPF/external/ChOma/include -I$(IDEVICE_VENDOR)/include -I$(PWD)/$(BAD_QUERY_ROOT)/bad_query \
@@ -82,6 +82,9 @@ before-FilzaApplySandboxExt-all::
 	@test -f "SystemPathDiagnostics.m" || (echo "Missing SystemPathDiagnostics.m" >&2; exit 1)
 	@test -f "BadQuerySystemProbe.m" || (echo "Missing BadQuerySystemProbe.m" >&2; exit 1)
 	@test -f "GestaltManager.m" || (echo "Missing GestaltManager.m" >&2; exit 1)
+	@test -f "FilzaMondBridge.m" || (echo "Missing FilzaMondBridge.m" >&2; exit 1)
+	@test -f "FilzaMainToolbarGestalt.m" || (echo "Missing FilzaMainToolbarGestalt.m" >&2; exit 1)
+	@test -f "MondGestaltView.swift" || (echo "Missing MondGestaltView.swift" >&2; exit 1)
 	@test -f "FilzaDiagnostics.m" || (echo "Missing FilzaDiagnostics.m" >&2; exit 1)
 	@test -f "FilzaQuickActions.m" || (echo "Missing FilzaQuickActions.m" >&2; exit 1)
 

--- a/MondGestaltView.swift
+++ b/MondGestaltView.swift
@@ -355,7 +355,15 @@ struct MondGestaltView: View {
     }
 
     private func write(_ dictionary: NSMutableDictionary) throws {
-        if let error = FilzaGestaltWritePlist(gestaltPath, dictionary) {
+        guard let bridgedDictionary = dictionary as? [AnyHashable: Any] else {
+            throw NSError(
+                domain: "FilzaSlop.Gestalt",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "The MobileGestalt property list contains an unsupported key type."]
+            )
+        }
+
+        if let error = FilzaGestaltWritePlist(gestaltPath, bridgedDictionary) {
             throw error
         }
     }

--- a/MondGestaltView.swift
+++ b/MondGestaltView.swift
@@ -1,0 +1,470 @@
+import SwiftUI
+import UIKit
+import Darwin
+import MachO
+
+private enum MondGestaltError: Error, LocalizedError {
+    case invalidPlist
+    case missingArtworkSubtype
+    case missingArtworkDeviceName
+    case writeValidationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidPlist: return "MobileGestalt.plist is invalid."
+        case .missingArtworkSubtype: return "Failed to get ArtworkDeviceSubType."
+        case .missingArtworkDeviceName: return "Failed to get ArtworkDeviceProductDescription."
+        case .writeValidationFailed: return "The written plist failed validation."
+        }
+    }
+}
+
+private var mondOffsetCache: [String: Int] = [:]
+
+private func mondCacheDataOffset(_ key: String) -> Int {
+    if let cached = mondOffsetCache[key] { return cached }
+
+    let libMG = "/usr/lib/libMobileGestalt.dylib"
+    dlopen(libMG, RTLD_GLOBAL)
+
+    var header: UnsafePointer<mach_header_64>?
+    for index in 0..<_dyld_image_count() {
+        guard let rawName = _dyld_get_image_name(index) else { continue }
+        if String(cString: rawName) == libMG {
+            header = unsafeBitCast(_dyld_get_image_header(index), to: UnsafePointer<mach_header_64>.self)
+            break
+        }
+    }
+    guard let header else { mondOffsetCache[key] = 0; return 0 }
+
+    var textSize: UInt = 0
+    guard let cstringBytes = getsectiondata(header, "__TEXT", "__cstring", &textSize) else {
+        mondOffsetCache[key] = 0
+        return 0
+    }
+    let start = cstringBytes.withMemoryRebound(to: CChar.self, capacity: Int(textSize)) { $0 }
+    var keyPointer = start
+    while keyPointer - start < Int(textSize) {
+        if String(cString: keyPointer) == key { break }
+        keyPointer += strlen(keyPointer) + 1
+    }
+
+    var constSize: UInt = 0
+    var slots = getsectiondata(header, "__AUTH_CONST", "__const", &constSize)?
+        .withMemoryRebound(to: UInt.self, capacity: Int(constSize) / 8) { $0 }
+    if slots == nil {
+        slots = getsectiondata(header, "__DATA_CONST", "__const", &constSize)?
+            .withMemoryRebound(to: UInt.self, capacity: Int(constSize) / 8) { $0 }
+    }
+    guard let slots else { mondOffsetCache[key] = 0; return 0 }
+
+    for index in 0..<(Int(constSize) / 8) where slots[index] == UInt(bitPattern: keyPointer) {
+        let entry = slots.advanced(by: index).withMemoryRebound(to: UInt16.self, capacity: 1) { $0 }
+        let offset = Int(entry[0x9a / 2] << 3)
+        mondOffsetCache[key] = offset
+        return offset
+    }
+    mondOffsetCache[key] = 0
+    return 0
+}
+
+private func mondMachineName() -> String {
+    var info = utsname()
+    uname(&info)
+    return withUnsafePointer(to: &info.machine) {
+        $0.withMemoryRebound(to: CChar.self, capacity: 1) { String(cString: $0) }
+    }
+}
+
+private func mondSystemVersion() -> Double {
+    let version = ProcessInfo.processInfo.operatingSystemVersion
+    return Double(version.majorVersion) + Double(version.minorVersion) / 10.0
+}
+
+private func mondHasHomeButton() -> Bool {
+    let windows = UIApplication.shared.connectedScenes
+        .compactMap { $0 as? UIWindowScene }
+        .flatMap { $0.windows }
+    return (windows.first(where: { $0.isKeyWindow })?.safeAreaInsets.bottom ?? 0) == 0
+}
+
+private func mondBackupURL() -> URL {
+    let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    let directory = base.appendingPathComponent("GestaltManager", isDirectory: true)
+    try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory.appendingPathComponent("SavedGestalt.plist")
+}
+
+private struct MondToggle: View {
+    let text: String
+    let minimum: Double?
+    @Binding var isOn: Bool
+
+    init(_ text: String, minimum: Double? = nil, isOn: Binding<Bool>) {
+        self.text = text
+        self.minimum = minimum
+        self._isOn = isOn
+    }
+
+    var body: some View {
+        Toggle(text, isOn: $isOn)
+            .disabled(minimum.map { mondSystemVersion() < $0 } ?? false)
+    }
+}
+
+struct MondGestaltView: View {
+    let gestaltPath: String
+
+    @AppStorage("mg_devicename") private var deviceName = ""
+    @State private var plist = NSMutableDictionary()
+    @State private var valid = true
+    @State private var empty = false
+    @State private var loading = false
+    @State private var originalSubtype = 0
+    @State private var selectedSubtype = "og"
+    @State private var customDeviceName = false
+    @State private var originalDeviceName = ""
+    @State private var productType = ""
+    @State private var message: String?
+
+    private var cacheExtra: NSMutableDictionary? {
+        if let mutable = plist["CacheExtra"] as? NSMutableDictionary { return mutable }
+        if let existing = plist["CacheExtra"] as? NSDictionary {
+            let mutable = existing.mutableCopy() as! NSMutableDictionary
+            plist["CacheExtra"] = mutable
+            return mutable
+        }
+        if plist.count > 0 {
+            let mutable = NSMutableDictionary()
+            plist["CacheExtra"] = mutable
+            return mutable
+        }
+        return nil
+    }
+
+    private var selectedSubtypeValue: Int {
+        switch selectedSubtype {
+        case "og": return originalSubtype
+        case "none": return 0
+        case "14p": return 2436
+        case "14pm": return 2796
+        case "15pm": return 2976
+        case "16p": return 2622
+        case "16pm": return 2868
+        case "air": return 2736
+        case "x": return 2436
+        default: return originalSubtype
+        }
+    }
+
+    var body: some View {
+        List {
+            if loading {
+                Section {
+                    HStack {
+                        ProgressView()
+                        Text("Loading MobileGestalt…")
+                    }
+                }
+            }
+
+            if !valid || empty {
+                Section("Warning") {
+                    if empty { Label("Do not reboot — MobileGestalt.plist is empty.", systemImage: "exclamationmark.triangle.fill") }
+                    if !valid { Label("Do not reboot — MobileGestalt.plist is invalid.", systemImage: "exclamationmark.triangle.fill") }
+                }
+            }
+
+            Section {
+                Button("Apply Tweaks", action: apply)
+                Button("Revert Tweaks", role: .destructive, action: revert)
+            } footer: {
+                Text("WARNING: These tweaks can break device features or soft-brick the device if misused.")
+            }
+
+            Section("Device Artwork") {
+                Picker("Subtype", selection: $selectedSubtype) {
+                    Text("Original (\(originalSubtype))").tag("og")
+                    Text("Disable Dynamic Island").tag("none")
+                    Text("iPhone 14 Pro").tag("14p")
+                    Text("iPhone 14 Pro Max").tag("14pm")
+                    Text("iPhone 15 Pro Max").tag("15pm")
+                    Text("iPhone 16 Pro").tag("16p")
+                    Text("iPhone 16 Pro Max").tag("16pm")
+                    Text("iPhone Air").tag("air")
+                    if mondHasHomeButton() { Text("iPhone X Gestures").tag("x") }
+                }
+                Toggle("Custom Device Name", isOn: $customDeviceName)
+                if customDeviceName { TextField("Device Name", text: $deviceName) }
+            }
+
+            Section("Software-Oriented Features") {
+                MondToggle("Dynamic Island", minimum: 19.0, isOn: keyBinding(["YlEtTtHlNesRBMal1CqRaA"]))
+                MondToggle("Always On Display", minimum: 18.0, isOn: keyBinding(["j8/Omm6s1lsmTDFsXjsBfA", "2OOJf1VhaM7NxfRok3HbWQ"]))
+                MondToggle("AOD Vibrancy", minimum: 18.0, isOn: keyBinding(["ykpu7qyhqFweVMKtxNylWA"]))
+                MondToggle("Charge Limit", minimum: 17.0, isOn: keyBinding(["37NVydb//GP/GrhuTN+exg"]))
+                MondToggle("Boot Chime", isOn: keyBinding(["QHxt+hGLaBPbQJbXiUJX3w"]))
+                MondToggle("Liquid Glass LPM", minimum: 19.0, isOn: keyBinding(["SAGvsp6O6kAQ4fEfDJpC4Q"]))
+            }
+
+            Section("Hardware-Oriented Features") {
+                MondToggle("Camera Control", minimum: 18.0, isOn: keyBinding(["CwvKxM2cEogD3p+HYgaW0Q", "oOV1jhJbdV3AddkcCg0AEA"]))
+                MondToggle("Action Button", minimum: 17.0, isOn: keyBinding(["cT44WE1EohiwRzhsZ8xEsw"]))
+                MondToggle("Crash Detection", isOn: keyBinding(["HCzWusHQwZDea6nNhaKndw"]))
+                if mondHasHomeButton() { MondToggle("Enable Tap to Wake", isOn: keyBinding(["yZf3GTRMGTuwSV/lD7Cagw"])) }
+                MondToggle("Pulse Width Modulation", minimum: 19.0, isOn: keyBinding(["6IejgN+1Fmu5/QrZFOIeNw"]))
+            }
+
+            Section("Eligibility") {
+                MondToggle("Security Research Device UI", minimum: 26.0, isOn: keyBinding(["XYlJKKkj2hztRP1NWWnhlw"]))
+                Toggle("Disable Region Restrictions", isOn: regionBinding())
+                MondToggle("Apple Intelligence", minimum: 18.1, isOn: appleIntelligenceBinding())
+                Picker("Spoofing", selection: $productType) {
+                    Text("Default").tag(mondMachineName())
+                    if UIDevice.current.userInterfaceIdiom == .pad {
+                        Text("iPad Pro 11-inch (M4)").tag("iPad16,3")
+                        Text("iPad Pro 11-inch (M4, Cellular)").tag("iPad16,4")
+                        Text("iPad Pro 11-inch (4th Gen)").tag("iPad14,3")
+                        Text("iPad Pro 11-inch (4th Gen, Cellular)").tag("iPad14,4")
+                    } else {
+                        Text("iPhone 15 Pro").tag("iPhone16,1")
+                        Text("iPhone 15 Pro Max").tag("iPhone16,2")
+                        Text("iPhone 16").tag("iPhone17,3")
+                        Text("iPhone 16 Plus").tag("iPhone17,4")
+                        Text("iPhone 16 Pro").tag("iPhone17,1")
+                        Text("iPhone 16 Pro Max").tag("iPhone17,2")
+                        Text("iPhone 17").tag("iPhone18,3")
+                        Text("iPhone 17 Pro").tag("iPhone18,1")
+                        Text("iPhone 17 Pro Max").tag("iPhone18,2")
+                        Text("iPhone Air").tag("iPhone18,4")
+                    }
+                }
+            }
+
+            Section("iPadOS Features") {
+                MondToggle("Allow Installing iPadOS Apps", isOn: arrayBinding("9MZ5AdH43csAUajl/dU+IQ"))
+                MondToggle("Apple Pencil Settings", isOn: keyBinding(["yhHcB0iH0d1XzPO/CFd3ow"]))
+                if UIDevice.current.userInterfaceIdiom == .pad {
+                    MondToggle("Stage Manager", isOn: keyBinding(["qeaj75wk3HF4DwQ8qbIi7g"]))
+                }
+                Toggle("iPadOS UI", isOn: trollPadBinding())
+                    .disabled(cacheExtra?["+3Uf0Pm5F8Xy7Onyvko0vA"] as? String != "iPhone")
+            }
+
+            Section("Internal") {
+                MondToggle("Internal Storage", isOn: keyBinding(["LBJfwOEzExRxzlAnSuI7eg"]))
+                Toggle("Internal Features", isOn: internalBinding())
+                MondToggle("Metal HUD in All Apps", isOn: keyBinding(["EqrsVvjcYDdxHBiQmGhAWw"]))
+            }
+
+        }
+        .navigationTitle("Gestalt Editor")
+        .onAppear(perform: load)
+        .alert("Gestalt Editor", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
+            Button("OK", role: .cancel) { message = nil }
+        } message: {
+            Text(message ?? "")
+        }
+    }
+
+    private func load() {
+        guard !loading, plist.count == 0 else { return }
+        loading = true
+        let url = URL(fileURLWithPath: gestaltPath)
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let data = try Data(contentsOf: url)
+                let object = try PropertyListSerialization.propertyList(from: data, options: [.mutableContainersAndLeaves], format: nil)
+                guard let loaded = object as? NSMutableDictionary else { throw MondGestaltError.invalidPlist }
+                let backup = mondBackupURL()
+                if !FileManager.default.fileExists(atPath: backup.path) { try data.write(to: backup, options: .atomic) }
+
+                let savedData = try Data(contentsOf: backup)
+                let savedObject = try PropertyListSerialization.propertyList(from: savedData, options: [.mutableContainersAndLeaves], format: nil)
+                guard let saved = savedObject as? NSMutableDictionary else { throw MondGestaltError.invalidPlist }
+                let savedExtra = saved["CacheExtra"] as? NSMutableDictionary ?? NSMutableDictionary()
+                let savedArtwork = savedExtra["oPeik/9e8lQWMszEjbPzng"] as? NSMutableDictionary ?? NSMutableDictionary()
+                guard let subtype = savedArtwork["ArtworkDeviceSubType"] as? Int else { throw MondGestaltError.missingArtworkSubtype }
+                guard let originalName = savedArtwork["ArtworkDeviceProductDescription"] as? String else { throw MondGestaltError.missingArtworkDeviceName }
+
+                let extra = loaded["CacheExtra"] as? NSMutableDictionary ?? NSMutableDictionary()
+                let artwork = extra["oPeik/9e8lQWMszEjbPzng"] as? NSMutableDictionary ?? NSMutableDictionary()
+                let currentSubtype = artwork["ArtworkDeviceSubType"] as? Int ?? subtype
+                let subtypeMap = [0: "none", 2436: "14p", 2796: "14pm", 2976: "15pm", 2622: "16p", 2868: "16pm", 2736: "air"]
+                let currentName = artwork["ArtworkDeviceProductDescription"] as? String ?? originalName
+                let currentProduct = extra["h9jDsbgj7xIVeIQ8S3/X3Q"] as? String ?? mondMachineName()
+
+                DispatchQueue.main.async {
+                    self.plist = loaded
+                    self.originalSubtype = subtype
+                    self.selectedSubtype = subtypeMap[currentSubtype] ?? "og"
+                    self.originalDeviceName = originalName
+                    self.deviceName = currentName
+                    self.customDeviceName = currentName != originalName
+                    self.productType = currentProduct
+                    self.empty = data.isEmpty
+                    self.valid = true
+                    self.loading = false
+                    FilzaDiagnosticsAppend("Gestalt", "loaded MobileGestalt from \(gestaltPath)")
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.valid = false
+                    self.empty = ((try? Data(contentsOf: url).isEmpty) ?? false)
+                    self.loading = false
+                    self.message = error.localizedDescription
+                    FilzaDiagnosticsAppend("Gestalt", "load failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private func apply() {
+        guard let extra = cacheExtra else { return }
+        if !productType.isEmpty { extra["h9jDsbgj7xIVeIQ8S3/X3Q"] = productType }
+        let artworkKey = "oPeik/9e8lQWMszEjbPzng"
+        let artwork = (extra[artworkKey] as? NSMutableDictionary) ?? NSMutableDictionary()
+        artwork["ArtworkDeviceSubType"] = selectedSubtypeValue
+        if customDeviceName { artwork["ArtworkDeviceProductDescription"] = deviceName }
+        else { artwork["ArtworkDeviceProductDescription"] = originalDeviceName }
+        extra[artworkKey] = artwork
+
+        do {
+            try write(plist)
+            message = "Successfully applied Gestalt tweaks. Some changes require a respring or reboot."
+            FilzaDiagnosticsAppend("Gestalt", "Gestalt changes written and validated")
+        } catch {
+            message = "Failed to apply MobileGestalt: \(error.localizedDescription)"
+            FilzaDiagnosticsAppend("Gestalt", "write failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func revert() {
+        do {
+            if let error = FilzaGestaltRestoreBackup(gestaltPath) {
+                throw error
+            }
+            plist = NSMutableDictionary()
+            load()
+            message = "Saved original MobileGestalt restored."
+            FilzaDiagnosticsAppend("Gestalt", "restored saved Gestalt backup")
+        } catch {
+            message = "Failed to restore MobileGestalt: \(error.localizedDescription)"
+        }
+    }
+
+    private func write(_ dictionary: NSMutableDictionary) throws {
+        if let error = FilzaGestaltWritePlist(gestaltPath, dictionary) {
+            throw error
+        }
+    }
+
+    private func keyBinding(_ keys: [String]) -> Binding<Bool> {
+        Binding(get: {
+            guard let extra = cacheExtra, let first = keys.first else { return false }
+            return (extra[first] as? NSNumber)?.intValue == 1
+        }, set: { enabled in
+            guard let extra = cacheExtra else { return }
+            for key in keys {
+                if enabled { extra[key] = 1 } else { extra.removeObject(forKey: key) }
+            }
+        })
+    }
+
+    private func arrayBinding(_ key: String) -> Binding<Bool> {
+        Binding(get: {
+            guard let extra = cacheExtra else { return false }
+            return (extra[key] as? [Int]) == [1, 2]
+        }, set: { enabled in
+            cacheExtra?[key] = enabled ? [1, 2] : [1]
+        })
+    }
+
+    private func regionBinding() -> Binding<Bool> {
+        Binding(get: {
+            guard let extra = cacheExtra else { return false }
+            return extra["h63QSdBCiT/z0WU6rdQv6Q"] as? String == "US" &&
+                   extra["zHeENZu+wbg7PUprwNwBWg"] as? String == "LL/A"
+        }, set: { enabled in
+            guard let extra = cacheExtra else { return }
+            if enabled {
+                extra["h63QSdBCiT/z0WU6rdQv6Q"] = "US"
+                extra["zHeENZu+wbg7PUprwNwBWg"] = "LL/A"
+            } else {
+                extra.removeObject(forKey: "h63QSdBCiT/z0WU6rdQv6Q")
+                extra.removeObject(forKey: "zHeENZu+wbg7PUprwNwBWg")
+            }
+        })
+    }
+
+    private func appleIntelligenceBinding() -> Binding<Bool> {
+        let key = "A62OafQ85EJAiiqKn4agtg"
+        return Binding(get: { (cacheExtra?[key] as? NSNumber)?.intValue == 1 }, set: { enabled in
+            if enabled { cacheExtra?[key] = 1 } else { cacheExtra?.removeObject(forKey: key) }
+        })
+    }
+
+    private func mutableCacheData() -> NSMutableData? {
+        if let mutable = plist["CacheData"] as? NSMutableData { return mutable }
+        if let data = plist["CacheData"] as? NSData {
+            let mutable = data.mutableCopy() as! NSMutableData
+            plist["CacheData"] = mutable
+            return mutable
+        }
+        return nil
+    }
+
+    private func readCacheInt(_ key: String) -> Int64? {
+        guard let data = mutableCacheData() else { return nil }
+        let offset = mondCacheDataOffset(key)
+        guard offset > 0, offset + MemoryLayout<Int64>.size <= data.length else { return nil }
+        var value: Int64 = 0
+        memcpy(&value, data.bytes.advanced(by: offset), MemoryLayout<Int64>.size)
+        return value
+    }
+
+    private func writeCacheInt(_ key: String, value: Int64) {
+        guard let data = mutableCacheData() else { return }
+        let offset = mondCacheDataOffset(key)
+        guard offset > 0, offset + MemoryLayout<Int64>.size <= data.length else { return }
+        var mutableValue = value
+        memcpy(data.mutableBytes.advanced(by: offset), &mutableValue, MemoryLayout<Int64>.size)
+    }
+
+    private func internalBinding() -> Binding<Bool> {
+        let keys = ["EqrsVvjcYDdxHBiQmGhAWw", "Oji6HRoPi7rH7HPdWVakuw", "LBJfwOEzExRxzlAnSuI7eg"]
+        return Binding(get: { keys.allSatisfy { readCacheInt($0) == 1 } }, set: { enabled in
+            for key in keys { writeCacheInt(key, value: enabled ? 1 : 0) }
+        })
+    }
+
+    private func trollPadBinding() -> Binding<Bool> {
+        let values = [
+            "mG0AnH/Vy1veoqoLRAIgTA", "UCG5MkVahJxG1YULbbd5Bg",
+            "ZYqko/XM5zD3XBfN5RmaXA", "nVh/gwNpy7Jv1NOk00CMrw", "uKc7FPnEO++lVhHWHFlGbQ"
+        ]
+        return Binding(get: {
+            guard let extra = cacheExtra else { return false }
+            return readCacheInt("mtrAoWJ3gsq+I90ZnQ0vQw") == 3 && values.allSatisfy { (extra[$0] as? NSNumber)?.intValue == 1 }
+        }, set: { enabled in
+            guard let extra = cacheExtra else { return }
+            writeCacheInt("mtrAoWJ3gsq+I90ZnQ0vQw", value: enabled ? 3 : 1)
+            for key in values {
+                if enabled { extra[key] = 1 } else { extra.removeObject(forKey: key) }
+            }
+        })
+    }
+}
+
+@objc(MondGestaltHostFactory)
+public final class MondGestaltHostFactory: NSObject {
+    @objc(makeViewControllerWithPath:)
+    public static func makeViewController(path: String) -> UIViewController {
+        FilzaDiagnosticsAppend("Gestalt", "constructing complete embedded Gestalt Editor")
+        let controller = UIHostingController(rootView: MondGestaltView(gestaltPath: path))
+        controller.title = "Gestalt Editor"
+        controller.view.backgroundColor = .systemGroupedBackground
+        return controller
+    }
+}

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ This fork currently targets the iOS 18 / iOS 26 / early iOS 27 behavior exposed 
 | Foreign app data-container fallback | ✅ Integrated |
 | App size metadata retry | ✅ Integrated |
 | App icon fallback | ✅ Integrated |
-| Gestalt Manager | ✅ Built and packaged |
-| Gestalt Home Screen quick action | ✅ Packaged in `Info.plist` |
+| Gestalt Editor | ✅ Complete editor is linked into the main toolbar route |
+| Gestalt Home Screen quick action | ✅ Static action and runtime handler are both linked |
 | iOS 27 Gestalt key catalog | ✅ Included |
 | ByeTunes resources | ✅ Packaged into the IPA |
-| ByeTunes runtime stability | ⚠️ Still requires on-device validation |
+| ByeTunes Music Library integration | ✅ Complete ByeTunes UI mounts directly; on-device validation still required |
 | Arbitrary `/` / full system filesystem access | ❌ Not established |
 
 ## Managers
@@ -51,28 +51,36 @@ AppIconImage.png
 ByeTunes-Info.plist
 ```
 
-The embed now starts through an inert UIKit boundary instead of immediately constructing the full SwiftUI runtime when the Music Library screen is opened.
+The Music Library entry now mounts the complete ByeTunes `ContentView` directly inside
+`TGMusicLibraryViewController`. There is no inert “Load ByeTunes” placeholder. A small
+UIKit shell is attached first, then the complete SwiftUI application is constructed on
+the next main-loop turn so startup boundaries can be recorded without replacing the UI.
 
 A runtime stage marker is written to:
 
 ```text
-Documents/ByeTunesEmbedStage.txt
+Documents/FilzaSlop Logs/ByeTunesEmbedStage.txt
 ```
 
-If the embedded UI still crashes on device, that file is used to identify how far startup reached. CI success only proves compilation/linking and packaging; it does not prove the embedded runtime survives on-device execution.
+The stage log records the factory call, `ContentView` construction, hosting-controller
+construction, view materialization, and final attachment. CI proves the complete source
+is compiled and linked into the IPA; the installed build still requires device runtime
+validation.
 
-### Gestalt Manager
+### Gestalt Editor
 
-Gestalt Manager is built directly into the Filza runtime and is intended to appear alongside the other manager entries.
+The complete Gestalt editor is compiled into the Filza runtime. A **Gestalt Editor**
+button is inserted into `TGMainView` beside the existing Apps and Music actions.
 
 It is also exposed as a static Home Screen quick action:
 
 ```text
-Gestalt Manager
+Gestalt Editor
 Edit MobileGestalt
 ```
 
-The manager attempts to resolve:
+Both the in-app button and Home Screen quick action resolve the same embedded editor.
+The editor attempts to resolve:
 
 ```text
 /private/var/containers/Shared/SystemGroup/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist
@@ -95,7 +103,10 @@ Write handling includes:
 - post-write plist read-back validation;
 - automatic restoration of the backup if validation fails.
 
-The manager supports feature toggles, raw key inspection/editing, `CacheData`-backed values where an offset can be resolved, key search, and restore/reload controls.
+The editor includes the complete device-artwork, software, hardware, eligibility,
+iPadOS, internal-feature, spoofing, Apply, and Revert controls. Writes use the verified
+direct-file-descriptor fallback, property-list read-back validation, and automatic
+backup restoration if validation fails.
 
 ## iOS 27 Gestalt keys
 
@@ -220,7 +231,7 @@ now performs the complete installable build:
 4. stages ByeTunes runtime resources;
 5. downloads and hash-verifies the pinned unsigned Filza base IPA;
 6. injects the current runtime dylib and resources;
-7. writes the Gestalt Manager Home Screen shortcut into `Info.plist`;
+7. writes exactly three Home Screen shortcuts into `Info.plist` and assigns build version `4.1`;
 8. verifies the base executable actually loads `FilzaApplySandboxExt.dylib`;
 9. repacks a real unsigned IPA;
 10. uploads the IPA as a GitHub Actions artifact.
@@ -238,7 +249,7 @@ Open **Actions → Verify Filza installable IPA** to download the latest build a
 ## Current limitations
 
 - A green build proves the current source compiled, linked, packaged, and uploaded successfully. It does **not** prove every private API or sandbox-extension path still works on a specific iOS build.
-- ByeTunes still needs on-device runtime validation after the packaging fixes.
+- ByeTunes and Gestalt Editor still need on-device runtime validation after each new IPA build.
 - The existing container-access primitives do not establish unrestricted `/`, `/System`, `/Library`, `/Applications`, or arbitrary `/private` traversal.
 - No kernel read/write or full jailbreak primitive is claimed by this README.
 
@@ -256,3 +267,4 @@ Open **Actions → Verify Filza installable IPA** to download the latest build a
 - XPF and ChOma contributors
 - `SerStars/nugget-wallpapers`
 - mightycooldude12
+- [`rooootdev/mond`](https://github.com/rooootdev/mond) for the Gestalt editor behavior integrated into this fork

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This fork currently targets the iOS 18 / iOS 26 / early iOS 27 behavior exposed 
 | iOS 27 Gestalt key catalog | ✅ Included |
 | ByeTunes resources | ✅ Packaged into the IPA |
 | ByeTunes Music Library integration | ✅ Complete ByeTunes UI mounts directly; on-device validation still required |
+| WebDAV server | ✅ Redirected to Filza's in-process server for jailed/sideloaded use |
 | Arbitrary `/` / full system filesystem access | ❌ Not established |
 
 ## Managers
@@ -51,10 +52,11 @@ AppIconImage.png
 ByeTunes-Info.plist
 ```
 
-The Music Library entry now mounts the complete ByeTunes `ContentView` directly inside
-`TGMusicLibraryViewController`. There is no inert “Load ByeTunes” placeholder. A small
-UIKit shell is attached first, then the complete SwiftUI application is constructed on
-the next main-loop turn so startup boundaries can be recorded without replacing the UI.
+The Music Library action now intercepts `TGMainView.openMusicLib` and presents the
+complete ByeTunes `ContentView` directly. The Home Screen Music Library action uses the
+same presenter. `TGMusicLibraryViewController` embedding remains only as a fallback.
+A small UIKit shell is attached first, then the complete SwiftUI application is
+constructed on the next main-loop turn so startup boundaries can be recorded.
 
 A runtime stage marker is written to:
 
@@ -70,7 +72,8 @@ validation.
 ### Gestalt Editor
 
 The complete Gestalt editor is compiled into the Filza runtime. A **Gestalt Editor**
-button is inserted into `TGMainView` beside the existing Apps and Music actions.
+action is inserted beside the existing Apps Manager and Music Library entries, with a
+`TGMainView` toolbar hook as a second in-app route.
 
 It is also exposed as a static Home Screen quick action:
 
@@ -79,7 +82,9 @@ Gestalt Editor
 Edit MobileGestalt
 ```
 
-Both the in-app button and Home Screen quick action resolve the same embedded editor.
+Both the in-app button and Home Screen quick action immediately show the same embedded
+editor shell. MobileGestalt access is resolved from that visible screen; failures are
+shown there with the precise error and a Retry action instead of appearing to do nothing.
 The editor attempts to resolve:
 
 ```text
@@ -107,6 +112,32 @@ The editor includes the complete device-artwork, software, hardware, eligibility
 iPadOS, internal-feature, spoofing, Apply, and Revert controls. Writes use the verified
 direct-file-descriptor fallback, property-list read-back validation, and automatic
 backup restoration if validation fails.
+
+### WebDAV server
+
+Filza's original **Run as system service** option targets jailbreak-only `launchctl`
+and `/usr/libexec/filza/FilzaWebDAVServer` paths. Those paths cannot work from the
+sideloaded MobileHouseArrest app container. FilzaSlop now links a pinned complete
+`GCDWebDAVServer` implementation and forces WebDAV through that in-process server
+while preserving Filza's port, Bonjour, authentication, WebDAV methods, and
+shared-folder settings. It implements OPTIONS, PROPFIND, GET/HEAD, PUT, MKCOL,
+DELETE, COPY, MOVE, LOCK, and UNLOCK. When Filza authentication is enabled, the
+server validates HTTP Basic credentials against Filza's saved password hash and
+refuses to start if those credentials are incomplete.
+
+Use **Preferences → Advanced options → Enable WebDAV server**. The default port is
+`11111`; the exact listening URL and root are recorded after every start or resume in:
+
+```text
+Documents/FilzaSlop Logs/WebDAVStatus.txt
+Documents/FilzaSlop Logs/Runtime.log
+```
+
+The IPA declares local-network and `_http._tcp` Bonjour usage, so accept the iOS Local
+Network prompt the first time the server starts. Keep FilzaSlop in the foreground while
+transferring files: a sideloaded app cannot install a persistent launch daemon, and iOS
+may suspend its listener in the background. Returning to the app automatically checks
+and restarts the listener when WebDAV remains enabled.
 
 ## iOS 27 Gestalt keys
 
@@ -231,7 +262,7 @@ now performs the complete installable build:
 4. stages ByeTunes runtime resources;
 5. downloads and hash-verifies the pinned unsigned Filza base IPA;
 6. injects the current runtime dylib and resources;
-7. writes exactly three Home Screen shortcuts into `Info.plist` and assigns build version `4.1`;
+7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.2`;
 8. verifies the base executable actually loads `FilzaApplySandboxExt.dylib`;
 9. repacks a real unsigned IPA;
 10. uploads the IPA as a GitHub Actions artifact.
@@ -249,7 +280,7 @@ Open **Actions → Verify Filza installable IPA** to download the latest build a
 ## Current limitations
 
 - A green build proves the current source compiled, linked, packaged, and uploaded successfully. It does **not** prove every private API or sandbox-extension path still works on a specific iOS build.
-- ByeTunes and Gestalt Editor still need on-device runtime validation after each new IPA build.
+- ByeTunes, Gestalt Editor, and WebDAV still need on-device runtime validation after each new IPA build.
 - The existing container-access primitives do not establish unrestricted `/`, `/System`, `/Library`, `/Applications`, or arbitrary `/private` traversal.
 - No kernel read/write or full jailbreak primitive is claimed by this README.
 

--- a/ThirdParty/GCDWebServer/GCDWebDAVServer/GCDWebDAVServer.h
+++ b/ThirdParty/GCDWebServer/GCDWebDAVServer/GCDWebDAVServer.h
@@ -1,0 +1,160 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class GCDWebDAVServer;
+
+/**
+ *  Delegate methods for GCDWebDAVServer.
+ *
+ *  @warning These methods are always called on the main thread in a serialized way.
+ */
+@protocol GCDWebDAVServerDelegate <GCDWebServerDelegate>
+@optional
+
+/**
+ *  This method is called whenever a file has been downloaded.
+ */
+- (void)davServer:(GCDWebDAVServer*)server didDownloadFileAtPath:(NSString*)path;
+
+/**
+ *  This method is called whenever a file has been uploaded.
+ */
+- (void)davServer:(GCDWebDAVServer*)server didUploadFileAtPath:(NSString*)path;
+
+/**
+ *  This method is called whenever a file or directory has been moved.
+ */
+- (void)davServer:(GCDWebDAVServer*)server didMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+
+/**
+ *  This method is called whenever a file or directory has been copied.
+ */
+- (void)davServer:(GCDWebDAVServer*)server didCopyItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+
+/**
+ *  This method is called whenever a file or directory has been deleted.
+ */
+- (void)davServer:(GCDWebDAVServer*)server didDeleteItemAtPath:(NSString*)path;
+
+/**
+ *  This method is called whenever a directory has been created.
+ */
+- (void)davServer:(GCDWebDAVServer*)server didCreateDirectoryAtPath:(NSString*)path;
+
+@end
+
+/**
+ *  The GCDWebDAVServer subclass of GCDWebServer implements a class 1 compliant
+ *  WebDAV server. It is also partially class 2 compliant but only when the
+ *  client is the OS X WebDAV implementation (so it can work with the OS X Finder).
+ *
+ *  See the README.md file for more information about the features of GCDWebDAVServer.
+ */
+@interface GCDWebDAVServer : GCDWebServer
+
+/**
+ *  Returns the upload directory as specified when the server was initialized.
+ */
+@property(nonatomic, readonly) NSString* uploadDirectory;
+
+/**
+ *  Sets the delegate for the server.
+ */
+@property(nonatomic, weak, nullable) id<GCDWebDAVServerDelegate> delegate;
+
+/**
+ *  Sets which files are allowed to be operated on depending on their extension.
+ *
+ *  The default value is nil i.e. all file extensions are allowed.
+ */
+@property(nonatomic, copy) NSArray<NSString*>* allowedFileExtensions;
+
+/**
+ *  Sets if files and directories whose name start with a period are allowed to
+ *  be operated on.
+ *
+ *  The default value is NO.
+ */
+@property(nonatomic) BOOL allowHiddenItems;
+
+/**
+ *  This method is the designated initializer for the class.
+ */
+- (instancetype)initWithUploadDirectory:(NSString*)path;
+
+@end
+
+/**
+ *  Hooks to customize the behavior of GCDWebDAVServer.
+ *
+ *  @warning These methods can be called on any GCD thread.
+ */
+@interface GCDWebDAVServer (Subclassing)
+
+/**
+ *  This method is called to check if a file upload is allowed to complete.
+ *  The uploaded file is available for inspection at "tempPath".
+ *
+ *  The default implementation returns YES.
+ */
+- (BOOL)shouldUploadFileAtPath:(NSString*)path withTemporaryFile:(NSString*)tempPath;
+
+/**
+ *  This method is called to check if a file or directory is allowed to be moved.
+ *
+ *  The default implementation returns YES.
+ */
+- (BOOL)shouldMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+
+/**
+ *  This method is called to check if a file or directory is allowed to be copied.
+ *
+ *  The default implementation returns YES.
+ */
+- (BOOL)shouldCopyItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath;
+
+/**
+ *  This method is called to check if a file or directory is allowed to be deleted.
+ *
+ *  The default implementation returns YES.
+ */
+- (BOOL)shouldDeleteItemAtPath:(NSString*)path;
+
+/**
+ *  This method is called to check if a directory is allowed to be created.
+ *
+ *  The default implementation returns YES.
+ */
+- (BOOL)shouldCreateDirectoryAtPath:(NSString*)path;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebDAVServer/GCDWebDAVServer.m
+++ b/ThirdParty/GCDWebServer/GCDWebDAVServer/GCDWebDAVServer.m
@@ -1,0 +1,717 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebDAVServer requires ARC
+#endif
+
+// WebDAV specifications: http://webdav.org/specs/rfc4918.html
+
+// Requires "HEADER_SEARCH_PATHS = $(SDKROOT)/usr/include/libxml2" in Xcode build settings
+#import <libxml/parser.h>
+
+#import "GCDWebDAVServer.h"
+
+#import "GCDWebServerFunctions.h"
+
+#import "GCDWebServerDataRequest.h"
+#import "GCDWebServerFileRequest.h"
+
+#import "GCDWebServerDataResponse.h"
+#import "GCDWebServerErrorResponse.h"
+#import "GCDWebServerFileResponse.h"
+
+#define kXMLParseOptions (XML_PARSE_NONET | XML_PARSE_RECOVER | XML_PARSE_NOBLANKS | XML_PARSE_COMPACT | XML_PARSE_NOWARNING | XML_PARSE_NOERROR)
+
+typedef NS_ENUM(NSInteger, DAVProperties) {
+  kDAVProperty_ResourceType = (1 << 0),
+  kDAVProperty_CreationDate = (1 << 1),
+  kDAVProperty_LastModified = (1 << 2),
+  kDAVProperty_ContentLength = (1 << 3),
+  kDAVAllProperties = kDAVProperty_ResourceType | kDAVProperty_CreationDate | kDAVProperty_LastModified | kDAVProperty_ContentLength
+};
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GCDWebDAVServer (Methods)
+- (nullable GCDWebServerResponse*)performOPTIONS:(GCDWebServerRequest*)request;
+- (nullable GCDWebServerResponse*)performGET:(GCDWebServerRequest*)request;
+- (nullable GCDWebServerResponse*)performPUT:(GCDWebServerFileRequest*)request;
+- (nullable GCDWebServerResponse*)performDELETE:(GCDWebServerRequest*)request;
+- (nullable GCDWebServerResponse*)performMKCOL:(GCDWebServerDataRequest*)request;
+- (nullable GCDWebServerResponse*)performCOPY:(GCDWebServerRequest*)request isMove:(BOOL)isMove;
+- (nullable GCDWebServerResponse*)performPROPFIND:(GCDWebServerDataRequest*)request;
+- (nullable GCDWebServerResponse*)performLOCK:(GCDWebServerDataRequest*)request;
+- (nullable GCDWebServerResponse*)performUNLOCK:(GCDWebServerRequest*)request;
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation GCDWebDAVServer
+
+@dynamic delegate;
+
+- (instancetype)initWithUploadDirectory:(NSString*)path {
+  if ((self = [super init])) {
+    _uploadDirectory = [path copy];
+    GCDWebDAVServer* __unsafe_unretained server = self;
+
+    // 9.1 PROPFIND method
+    [self addDefaultHandlerForMethod:@"PROPFIND"
+                        requestClass:[GCDWebServerDataRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performPROPFIND:(GCDWebServerDataRequest*)request];
+                        }];
+
+    // 9.3 MKCOL Method
+    [self addDefaultHandlerForMethod:@"MKCOL"
+                        requestClass:[GCDWebServerDataRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performMKCOL:(GCDWebServerDataRequest*)request];
+                        }];
+
+    // 9.4 GET & HEAD methods
+    [self addDefaultHandlerForMethod:@"GET"
+                        requestClass:[GCDWebServerRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performGET:request];
+                        }];
+
+    // 9.6 DELETE method
+    [self addDefaultHandlerForMethod:@"DELETE"
+                        requestClass:[GCDWebServerRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performDELETE:request];
+                        }];
+
+    // 9.7 PUT method
+    [self addDefaultHandlerForMethod:@"PUT"
+                        requestClass:[GCDWebServerFileRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performPUT:(GCDWebServerFileRequest*)request];
+                        }];
+
+    // 9.8 COPY method
+    [self addDefaultHandlerForMethod:@"COPY"
+                        requestClass:[GCDWebServerRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performCOPY:request isMove:NO];
+                        }];
+
+    // 9.9 MOVE method
+    [self addDefaultHandlerForMethod:@"MOVE"
+                        requestClass:[GCDWebServerRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performCOPY:request isMove:YES];
+                        }];
+
+    // 9.10 LOCK method
+    [self addDefaultHandlerForMethod:@"LOCK"
+                        requestClass:[GCDWebServerDataRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performLOCK:(GCDWebServerDataRequest*)request];
+                        }];
+
+    // 9.11 UNLOCK method
+    [self addDefaultHandlerForMethod:@"UNLOCK"
+                        requestClass:[GCDWebServerRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performUNLOCK:request];
+                        }];
+
+    // 10.1 OPTIONS method / DAV Header
+    [self addDefaultHandlerForMethod:@"OPTIONS"
+                        requestClass:[GCDWebServerRequest class]
+                        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                          return [server performOPTIONS:request];
+                        }];
+  }
+  return self;
+}
+
+@end
+
+@implementation GCDWebDAVServer (Methods)
+
+- (BOOL)_checkFileExtension:(NSString*)fileName {
+  if (_allowedFileExtensions && ![_allowedFileExtensions containsObject:[[fileName pathExtension] lowercaseString]]) {
+    return NO;
+  }
+  return YES;
+}
+
+static inline BOOL _IsMacFinder(GCDWebServerRequest* request) {
+  NSString* userAgentHeader = [request.headers objectForKey:@"User-Agent"];
+  return ([userAgentHeader hasPrefix:@"WebDAVFS/"] || [userAgentHeader hasPrefix:@"WebDAVLib/"]);  // OS X WebDAV client
+}
+
+- (GCDWebServerResponse*)performOPTIONS:(GCDWebServerRequest*)request {
+  GCDWebServerResponse* response = [GCDWebServerResponse response];
+  if (_IsMacFinder(request)) {
+    [response setValue:@"1, 2" forAdditionalHeader:@"DAV"];  // Classes 1 and 2
+  } else {
+    [response setValue:@"1" forAdditionalHeader:@"DAV"];  // Class 1
+  }
+  return response;
+}
+
+- (GCDWebServerResponse*)performGET:(GCDWebServerRequest*)request {
+  NSString* relativePath = request.path;
+  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+  BOOL isDirectory = NO;
+  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+  }
+
+  NSString* itemName = [absolutePath lastPathComponent];
+  if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Downlading item name \"%@\" is not allowed", itemName];
+  }
+
+  // Because HEAD requests are mapped to GET ones, we need to handle directories but it's OK to return nothing per http://webdav.org/specs/rfc4918.html#rfc.section.9.4
+  if (isDirectory) {
+    return [GCDWebServerResponse response];
+  }
+
+  if ([self.delegate respondsToSelector:@selector(davServer:didDownloadFileAtPath:)]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.delegate davServer:self didDownloadFileAtPath:absolutePath];
+    });
+  }
+
+  if ([request hasByteRange]) {
+    return [GCDWebServerFileResponse responseWithFile:absolutePath byteRange:request.byteRange];
+  }
+
+  return [GCDWebServerFileResponse responseWithFile:absolutePath];
+}
+
+- (GCDWebServerResponse*)performPUT:(GCDWebServerFileRequest*)request {
+  if ([request hasByteRange]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Range uploads not supported"];
+  }
+
+  NSString* relativePath = request.path;
+  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+  BOOL isDirectory;
+  if (![[NSFileManager defaultManager] fileExistsAtPath:[absolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Missing intermediate collection(s) for \"%@\"", relativePath];
+  }
+
+  BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory];
+  if (existing && isDirectory) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"PUT not allowed on existing collection \"%@\"", relativePath];
+  }
+
+  NSString* fileName = [absolutePath lastPathComponent];
+  if (([fileName hasPrefix:@"."] && !_allowHiddenItems) || ![self _checkFileExtension:fileName]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file name \"%@\" is not allowed", fileName];
+  }
+
+  if (![self shouldUploadFileAtPath:absolutePath withTemporaryFile:request.temporaryPath]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Uploading file to \"%@\" is not permitted", relativePath];
+  }
+
+  [[NSFileManager defaultManager] removeItemAtPath:absolutePath error:NULL];
+  NSError* error = nil;
+  if (![[NSFileManager defaultManager] moveItemAtPath:request.temporaryPath toPath:absolutePath error:&error]) {
+    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed moving uploaded file to \"%@\"", relativePath];
+  }
+
+  if ([self.delegate respondsToSelector:@selector(davServer:didUploadFileAtPath:)]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.delegate davServer:self didUploadFileAtPath:absolutePath];
+    });
+  }
+  return [GCDWebServerResponse responseWithStatusCode:(existing ? kGCDWebServerHTTPStatusCode_NoContent : kGCDWebServerHTTPStatusCode_Created)];
+}
+
+- (GCDWebServerResponse*)performDELETE:(GCDWebServerRequest*)request {
+  NSString* depthHeader = [request.headers objectForKey:@"Depth"];
+  if (depthHeader && ![depthHeader isEqualToString:@"infinity"]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
+  }
+
+  NSString* relativePath = request.path;
+  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+  BOOL isDirectory = NO;
+  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+  }
+
+  NSString* itemName = [absolutePath lastPathComponent];
+  if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting item name \"%@\" is not allowed", itemName];
+  }
+
+  if (![self shouldDeleteItemAtPath:absolutePath]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Deleting \"%@\" is not permitted", relativePath];
+  }
+
+  NSError* error = nil;
+  if (![[NSFileManager defaultManager] removeItemAtPath:absolutePath error:&error]) {
+    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed deleting \"%@\"", relativePath];
+  }
+
+  if ([self.delegate respondsToSelector:@selector(davServer:didDeleteItemAtPath:)]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.delegate davServer:self didDeleteItemAtPath:absolutePath];
+    });
+  }
+  return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NoContent];
+}
+
+- (GCDWebServerResponse*)performMKCOL:(GCDWebServerDataRequest*)request {
+  if ([request hasBody] && (request.contentLength > 0)) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_UnsupportedMediaType message:@"Unexpected request body for MKCOL method"];
+  }
+
+  NSString* relativePath = request.path;
+  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+  BOOL isDirectory;
+  if (![[NSFileManager defaultManager] fileExistsAtPath:[absolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Missing intermediate collection(s) for \"%@\"", relativePath];
+  }
+
+  NSString* directoryName = [absolutePath lastPathComponent];
+  if (!_allowHiddenItems && [directoryName hasPrefix:@"."]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory name \"%@\" is not allowed", directoryName];
+  }
+
+  if (![self shouldCreateDirectoryAtPath:absolutePath]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Creating directory \"%@\" is not permitted", relativePath];
+  }
+
+  NSError* error = nil;
+  if (![[NSFileManager defaultManager] createDirectoryAtPath:absolutePath withIntermediateDirectories:NO attributes:nil error:&error]) {
+    return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed creating directory \"%@\"", relativePath];
+  }
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  NSString* creationDateHeader = [request.headers objectForKey:@"X-GCDWebServer-CreationDate"];
+  if (creationDateHeader) {
+    NSDate* date = GCDWebServerParseISO8601(creationDateHeader);
+    if (!date || ![[NSFileManager defaultManager] setAttributes:@{NSFileCreationDate : date} ofItemAtPath:absolutePath error:&error]) {
+      return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed setting creation date for directory \"%@\"", relativePath];
+    }
+  }
+#endif
+
+  if ([self.delegate respondsToSelector:@selector(davServer:didCreateDirectoryAtPath:)]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.delegate davServer:self didCreateDirectoryAtPath:absolutePath];
+    });
+  }
+  return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Created];
+}
+
+- (GCDWebServerResponse*)performCOPY:(GCDWebServerRequest*)request isMove:(BOOL)isMove {
+  if (!isMove) {
+    NSString* depthHeader = [request.headers objectForKey:@"Depth"];  // TODO: Support "Depth: 0"
+    if (depthHeader && ![depthHeader isEqualToString:@"infinity"]) {
+      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];
+    }
+  }
+
+  NSString* srcRelativePath = request.path;
+  NSString* srcAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(srcRelativePath)];
+
+  NSString* dstRelativePath = [request.headers objectForKey:@"Destination"];
+  NSRange range = [dstRelativePath rangeOfString:(NSString*)[request.headers objectForKey:@"Host"]];
+  if ((dstRelativePath == nil) || (range.location == NSNotFound)) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Malformed 'Destination' header: %@", dstRelativePath];
+  }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  dstRelativePath = [[dstRelativePath substringFromIndex:(range.location + range.length)] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+#pragma clang diagnostic pop
+  NSString* dstAbsolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(dstRelativePath)];
+  if (!dstAbsolutePath) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", srcRelativePath];
+  }
+
+  BOOL isDirectory;
+  if (![[NSFileManager defaultManager] fileExistsAtPath:[dstAbsolutePath stringByDeletingLastPathComponent] isDirectory:&isDirectory] || !isDirectory) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Conflict message:@"Invalid destination \"%@\"", dstRelativePath];
+  }
+
+  NSString* srcName = [srcAbsolutePath lastPathComponent];
+  if ((!_allowHiddenItems && [srcName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:srcName])) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"%@ from item name \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", srcName];
+  }
+
+  NSString* dstName = [dstAbsolutePath lastPathComponent];
+  if ((!_allowHiddenItems && [dstName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:dstName])) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"%@ to item name \"%@\" is not allowed", isMove ? @"Moving" : @"Copying", dstName];
+  }
+
+  NSString* overwriteHeader = [request.headers objectForKey:@"Overwrite"];
+  BOOL existing = [[NSFileManager defaultManager] fileExistsAtPath:dstAbsolutePath];
+  if (existing && ((isMove && ![overwriteHeader isEqualToString:@"T"]) || (!isMove && [overwriteHeader isEqualToString:@"F"]))) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_PreconditionFailed message:@"Destination \"%@\" already exists", dstRelativePath];
+  }
+
+  if (isMove) {
+    if (![self shouldMoveItemFromPath:srcAbsolutePath toPath:dstAbsolutePath]) {
+      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Moving \"%@\" to \"%@\" is not permitted", srcRelativePath, dstRelativePath];
+    }
+  } else {
+    if (![self shouldCopyItemFromPath:srcAbsolutePath toPath:dstAbsolutePath]) {
+      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Copying \"%@\" to \"%@\" is not permitted", srcRelativePath, dstRelativePath];
+    }
+  }
+
+  NSError* error = nil;
+  if (isMove) {
+    [[NSFileManager defaultManager] removeItemAtPath:dstAbsolutePath error:NULL];
+    if (![[NSFileManager defaultManager] moveItemAtPath:srcAbsolutePath toPath:dstAbsolutePath error:&error]) {
+      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden underlyingError:error message:@"Failed copying \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
+    }
+  } else {
+    if (![[NSFileManager defaultManager] copyItemAtPath:srcAbsolutePath toPath:dstAbsolutePath error:&error]) {
+      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden underlyingError:error message:@"Failed copying \"%@\" to \"%@\"", srcRelativePath, dstRelativePath];
+    }
+  }
+
+  if (isMove) {
+    if ([self.delegate respondsToSelector:@selector(davServer:didMoveItemFromPath:toPath:)]) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self.delegate davServer:self didMoveItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
+      });
+    }
+  } else {
+    if ([self.delegate respondsToSelector:@selector(davServer:didCopyItemFromPath:toPath:)]) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self.delegate davServer:self didCopyItemFromPath:srcAbsolutePath toPath:dstAbsolutePath];
+      });
+    }
+  }
+
+  return [GCDWebServerResponse responseWithStatusCode:(existing ? kGCDWebServerHTTPStatusCode_NoContent : kGCDWebServerHTTPStatusCode_Created)];
+}
+
+static inline xmlNodePtr _XMLChildWithName(xmlNodePtr child, const xmlChar* name) {
+  while (child) {
+    if ((child->type == XML_ELEMENT_NODE) && !xmlStrcmp(child->name, name)) {
+      return child;
+    }
+    child = child->next;
+  }
+  return NULL;
+}
+
+- (void)_addPropertyResponseForItem:(NSString*)itemPath resource:(NSString*)resourcePath properties:(DAVProperties)properties xmlString:(NSMutableString*)xmlString {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  CFStringRef escapedPath = CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)resourcePath, NULL, CFSTR("<&>?+"), kCFStringEncodingUTF8);
+#pragma clang diagnostic pop
+  if (escapedPath) {
+    NSDictionary* attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:itemPath error:NULL];
+    NSString* type = [attributes objectForKey:NSFileType];
+    BOOL isFile = [type isEqualToString:NSFileTypeRegular];
+    BOOL isDirectory = [type isEqualToString:NSFileTypeDirectory];
+    if ((isFile && [self _checkFileExtension:itemPath]) || isDirectory) {
+      [xmlString appendString:@"<D:response>"];
+      [xmlString appendFormat:@"<D:href>%@</D:href>", escapedPath];
+      [xmlString appendString:@"<D:propstat>"];
+      [xmlString appendString:@"<D:prop>"];
+
+      if (properties & kDAVProperty_ResourceType) {
+        if (isDirectory) {
+          [xmlString appendString:@"<D:resourcetype><D:collection/></D:resourcetype>"];
+        } else {
+          [xmlString appendString:@"<D:resourcetype/>"];
+        }
+      }
+
+      if ((properties & kDAVProperty_CreationDate) && [attributes objectForKey:NSFileCreationDate]) {
+        [xmlString appendFormat:@"<D:creationdate>%@</D:creationdate>", GCDWebServerFormatISO8601((NSDate*)[attributes fileCreationDate])];
+      }
+
+      if ((properties & kDAVProperty_LastModified) && isFile && [attributes objectForKey:NSFileModificationDate]) {  // Last modification date is not useful for directories as it changes implicitely and 'Last-Modified' header is not provided for directories anyway
+        [xmlString appendFormat:@"<D:getlastmodified>%@</D:getlastmodified>", GCDWebServerFormatRFC822((NSDate*)[attributes fileModificationDate])];
+      }
+
+      if ((properties & kDAVProperty_ContentLength) && !isDirectory && [attributes objectForKey:NSFileSize]) {
+        [xmlString appendFormat:@"<D:getcontentlength>%llu</D:getcontentlength>", [attributes fileSize]];
+      }
+
+      [xmlString appendString:@"</D:prop>"];
+      [xmlString appendString:@"<D:status>HTTP/1.1 200 OK</D:status>"];
+      [xmlString appendString:@"</D:propstat>"];
+      [xmlString appendString:@"</D:response>\n"];
+    }
+    CFRelease(escapedPath);
+  } else {
+    [self logError:@"Failed escaping path: %@", itemPath];
+  }
+}
+
+- (GCDWebServerResponse*)performPROPFIND:(GCDWebServerDataRequest*)request {
+  NSInteger depth;
+  NSString* depthHeader = [request.headers objectForKey:@"Depth"];
+  if ([depthHeader isEqualToString:@"0"]) {
+    depth = 0;
+  } else if ([depthHeader isEqualToString:@"1"]) {
+    depth = 1;
+  } else {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Unsupported 'Depth' header: %@", depthHeader];  // TODO: Return 403 / propfind-finite-depth for "infinity" depth
+  }
+
+  DAVProperties properties = 0;
+  if (request.data.length) {
+    BOOL success = YES;
+    xmlDocPtr document = xmlReadMemory(request.data.bytes, (int)request.data.length, NULL, NULL, kXMLParseOptions);
+    if (document) {
+      xmlNodePtr rootNode = _XMLChildWithName(document->children, (const xmlChar*)"propfind");
+      xmlNodePtr allNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar*)"allprop") : NULL;
+      xmlNodePtr propNode = rootNode ? _XMLChildWithName(rootNode->children, (const xmlChar*)"prop") : NULL;
+      if (allNode) {
+        properties = kDAVAllProperties;
+      } else if (propNode) {
+        xmlNodePtr node = propNode->children;
+        while (node) {
+          if (!xmlStrcmp(node->name, (const xmlChar*)"resourcetype")) {
+            properties |= kDAVProperty_ResourceType;
+          } else if (!xmlStrcmp(node->name, (const xmlChar*)"creationdate")) {
+            properties |= kDAVProperty_CreationDate;
+          } else if (!xmlStrcmp(node->name, (const xmlChar*)"getlastmodified")) {
+            properties |= kDAVProperty_LastModified;
+          } else if (!xmlStrcmp(node->name, (const xmlChar*)"getcontentlength")) {
+            properties |= kDAVProperty_ContentLength;
+          } else {
+            [self logWarning:@"Unknown DAV property requested \"%s\"", node->name];
+          }
+          node = node->next;
+        }
+      } else {
+        success = NO;
+      }
+      xmlFreeDoc(document);
+    } else {
+      success = NO;
+    }
+    if (!success) {
+      NSString* string = [[NSString alloc] initWithData:request.data encoding:NSUTF8StringEncoding];
+      return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Invalid DAV properties:\n%@", string];
+    }
+  } else {
+    properties = kDAVAllProperties;
+  }
+
+  NSString* relativePath = request.path;
+  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+  BOOL isDirectory = NO;
+  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+  }
+
+  NSString* itemName = [absolutePath lastPathComponent];
+  if (([itemName hasPrefix:@"."] && !_allowHiddenItems) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Retrieving properties for item name \"%@\" is not allowed", itemName];
+  }
+
+  NSArray* items = nil;
+  if (isDirectory) {
+    NSError* error = nil;
+    items = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:absolutePath error:&error] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
+    if (items == nil) {
+      return [GCDWebServerErrorResponse responseWithServerError:kGCDWebServerHTTPStatusCode_InternalServerError underlyingError:error message:@"Failed listing directory \"%@\"", relativePath];
+    }
+  }
+
+  NSMutableString* xmlString = [NSMutableString stringWithString:@"<?xml version=\"1.0\" encoding=\"utf-8\" ?>"];
+  [xmlString appendString:@"<D:multistatus xmlns:D=\"DAV:\">\n"];
+  if (![relativePath hasPrefix:@"/"]) {
+    relativePath = [@"/" stringByAppendingString:relativePath];
+  }
+  [self _addPropertyResponseForItem:absolutePath resource:relativePath properties:properties xmlString:xmlString];
+  if (depth == 1) {
+    if (![relativePath hasSuffix:@"/"]) {
+      relativePath = [relativePath stringByAppendingString:@"/"];
+    }
+    for (NSString* item in items) {
+      if (_allowHiddenItems || ![item hasPrefix:@"."]) {
+        [self _addPropertyResponseForItem:[absolutePath stringByAppendingPathComponent:item] resource:[relativePath stringByAppendingString:item] properties:properties xmlString:xmlString];
+      }
+    }
+  }
+  [xmlString appendString:@"</D:multistatus>"];
+
+  GCDWebServerDataResponse* response = [GCDWebServerDataResponse responseWithData:(NSData*)[xmlString dataUsingEncoding:NSUTF8StringEncoding]
+                                                                      contentType:@"application/xml; charset=\"utf-8\""];
+  response.statusCode = kGCDWebServerHTTPStatusCode_MultiStatus;
+  return response;
+}
+
+- (GCDWebServerResponse*)performLOCK:(GCDWebServerDataRequest*)request {
+  if (!_IsMacFinder(request)) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"LOCK method only allowed for Mac Finder"];
+  }
+
+  NSString* relativePath = request.path;
+  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+  BOOL isDirectory = NO;
+  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+  }
+
+  NSString* depthHeader = [request.headers objectForKey:@"Depth"];
+  NSString* timeoutHeader = [request.headers objectForKey:@"Timeout"];
+  NSString* scope = nil;
+  NSString* type = nil;
+  NSString* owner = nil;
+  NSString* token = nil;
+  BOOL success = YES;
+  xmlDocPtr document = xmlReadMemory(request.data.bytes, (int)request.data.length, NULL, NULL, kXMLParseOptions);
+  if (document) {
+    xmlNodePtr node = _XMLChildWithName(document->children, (const xmlChar*)"lockinfo");
+    if (node) {
+      xmlNodePtr scopeNode = _XMLChildWithName(node->children, (const xmlChar*)"lockscope");
+      if (scopeNode && scopeNode->children && scopeNode->children->name) {
+        scope = [NSString stringWithUTF8String:(const char*)scopeNode->children->name];
+      }
+      xmlNodePtr typeNode = _XMLChildWithName(node->children, (const xmlChar*)"locktype");
+      if (typeNode && typeNode->children && typeNode->children->name) {
+        type = [NSString stringWithUTF8String:(const char*)typeNode->children->name];
+      }
+      xmlNodePtr ownerNode = _XMLChildWithName(node->children, (const xmlChar*)"owner");
+      if (ownerNode) {
+        ownerNode = _XMLChildWithName(ownerNode->children, (const xmlChar*)"href");
+        if (ownerNode && ownerNode->children && ownerNode->children->content) {
+          owner = [NSString stringWithUTF8String:(const char*)ownerNode->children->content];
+        }
+      }
+    } else {
+      success = NO;
+    }
+    xmlFreeDoc(document);
+  } else {
+    success = NO;
+  }
+  if (!success) {
+    NSString* string = [[NSString alloc] initWithData:request.data encoding:NSUTF8StringEncoding];
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Invalid DAV properties:\n%@", string];
+  }
+
+  if (![scope isEqualToString:@"exclusive"] || ![type isEqualToString:@"write"] || ![depthHeader isEqualToString:@"0"]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Locking request \"%@/%@/%@\" for \"%@\" is not allowed", scope, type, depthHeader, relativePath];
+  }
+
+  NSString* itemName = [absolutePath lastPathComponent];
+  if ((!_allowHiddenItems && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Locking item name \"%@\" is not allowed", itemName];
+  }
+
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  NSString* lockTokenHeader = [request.headers objectForKey:@"X-GCDWebServer-LockToken"];
+  if (lockTokenHeader) {
+    token = lockTokenHeader;
+  }
+#endif
+  if (!token) {
+    CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
+    CFStringRef string = CFUUIDCreateString(kCFAllocatorDefault, uuid);
+    token = [NSString stringWithFormat:@"urn:uuid:%@", (__bridge NSString*)string];
+    CFRelease(string);
+    CFRelease(uuid);
+  }
+
+  NSMutableString* xmlString = [NSMutableString stringWithString:@"<?xml version=\"1.0\" encoding=\"utf-8\" ?>"];
+  [xmlString appendString:@"<D:prop xmlns:D=\"DAV:\">\n"];
+  [xmlString appendString:@"<D:lockdiscovery>\n<D:activelock>\n"];
+  [xmlString appendFormat:@"<D:locktype><D:%@/></D:locktype>\n", type];
+  [xmlString appendFormat:@"<D:lockscope><D:%@/></D:lockscope>\n", scope];
+  [xmlString appendFormat:@"<D:depth>%@</D:depth>\n", depthHeader];
+  if (owner) {
+    [xmlString appendFormat:@"<D:owner><D:href>%@</D:href></D:owner>\n", owner];
+  }
+  if (timeoutHeader) {
+    [xmlString appendFormat:@"<D:timeout>%@</D:timeout>\n", timeoutHeader];
+  }
+  [xmlString appendFormat:@"<D:locktoken><D:href>%@</D:href></D:locktoken>\n", token];
+  NSString* lockroot = [@"http://" stringByAppendingString:[(NSString*)[request.headers objectForKey:@"Host"] stringByAppendingString:[@"/" stringByAppendingString:relativePath]]];
+  [xmlString appendFormat:@"<D:lockroot><D:href>%@</D:href></D:lockroot>\n", lockroot];
+  [xmlString appendString:@"</D:activelock>\n</D:lockdiscovery>\n"];
+  [xmlString appendString:@"</D:prop>"];
+
+  [self logVerbose:@"WebDAV pretending to lock \"%@\"", relativePath];
+  GCDWebServerDataResponse* response = [GCDWebServerDataResponse responseWithData:(NSData*)[xmlString dataUsingEncoding:NSUTF8StringEncoding]
+                                                                      contentType:@"application/xml; charset=\"utf-8\""];
+  return response;
+}
+
+- (GCDWebServerResponse*)performUNLOCK:(GCDWebServerRequest*)request {
+  if (!_IsMacFinder(request)) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_MethodNotAllowed message:@"UNLOCK method only allowed for Mac Finder"];
+  }
+
+  NSString* relativePath = request.path;
+  NSString* absolutePath = [_uploadDirectory stringByAppendingPathComponent:GCDWebServerNormalizePath(relativePath)];
+  BOOL isDirectory = NO;
+  if (![[NSFileManager defaultManager] fileExistsAtPath:absolutePath isDirectory:&isDirectory]) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_NotFound message:@"\"%@\" does not exist", relativePath];
+  }
+
+  NSString* tokenHeader = [request.headers objectForKey:@"Lock-Token"];
+  if (!tokenHeader.length) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_BadRequest message:@"Missing 'Lock-Token' header"];
+  }
+
+  NSString* itemName = [absolutePath lastPathComponent];
+  if ((!_allowHiddenItems && [itemName hasPrefix:@"."]) || (!isDirectory && ![self _checkFileExtension:itemName])) {
+    return [GCDWebServerErrorResponse responseWithClientError:kGCDWebServerHTTPStatusCode_Forbidden message:@"Unlocking item name \"%@\" is not allowed", itemName];
+  }
+
+  [self logVerbose:@"WebDAV pretending to unlock \"%@\"", relativePath];
+  return [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NoContent];
+}
+
+@end
+
+@implementation GCDWebDAVServer (Subclassing)
+
+- (BOOL)shouldUploadFileAtPath:(NSString*)path withTemporaryFile:(NSString*)tempPath {
+  return YES;
+}
+
+- (BOOL)shouldMoveItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath {
+  return YES;
+}
+
+- (BOOL)shouldCopyItemFromPath:(NSString*)fromPath toPath:(NSString*)toPath {
+  return YES;
+}
+
+- (BOOL)shouldDeleteItemAtPath:(NSString*)path {
+  return YES;
+}
+
+- (BOOL)shouldCreateDirectoryAtPath:(NSString*)path {
+  return YES;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServer.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServer.h
@@ -1,0 +1,644 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <TargetConditionals.h>
+
+#import "GCDWebServerRequest.h"
+#import "GCDWebServerResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerMatchBlock is called for every handler added to the
+ *  GCDWebServer whenever a new HTTP request has started (i.e. HTTP headers have
+ *  been received). The block is passed the basic info for the request (HTTP method,
+ *  URL, headers...) and must decide if it wants to handle it or not.
+ *
+ *  If the handler can handle the request, the block must return a new
+ *  GCDWebServerRequest instance created with the same basic info.
+ *  Otherwise, it simply returns nil.
+ */
+typedef GCDWebServerRequest* _Nullable (^GCDWebServerMatchBlock)(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery);
+
+/**
+ *  The GCDWebServerProcessBlock is called after the HTTP request has been fully
+ *  received (i.e. the entire HTTP body has been read). The block is passed the
+ *  GCDWebServerRequest created at the previous step by the GCDWebServerMatchBlock.
+ *
+ *  The block must return a GCDWebServerResponse or nil on error, which will
+ *  result in a 500 HTTP status code returned to the client. It's however
+ *  recommended to return a GCDWebServerErrorResponse on error so more useful
+ *  information can be returned to the client.
+ */
+typedef GCDWebServerResponse* _Nullable (^GCDWebServerProcessBlock)(__kindof GCDWebServerRequest* request);
+
+/**
+ *  The GCDWebServerAsynchronousProcessBlock works like the GCDWebServerProcessBlock
+ *  except the GCDWebServerResponse can be returned to the server at a later time
+ *  allowing for asynchronous generation of the response.
+ *
+ *  The block must eventually call "completionBlock" passing a GCDWebServerResponse
+ *  or nil on error, which will result in a 500 HTTP status code returned to the client.
+ *  It's however recommended to return a GCDWebServerErrorResponse on error so more
+ *  useful information can be returned to the client.
+ */
+typedef void (^GCDWebServerCompletionBlock)(GCDWebServerResponse* _Nullable response);
+typedef void (^GCDWebServerAsyncProcessBlock)(__kindof GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock);
+
+/**
+ *  The GCDWebServerBuiltInLoggerBlock is used to override the built-in logger at runtime.
+ *  The block will be passed the log level and the log message, see setLogLevel for
+ *  documentation of the log levels for the built-in logger.
+ */
+typedef void (^GCDWebServerBuiltInLoggerBlock)(int level, NSString* _Nonnull message);
+
+/**
+ *  The port used by the GCDWebServer (NSNumber / NSUInteger).
+ *
+ *  The default value is 0 i.e. let the OS pick a random port.
+ */
+extern NSString* const GCDWebServerOption_Port;
+
+/**
+ *  The Bonjour name used by the GCDWebServer (NSString). If set to an empty string,
+ *  the name will automatically take the value of the GCDWebServerOption_ServerName
+ *  option. If this option is set to nil, Bonjour will be disabled.
+ *
+ *  The default value is nil.
+ */
+extern NSString* const GCDWebServerOption_BonjourName;
+
+/**
+*  The Bonjour TXT Data used by the GCDWebServer (NSDictionary<NSString, NSString>).
+*
+*  The default value is nil.
+*/
+extern NSString* const GCDWebServerOption_BonjourTXTData;
+
+/**
+ *  The Bonjour service type used by the GCDWebServer (NSString).
+ *
+ *  The default value is "_http._tcp", the service type for HTTP web servers.
+ */
+extern NSString* const GCDWebServerOption_BonjourType;
+
+/**
+ *  Request a port mapping in the NAT gateway (NSNumber / BOOL).
+ *
+ *  This uses the DNSService API under the hood which supports IPv4 mappings only.
+ *
+ *  The default value is NO.
+ *
+ *  @warning The external port set up by the NAT gateway may be different than
+ *  the one used by the GCDWebServer.
+ */
+extern NSString* const GCDWebServerOption_RequestNATPortMapping;
+
+/**
+ *  Only accept HTTP requests coming from localhost i.e. not from the outside
+ *  network (NSNumber / BOOL).
+ *
+ *  The default value is NO.
+ *
+ *  @warning Bonjour and NAT port mapping should be disabled if using this option
+ *  since the server will not be reachable from the outside network anyway.
+ */
+extern NSString* const GCDWebServerOption_BindToLocalhost;
+
+/**
+ *  The maximum number of incoming HTTP requests that can be queued waiting to
+ *  be handled before new ones are dropped (NSNumber / NSUInteger).
+ *
+ *  The default value is 16.
+ */
+extern NSString* const GCDWebServerOption_MaxPendingConnections;
+
+/**
+ *  The value for "Server" HTTP header used by the GCDWebServer (NSString).
+ *
+ *  The default value is the GCDWebServer class name.
+ */
+extern NSString* const GCDWebServerOption_ServerName;
+
+/**
+ *  The authentication method used by the GCDWebServer
+ *  (one of "GCDWebServerAuthenticationMethod_...").
+ *
+ *  The default value is nil i.e. authentication is disabled.
+ */
+extern NSString* const GCDWebServerOption_AuthenticationMethod;
+
+/**
+ *  The authentication realm used by the GCDWebServer (NSString).
+ *
+ *  The default value is the same as the GCDWebServerOption_ServerName option.
+ */
+extern NSString* const GCDWebServerOption_AuthenticationRealm;
+
+/**
+ *  The authentication accounts used by the GCDWebServer
+ *  (NSDictionary of username / password pairs).
+ *
+ *  The default value is nil i.e. no accounts.
+ */
+extern NSString* const GCDWebServerOption_AuthenticationAccounts;
+
+/**
+ *  The class used by the GCDWebServer when instantiating GCDWebServerConnection
+ *  (subclass of GCDWebServerConnection).
+ *
+ *  The default value is the GCDWebServerConnection class.
+ */
+extern NSString* const GCDWebServerOption_ConnectionClass;
+
+/**
+ *  Allow the GCDWebServer to pretend "HEAD" requests are actually "GET" ones
+ *  and automatically discard the HTTP body of the response (NSNumber / BOOL).
+ *
+ *  The default value is YES.
+ */
+extern NSString* const GCDWebServerOption_AutomaticallyMapHEADToGET;
+
+/**
+ *  The interval expressed in seconds used by the GCDWebServer to decide how to
+ *  coalesce calls to -webServerDidConnect: and -webServerDidDisconnect:
+ *  (NSNumber / double). Coalescing will be disabled if the interval is <= 0.0.
+ *
+ *  The default value is 1.0 second.
+ */
+extern NSString* const GCDWebServerOption_ConnectedStateCoalescingInterval;
+
+/**
+ *  Set the dispatch queue priority on which server connection will be 
+ *  run (NSNumber / long).
+ *
+ *
+ *  The default value is DISPATCH_QUEUE_PRIORITY_DEFAULT.
+ */
+extern NSString* const GCDWebServerOption_DispatchQueuePriority;
+
+#if TARGET_OS_IPHONE
+
+/**
+ *  Enables the GCDWebServer to automatically suspend itself (as if -stop was
+ *  called) when the iOS app goes into the background and the last
+ *  GCDWebServerConnection is closed, then resume itself (as if -start was called)
+ *  when the iOS app comes back to the foreground (NSNumber / BOOL).
+ *
+ *  See the README.md file for more information about this option.
+ *
+ *  The default value is YES.
+ *
+ *  @warning The running property will be NO while the GCDWebServer is suspended.
+ */
+extern NSString* const GCDWebServerOption_AutomaticallySuspendInBackground;
+
+#endif
+
+/**
+ *  HTTP Basic Authentication scheme (see https://tools.ietf.org/html/rfc2617).
+ *
+ *  @warning Use of this authentication scheme is not recommended as the
+ *  passwords are sent in clear.
+ */
+extern NSString* const GCDWebServerAuthenticationMethod_Basic;
+
+/**
+ *  HTTP Digest Access Authentication scheme (see https://tools.ietf.org/html/rfc2617).
+ */
+extern NSString* const GCDWebServerAuthenticationMethod_DigestAccess;
+
+@class GCDWebServer;
+
+/**
+ *  Delegate methods for GCDWebServer.
+ *
+ *  @warning These methods are always called on the main thread in a serialized way.
+ */
+@protocol GCDWebServerDelegate <NSObject>
+@optional
+
+/**
+ *  This method is called after the server has successfully started.
+ */
+- (void)webServerDidStart:(GCDWebServer*)server;
+
+/**
+ *  This method is called after the Bonjour registration for the server has
+ *  successfully completed.
+ *
+ *  Use the "bonjourServerURL" property to retrieve the Bonjour address of the
+ *  server.
+ */
+- (void)webServerDidCompleteBonjourRegistration:(GCDWebServer*)server;
+
+/**
+ *  This method is called after the NAT port mapping for the server has been
+ *  updated.
+ *
+ *  Use the "publicServerURL" property to retrieve the public address of the
+ *  server.
+ */
+- (void)webServerDidUpdateNATPortMapping:(GCDWebServer*)server;
+
+/**
+ *  This method is called when the first GCDWebServerConnection is opened by the
+ *  server to serve a series of HTTP requests.
+ *
+ *  A series of HTTP requests is considered ongoing as long as new HTTP requests
+ *  keep coming (and new GCDWebServerConnection instances keep being opened),
+ *  until before the last HTTP request has been responded to (and the
+ *  corresponding last GCDWebServerConnection closed).
+ */
+- (void)webServerDidConnect:(GCDWebServer*)server;
+
+/**
+ *  This method is called when the last GCDWebServerConnection is closed after
+ *  the server has served a series of HTTP requests.
+ *
+ *  The GCDWebServerOption_ConnectedStateCoalescingInterval option can be used
+ *  to have the server wait some extra delay before considering that the series
+ *  of HTTP requests has ended (in case there some latency between consecutive
+ *  requests). This effectively coalesces the calls to -webServerDidConnect:
+ *  and -webServerDidDisconnect:.
+ */
+- (void)webServerDidDisconnect:(GCDWebServer*)server;
+
+/**
+ *  This method is called after the server has stopped.
+ */
+- (void)webServerDidStop:(GCDWebServer*)server;
+
+@end
+
+/**
+ *  The GCDWebServer class listens for incoming HTTP requests on a given port,
+ *  then passes each one to a "handler" capable of generating an HTTP response
+ *  for it, which is then sent back to the client.
+ *
+ *  GCDWebServer instances can be created and used from any thread but it's
+ *  recommended to have the main thread's runloop be running so internal callbacks
+ *  can be handled e.g. for Bonjour registration.
+ *
+ *  See the README.md file for more information about the architecture of GCDWebServer.
+ */
+@interface GCDWebServer : NSObject
+
+/**
+ *  Sets the delegate for the server.
+ */
+@property(nonatomic, weak, nullable) id<GCDWebServerDelegate> delegate;
+
+/**
+ *  Returns YES if the server is currently running.
+ */
+@property(nonatomic, readonly, getter=isRunning) BOOL running;
+
+/**
+ *  Returns the port used by the server.
+ *
+ *  @warning This property is only valid if the server is running.
+ */
+@property(nonatomic, readonly) NSUInteger port;
+
+/**
+ *  Returns the Bonjour name used by the server.
+ *
+ *  @warning This property is only valid if the server is running and Bonjour
+ *  registration has successfully completed, which can take up to a few seconds.
+ */
+@property(nonatomic, readonly, nullable) NSString* bonjourName;
+
+/**
+ *  Returns the Bonjour service type used by the server.
+ *
+ *  @warning This property is only valid if the server is running and Bonjour
+ *  registration has successfully completed, which can take up to a few seconds.
+ */
+@property(nonatomic, readonly, nullable) NSString* bonjourType;
+
+/**
+ *  This method is the designated initializer for the class.
+ */
+- (instancetype)init;
+
+/**
+ *  Adds to the server a handler that generates responses synchronously when handling incoming HTTP requests.
+ *
+ *  Handlers are called in a LIFO queue, so if multiple handlers can potentially
+ *  respond to a given request, the latest added one wins.
+ *
+ *  @warning Addling handlers while the server is running is not allowed.
+ */
+- (void)addHandlerWithMatchBlock:(GCDWebServerMatchBlock)matchBlock processBlock:(GCDWebServerProcessBlock)processBlock;
+
+/**
+ *  Adds to the server a handler that generates responses asynchronously when handling incoming HTTP requests.
+ *
+ *  Handlers are called in a LIFO queue, so if multiple handlers can potentially
+ *  respond to a given request, the latest added one wins.
+ *
+ *  @warning Addling handlers while the server is running is not allowed.
+ */
+- (void)addHandlerWithMatchBlock:(GCDWebServerMatchBlock)matchBlock asyncProcessBlock:(GCDWebServerAsyncProcessBlock)processBlock;
+
+/**
+ *  Removes all handlers previously added to the server.
+ *
+ *  @warning Removing handlers while the server is running is not allowed.
+ */
+- (void)removeAllHandlers;
+
+/**
+ *  Starts the server with explicit options. This method is the designated way
+ *  to start the server.
+ *
+ *  Returns NO if the server failed to start and sets "error" argument if not NULL.
+ */
+- (BOOL)startWithOptions:(nullable NSDictionary<NSString*, id>*)options error:(NSError** _Nullable)error;
+
+/**
+ *  Stops the server and prevents it to accepts new HTTP requests.
+ *
+ *  @warning Stopping the server does not abort GCDWebServerConnection instances
+ *  currently handling already received HTTP requests. These connections will
+ *  continue to execute normally until completion.
+ */
+- (void)stop;
+
+@end
+
+@interface GCDWebServer (Extensions)
+
+/**
+ *  Returns the server's URL.
+ *
+ *  @warning This property is only valid if the server is running.
+ */
+@property(nonatomic, readonly, nullable) NSURL* serverURL;
+
+/**
+ *  Returns the server's Bonjour URL.
+ *
+ *  @warning This property is only valid if the server is running and Bonjour
+ *  registration has successfully completed, which can take up to a few seconds.
+ *  Also be aware this property will not automatically update if the Bonjour hostname
+ *  has been dynamically changed after the server started running (this should be rare).
+ */
+@property(nonatomic, readonly, nullable) NSURL* bonjourServerURL;
+
+/**
+ *  Returns the server's public URL.
+ *
+ *  @warning This property is only valid if the server is running and NAT port
+ *  mapping is active.
+ */
+@property(nonatomic, readonly, nullable) NSURL* publicServerURL;
+
+/**
+ *  Starts the server on port 8080 (OS X & iOS Simulator) or port 80 (iOS)
+ *  using the default Bonjour name.
+ *
+ *  Returns NO if the server failed to start.
+ */
+- (BOOL)start;
+
+/**
+ *  Starts the server on a given port and with a specific Bonjour name.
+ *  Pass a nil Bonjour name to disable Bonjour entirely or an empty string to
+ *  use the default name.
+ *
+ *  Returns NO if the server failed to start.
+ */
+- (BOOL)startWithPort:(NSUInteger)port bonjourName:(nullable NSString*)name;
+
+#if !TARGET_OS_IPHONE
+
+/**
+ *  Runs the server synchronously using -startWithPort:bonjourName: until a
+ *  SIGINT signal is received i.e. Ctrl-C. This method is intended to be used
+ *  by command line tools.
+ *
+ *  Returns NO if the server failed to start.
+ *
+ *  @warning This method must be used from the main thread only.
+ */
+- (BOOL)runWithPort:(NSUInteger)port bonjourName:(nullable NSString*)name;
+
+/**
+ *  Runs the server synchronously using -startWithOptions: until a SIGTERM or
+ *  SIGINT signal is received i.e. Ctrl-C in Terminal. This method is intended to
+ *  be used by command line tools.
+ *
+ *  Returns NO if the server failed to start and sets "error" argument if not NULL.
+ *
+ *  @warning This method must be used from the main thread only.
+ */
+- (BOOL)runWithOptions:(nullable NSDictionary<NSString*, id>*)options error:(NSError** _Nullable)error;
+
+#endif
+
+@end
+
+@interface GCDWebServer (Handlers)
+
+/**
+ *  Adds a default handler to the server to handle all incoming HTTP requests
+ *  with a given HTTP method and generate responses synchronously.
+ */
+- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
+
+/**
+ *  Adds a default handler to the server to handle all incoming HTTP requests
+ *  with a given HTTP method and generate responses asynchronously.
+ */
+- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
+
+/**
+ *  Adds a handler to the server to handle incoming HTTP requests with a given
+ *  HTTP method and a specific case-insensitive path  and generate responses
+ *  synchronously.
+ */
+- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
+
+/**
+ *  Adds a handler to the server to handle incoming HTTP requests with a given
+ *  HTTP method and a specific case-insensitive path and generate responses
+ *  asynchronously.
+ */
+- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
+
+/**
+ *  Adds a handler to the server to handle incoming HTTP requests with a given
+ *  HTTP method and a path matching a case-insensitive regular expression and
+ *  generate responses synchronously.
+ */
+- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block;
+
+/**
+ *  Adds a handler to the server to handle incoming HTTP requests with a given
+ *  HTTP method and a path matching a case-insensitive regular expression and
+ *  generate responses asynchronously.
+ */
+- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block;
+
+@end
+
+@interface GCDWebServer (GETHandlers)
+
+/**
+ *  Adds a handler to the server to respond to incoming "GET" HTTP requests
+ *  with a specific case-insensitive path with in-memory data.
+ */
+- (void)addGETHandlerForPath:(NSString*)path staticData:(NSData*)staticData contentType:(nullable NSString*)contentType cacheAge:(NSUInteger)cacheAge;
+
+/**
+ *  Adds a handler to the server to respond to incoming "GET" HTTP requests
+ *  with a specific case-insensitive path with a file.
+ */
+- (void)addGETHandlerForPath:(NSString*)path filePath:(NSString*)filePath isAttachment:(BOOL)isAttachment cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests;
+
+/**
+ *  Adds a handler to the server to respond to incoming "GET" HTTP requests
+ *  with a case-insensitive path inside a base path with the corresponding file
+ *  inside a local directory. If no local file matches the request path, a 401
+ *  HTTP status code is returned to the client.
+ *
+ *  The "indexFilename" argument allows to specify an "index" file name to use
+ *  when the request path corresponds to a directory.
+ */
+- (void)addGETHandlerForBasePath:(NSString*)basePath directoryPath:(NSString*)directoryPath indexFilename:(nullable NSString*)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests;
+
+@end
+
+/**
+ *  GCDWebServer provides its own built-in logging facility which is used by
+ *  default. It simply sends log messages to stderr assuming it is connected
+ *  to a terminal type device.
+ *
+ *  GCDWebServer is also compatible with a limited set of third-party logging
+ *  facilities. If one of them is available at compile time, GCDWebServer will
+ *  automatically use it in place of the built-in one.
+ *
+ *  Currently supported third-party logging facilities are:
+ *  - XLFacility (by the same author as GCDWebServer): https://github.com/swisspol/XLFacility
+ *
+ *  For the built-in logging facility, the default logging level is INFO
+ *  (or DEBUG if the preprocessor constant "DEBUG" evaluates to non-zero at
+ *  compile time).
+ *
+ *  It's possible to have GCDWebServer use a custom logging facility by defining
+ *  the "__GCDWEBSERVER_LOGGING_HEADER__" preprocessor constant in Xcode build
+ *  settings to the name of a custom header file (escaped like \"MyLogging.h\").
+ *  This header file must define the following set of macros:
+ *
+ *    GWS_LOG_DEBUG(...)
+ *    GWS_LOG_VERBOSE(...)
+ *    GWS_LOG_INFO(...)
+ *    GWS_LOG_WARNING(...)
+ *    GWS_LOG_ERROR(...)
+ *
+ *  IMPORTANT: These macros must behave like NSLog(). Furthermore the GWS_LOG_DEBUG()
+ *  macro should not do anything unless the preprocessor constant "DEBUG" evaluates
+ *  to non-zero.
+ *
+ *  The logging methods below send log messages to the same logging facility
+ *  used by GCDWebServer. They can be used for consistency wherever you interact
+ *  with GCDWebServer in your code (e.g. in the implementation of handlers).
+ */
+@interface GCDWebServer (Logging)
+
+/**
+ *  Sets the log level of the logging facility below which log messages are discarded.
+ *
+ *  @warning The interpretation of the "level" argument depends on the logging
+ *  facility used at compile time.
+ *
+ *  If using the built-in logging facility, the log levels are as follow:
+ *  DEBUG = 0
+ *  VERBOSE = 1
+ *  INFO = 2
+ *  WARNING = 3
+ *  ERROR = 4
+ */
++ (void)setLogLevel:(int)level;
+
+/**
+ *  Set a logger to be used instead of the built-in logger which logs to stderr.
+ *
+ *  IMPORTANT: In order for this override to work, you should not be specifying
+ *  a custom logger at compile time with "__GCDWEBSERVER_LOGGING_HEADER__".
+ */
++ (void)setBuiltInLogger:(GCDWebServerBuiltInLoggerBlock)block;
+
+/**
+ *  Logs a message to the logging facility at the VERBOSE level.
+ */
+- (void)logVerbose:(NSString*)format, ... NS_FORMAT_FUNCTION(1, 2);
+
+/**
+ *  Logs a message to the logging facility at the INFO level.
+ */
+- (void)logInfo:(NSString*)format, ... NS_FORMAT_FUNCTION(1, 2);
+
+/**
+ *  Logs a message to the logging facility at the WARNING level.
+ */
+- (void)logWarning:(NSString*)format, ... NS_FORMAT_FUNCTION(1, 2);
+
+/**
+ *  Logs a message to the logging facility at the ERROR level.
+ */
+- (void)logError:(NSString*)format, ... NS_FORMAT_FUNCTION(1, 2);
+
+@end
+
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+
+@interface GCDWebServer (Testing)
+
+/**
+ *  Activates recording of HTTP requests and responses which create files in the
+ *  current directory containing the raw data for all requests and responses.
+ *
+ *  @warning The current directory must not contain any prior recording files.
+ */
+@property(nonatomic, getter=isRecordingEnabled) BOOL recordingEnabled;
+
+/**
+ *  Runs tests by playing back pre-recorded HTTP requests in the given directory
+ *  and comparing the generated responses with the pre-recorded ones.
+ *
+ *  Returns the number of failed tests or -1 if server failed to start.
+ */
+- (NSInteger)runTestsWithOptions:(nullable NSDictionary<NSString*, id>*)options inDirectory:(NSString*)path;
+
+@end
+
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServer.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServer.m
@@ -1,0 +1,1334 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import <TargetConditionals.h>
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#else
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+#import <AppKit/AppKit.h>
+#endif
+#endif
+#import <netinet/in.h>
+#import <dns_sd.h>
+
+#import "GCDWebServerPrivate.h"
+
+#if TARGET_OS_IPHONE && !TARGET_IPHONE_SIMULATOR
+#define kDefaultPort 80
+#else
+#define kDefaultPort 8080
+#endif
+
+#define kBonjourResolutionTimeout 5.0
+
+NSString* const GCDWebServerOption_Port = @"Port";
+NSString* const GCDWebServerOption_BonjourName = @"BonjourName";
+NSString* const GCDWebServerOption_BonjourType = @"BonjourType";
+NSString* const GCDWebServerOption_BonjourTXTData = @"BonjourTXTData";
+NSString* const GCDWebServerOption_RequestNATPortMapping = @"RequestNATPortMapping";
+NSString* const GCDWebServerOption_BindToLocalhost = @"BindToLocalhost";
+NSString* const GCDWebServerOption_MaxPendingConnections = @"MaxPendingConnections";
+NSString* const GCDWebServerOption_ServerName = @"ServerName";
+NSString* const GCDWebServerOption_AuthenticationMethod = @"AuthenticationMethod";
+NSString* const GCDWebServerOption_AuthenticationRealm = @"AuthenticationRealm";
+NSString* const GCDWebServerOption_AuthenticationAccounts = @"AuthenticationAccounts";
+NSString* const GCDWebServerOption_ConnectionClass = @"ConnectionClass";
+NSString* const GCDWebServerOption_AutomaticallyMapHEADToGET = @"AutomaticallyMapHEADToGET";
+NSString* const GCDWebServerOption_ConnectedStateCoalescingInterval = @"ConnectedStateCoalescingInterval";
+NSString* const GCDWebServerOption_DispatchQueuePriority = @"DispatchQueuePriority";
+#if TARGET_OS_IPHONE
+NSString* const GCDWebServerOption_AutomaticallySuspendInBackground = @"AutomaticallySuspendInBackground";
+#endif
+
+NSString* const GCDWebServerAuthenticationMethod_Basic = @"Basic";
+NSString* const GCDWebServerAuthenticationMethod_DigestAccess = @"DigestAccess";
+
+#if defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
+#if DEBUG
+GCDWebServerLoggingLevel GCDWebServerLogLevel = kGCDWebServerLoggingLevel_Debug;
+#else
+GCDWebServerLoggingLevel GCDWebServerLogLevel = kGCDWebServerLoggingLevel_Info;
+#endif
+#endif
+
+#if !TARGET_OS_IPHONE
+static BOOL _run;
+#endif
+
+#ifdef __GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__
+
+static GCDWebServerBuiltInLoggerBlock _builtInLoggerBlock;
+
+void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* format, ...) {
+  static const char* levelNames[] = {"DEBUG", "VERBOSE", "INFO", "WARNING", "ERROR"};
+  static int enableLogging = -1;
+  if (enableLogging < 0) {
+    enableLogging = (isatty(STDERR_FILENO) ? 1 : 0);
+  }
+  if (_builtInLoggerBlock || enableLogging) {
+    va_list arguments;
+    va_start(arguments, format);
+    NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
+    va_end(arguments);
+    if (_builtInLoggerBlock) {
+      _builtInLoggerBlock(level, message);
+    } else {
+      fprintf(stderr, "[%s] %s\n", levelNames[level], [message UTF8String]);
+    }
+  }
+}
+
+#endif
+
+#if !TARGET_OS_IPHONE
+
+static void _SignalHandler(int signal) {
+  _run = NO;
+  printf("\n");
+}
+
+#endif
+
+#if !TARGET_OS_IPHONE || defined(__GCDWEBSERVER_ENABLE_TESTING__)
+
+// This utility function is used to ensure scheduled callbacks on the main thread are called when running the server synchronously
+// https://developer.apple.com/library/mac/documentation/General/Conceptual/ConcurrencyProgrammingGuide/OperationQueues/OperationQueues.html
+// The main queue works with the application’s run loop to interleave the execution of queued tasks with the execution of other event sources attached to the run loop
+// TODO: Ensure all scheduled blocks on the main queue are also executed
+static void _ExecuteMainThreadRunLoopSources() {
+  SInt32 result;
+  do {
+    result = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
+  } while (result == kCFRunLoopRunHandledSource);
+}
+
+#endif
+
+@implementation GCDWebServerHandler
+
+- (instancetype)initWithMatchBlock:(GCDWebServerMatchBlock _Nonnull)matchBlock asyncProcessBlock:(GCDWebServerAsyncProcessBlock _Nonnull)processBlock {
+  if ((self = [super init])) {
+    _matchBlock = [matchBlock copy];
+    _asyncProcessBlock = [processBlock copy];
+  }
+  return self;
+}
+
+@end
+
+@implementation GCDWebServer {
+  dispatch_queue_t _syncQueue;
+  dispatch_group_t _sourceGroup;
+  NSMutableArray<GCDWebServerHandler*>* _handlers;
+  NSInteger _activeConnections;  // Accessed through _syncQueue only
+  BOOL _connected;  // Accessed on main thread only
+  CFRunLoopTimerRef _disconnectTimer;  // Accessed on main thread only
+
+  NSDictionary<NSString*, id>* _options;
+  NSMutableDictionary<NSString*, NSString*>* _authenticationBasicAccounts;
+  NSMutableDictionary<NSString*, NSString*>* _authenticationDigestAccounts;
+  Class _connectionClass;
+  CFTimeInterval _disconnectDelay;
+  dispatch_source_t _source4;
+  dispatch_source_t _source6;
+  CFNetServiceRef _registrationService;
+  CFNetServiceRef _resolutionService;
+  DNSServiceRef _dnsService;
+  CFSocketRef _dnsSocket;
+  CFRunLoopSourceRef _dnsSource;
+  NSString* _dnsAddress;
+  NSUInteger _dnsPort;
+  BOOL _bindToLocalhost;
+#if TARGET_OS_IPHONE
+  BOOL _suspendInBackground;
+  UIBackgroundTaskIdentifier _backgroundTask;
+#endif
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  BOOL _recording;
+#endif
+}
+
++ (void)initialize {
+  GCDWebServerInitializeFunctions();
+}
+
+- (instancetype)init {
+  if ((self = [super init])) {
+    _syncQueue = dispatch_queue_create([NSStringFromClass([self class]) UTF8String], DISPATCH_QUEUE_SERIAL);
+    _sourceGroup = dispatch_group_create();
+    _handlers = [[NSMutableArray alloc] init];
+#if TARGET_OS_IPHONE
+    _backgroundTask = UIBackgroundTaskInvalid;
+#endif
+  }
+  return self;
+}
+
+- (void)dealloc {
+  GWS_DCHECK(_connected == NO);
+  GWS_DCHECK(_activeConnections == 0);
+  GWS_DCHECK(_options == nil);  // The server can never be dealloc'ed while running because of the retain-cycle with the dispatch source
+  GWS_DCHECK(_disconnectTimer == NULL);  // The server can never be dealloc'ed while the disconnect timer is pending because of the retain-cycle
+
+#if !OS_OBJECT_USE_OBJC_RETAIN_RELEASE
+  dispatch_release(_sourceGroup);
+  dispatch_release(_syncQueue);
+#endif
+}
+
+#if TARGET_OS_IPHONE
+
+// Always called on main thread
+- (void)_startBackgroundTask {
+  GWS_DCHECK([NSThread isMainThread]);
+  if (_backgroundTask == UIBackgroundTaskInvalid) {
+    GWS_LOG_DEBUG(@"Did start background task");
+    _backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+      GWS_LOG_WARNING(@"Application is being suspended while %@ is still connected", [self class]);
+      [self _endBackgroundTask];
+    }];
+  } else {
+    GWS_DNOT_REACHED();
+  }
+}
+
+#endif
+
+// Always called on main thread
+- (void)_didConnect {
+  GWS_DCHECK([NSThread isMainThread]);
+  GWS_DCHECK(_connected == NO);
+  _connected = YES;
+  GWS_LOG_DEBUG(@"Did connect");
+
+#if TARGET_OS_IPHONE
+  if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground) {
+    [self _startBackgroundTask];
+  }
+#endif
+
+  if ([_delegate respondsToSelector:@selector(webServerDidConnect:)]) {
+    [_delegate webServerDidConnect:self];
+  }
+}
+
+- (void)willStartConnection:(GCDWebServerConnection*)connection {
+  dispatch_sync(_syncQueue, ^{
+    GWS_DCHECK(self->_activeConnections >= 0);
+    if (self->_activeConnections == 0) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_disconnectTimer) {
+          CFRunLoopTimerInvalidate(self->_disconnectTimer);
+          CFRelease(self->_disconnectTimer);
+          self->_disconnectTimer = NULL;
+        }
+        if (self->_connected == NO) {
+          [self _didConnect];
+        }
+      });
+    }
+    self->_activeConnections += 1;
+  });
+}
+
+#if TARGET_OS_IPHONE
+
+// Always called on main thread
+- (void)_endBackgroundTask {
+  GWS_DCHECK([NSThread isMainThread]);
+  if (_backgroundTask != UIBackgroundTaskInvalid) {
+    if (_suspendInBackground && ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) && _source4) {
+      [self _stop];
+    }
+    [[UIApplication sharedApplication] endBackgroundTask:_backgroundTask];
+    _backgroundTask = UIBackgroundTaskInvalid;
+    GWS_LOG_DEBUG(@"Did end background task");
+  }
+}
+
+#endif
+
+// Always called on main thread
+- (void)_didDisconnect {
+  GWS_DCHECK([NSThread isMainThread]);
+  GWS_DCHECK(_connected == YES);
+  _connected = NO;
+  GWS_LOG_DEBUG(@"Did disconnect");
+
+#if TARGET_OS_IPHONE
+  [self _endBackgroundTask];
+#endif
+
+  if ([_delegate respondsToSelector:@selector(webServerDidDisconnect:)]) {
+    [_delegate webServerDidDisconnect:self];
+  }
+}
+
+- (void)didEndConnection:(GCDWebServerConnection*)connection {
+  dispatch_sync(_syncQueue, ^{
+    GWS_DCHECK(self->_activeConnections > 0);
+    self->_activeConnections -= 1;
+    if (self->_activeConnections == 0) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if ((self->_disconnectDelay > 0.0) && (self->_source4 != NULL)) {
+          if (self->_disconnectTimer) {
+            CFRunLoopTimerInvalidate(self->_disconnectTimer);
+            CFRelease(self->_disconnectTimer);
+          }
+          self->_disconnectTimer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + self->_disconnectDelay, 0.0, 0, 0, ^(CFRunLoopTimerRef timer) {
+            GWS_DCHECK([NSThread isMainThread]);
+            [self _didDisconnect];
+            CFRelease(self->_disconnectTimer);
+            self->_disconnectTimer = NULL;
+          });
+          CFRunLoopAddTimer(CFRunLoopGetMain(), self->_disconnectTimer, kCFRunLoopCommonModes);
+        } else {
+          [self _didDisconnect];
+        }
+      });
+    }
+  });
+}
+
+- (NSString*)bonjourName {
+  CFStringRef name = _resolutionService ? CFNetServiceGetName(_resolutionService) : NULL;
+  return name && CFStringGetLength(name) ? CFBridgingRelease(CFStringCreateCopy(kCFAllocatorDefault, name)) : nil;
+}
+
+- (NSString*)bonjourType {
+  CFStringRef type = _resolutionService ? CFNetServiceGetType(_resolutionService) : NULL;
+  return type && CFStringGetLength(type) ? CFBridgingRelease(CFStringCreateCopy(kCFAllocatorDefault, type)) : nil;
+}
+
+- (void)addHandlerWithMatchBlock:(GCDWebServerMatchBlock)matchBlock processBlock:(GCDWebServerProcessBlock)processBlock {
+  [self addHandlerWithMatchBlock:matchBlock
+               asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
+                 completionBlock(processBlock(request));
+               }];
+}
+
+- (void)addHandlerWithMatchBlock:(GCDWebServerMatchBlock)matchBlock asyncProcessBlock:(GCDWebServerAsyncProcessBlock)processBlock {
+  GWS_DCHECK(_options == nil);
+  GCDWebServerHandler* handler = [[GCDWebServerHandler alloc] initWithMatchBlock:matchBlock asyncProcessBlock:processBlock];
+  [_handlers insertObject:handler atIndex:0];
+}
+
+- (void)removeAllHandlers {
+  GWS_DCHECK(_options == nil);
+  [_handlers removeAllObjects];
+}
+
+static void _NetServiceRegisterCallBack(CFNetServiceRef service, CFStreamError* error, void* info) {
+  GWS_DCHECK([NSThread isMainThread]);
+  @autoreleasepool {
+    if (error->error) {
+      GWS_LOG_ERROR(@"Bonjour registration error %i (domain %i)", (int)error->error, (int)error->domain);
+    } else {
+      GCDWebServer* server = (__bridge GCDWebServer*)info;
+      GWS_LOG_VERBOSE(@"Bonjour registration complete for %@", [server class]);
+      if (!CFNetServiceResolveWithTimeout(server->_resolutionService, kBonjourResolutionTimeout, NULL)) {
+        GWS_LOG_ERROR(@"Failed starting Bonjour resolution");
+        GWS_DNOT_REACHED();
+      }
+    }
+  }
+}
+
+static void _NetServiceResolveCallBack(CFNetServiceRef service, CFStreamError* error, void* info) {
+  GWS_DCHECK([NSThread isMainThread]);
+  @autoreleasepool {
+    if (error->error) {
+      if ((error->domain != kCFStreamErrorDomainNetServices) && (error->error != kCFNetServicesErrorTimeout)) {
+        GWS_LOG_ERROR(@"Bonjour resolution error %i (domain %i)", (int)error->error, (int)error->domain);
+      }
+    } else {
+      GCDWebServer* server = (__bridge GCDWebServer*)info;
+      GWS_LOG_INFO(@"%@ now locally reachable at %@", [server class], server.bonjourServerURL);
+      if ([server.delegate respondsToSelector:@selector(webServerDidCompleteBonjourRegistration:)]) {
+        [server.delegate webServerDidCompleteBonjourRegistration:server];
+      }
+    }
+  }
+}
+
+static void _DNSServiceCallBack(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t interfaceIndex, DNSServiceErrorType errorCode, uint32_t externalAddress, DNSServiceProtocol protocol, uint16_t internalPort, uint16_t externalPort, uint32_t ttl, void* context) {
+  GWS_DCHECK([NSThread isMainThread]);
+  @autoreleasepool {
+    GCDWebServer* server = (__bridge GCDWebServer*)context;
+    if ((errorCode == kDNSServiceErr_NoError) || (errorCode == kDNSServiceErr_DoubleNAT)) {
+      struct sockaddr_in addr4;
+      bzero(&addr4, sizeof(addr4));
+      addr4.sin_len = sizeof(addr4);
+      addr4.sin_family = AF_INET;
+      addr4.sin_addr.s_addr = externalAddress;  // Already in network byte order
+      server->_dnsAddress = GCDWebServerStringFromSockAddr((const struct sockaddr*)&addr4, NO);
+      server->_dnsPort = ntohs(externalPort);
+      GWS_LOG_INFO(@"%@ now publicly reachable at %@", [server class], server.publicServerURL);
+    } else {
+      GWS_LOG_ERROR(@"DNS service error %i", errorCode);
+      server->_dnsAddress = nil;
+      server->_dnsPort = 0;
+    }
+    if ([server.delegate respondsToSelector:@selector(webServerDidUpdateNATPortMapping:)]) {
+      [server.delegate webServerDidUpdateNATPortMapping:server];
+    }
+  }
+}
+
+static void _SocketCallBack(CFSocketRef s, CFSocketCallBackType type, CFDataRef address, const void* data, void* info) {
+  GWS_DCHECK([NSThread isMainThread]);
+  @autoreleasepool {
+    GCDWebServer* server = (__bridge GCDWebServer*)info;
+    DNSServiceErrorType status = DNSServiceProcessResult(server->_dnsService);
+    if (status != kDNSServiceErr_NoError) {
+      GWS_LOG_ERROR(@"DNS service error %i", status);
+    }
+  }
+}
+
+static inline id _GetOption(NSDictionary<NSString*, id>* options, NSString* key, id defaultValue) {
+  id value = [options objectForKey:key];
+  return value ? value : defaultValue;
+}
+
+static inline NSString* _EncodeBase64(NSString* string) {
+  NSData* data = [string dataUsingEncoding:NSUTF8StringEncoding];
+#if TARGET_OS_IPHONE || (__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9)
+  return [[NSString alloc] initWithData:[data base64EncodedDataWithOptions:0] encoding:NSASCIIStringEncoding];
+#else
+  if (@available(macOS 10.9, *)) {
+    return [[NSString alloc] initWithData:[data base64EncodedDataWithOptions:0] encoding:NSASCIIStringEncoding];
+  }
+  return [data base64Encoding];
+#endif
+}
+
+- (int)_createListeningSocket:(BOOL)useIPv6
+                 localAddress:(const void*)address
+                       length:(socklen_t)length
+        maxPendingConnections:(NSUInteger)maxPendingConnections
+                        error:(NSError**)error {
+  int listeningSocket = socket(useIPv6 ? PF_INET6 : PF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (listeningSocket > 0) {
+    int yes = 1;
+    setsockopt(listeningSocket, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+
+    if (bind(listeningSocket, address, length) == 0) {
+      if (listen(listeningSocket, (int)maxPendingConnections) == 0) {
+        GWS_LOG_DEBUG(@"Did open %s listening socket %i", useIPv6 ? "IPv6" : "IPv4", listeningSocket);
+        return listeningSocket;
+      } else {
+        if (error) {
+          *error = GCDWebServerMakePosixError(errno);
+        }
+        GWS_LOG_ERROR(@"Failed starting %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+        close(listeningSocket);
+      }
+    } else {
+      if (error) {
+        *error = GCDWebServerMakePosixError(errno);
+      }
+      GWS_LOG_ERROR(@"Failed binding %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+      close(listeningSocket);
+    }
+
+  } else {
+    if (error) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
+    GWS_LOG_ERROR(@"Failed creating %s listening socket: %s (%i)", useIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+  }
+  return -1;
+}
+
+- (dispatch_source_t)_createDispatchSourceWithListeningSocket:(int)listeningSocket isIPv6:(BOOL)isIPv6 {
+  dispatch_group_enter(_sourceGroup);
+  dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, listeningSocket, 0, dispatch_get_global_queue(_dispatchQueuePriority, 0));
+  dispatch_source_set_cancel_handler(source, ^{
+    @autoreleasepool {
+      int result = close(listeningSocket);
+      if (result != 0) {
+        GWS_LOG_ERROR(@"Failed closing %s listening socket: %s (%i)", isIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+      } else {
+        GWS_LOG_DEBUG(@"Did close %s listening socket %i", isIPv6 ? "IPv6" : "IPv4", listeningSocket);
+      }
+    }
+    dispatch_group_leave(self->_sourceGroup);
+  });
+  dispatch_source_set_event_handler(source, ^{
+    @autoreleasepool {
+      struct sockaddr_storage remoteSockAddr;
+      socklen_t remoteAddrLen = sizeof(remoteSockAddr);
+      int socket = accept(listeningSocket, (struct sockaddr*)&remoteSockAddr, &remoteAddrLen);
+      if (socket > 0) {
+        NSData* remoteAddress = [NSData dataWithBytes:&remoteSockAddr length:remoteAddrLen];
+
+        struct sockaddr_storage localSockAddr;
+        socklen_t localAddrLen = sizeof(localSockAddr);
+        NSData* localAddress = nil;
+        if (getsockname(socket, (struct sockaddr*)&localSockAddr, &localAddrLen) == 0) {
+          localAddress = [NSData dataWithBytes:&localSockAddr length:localAddrLen];
+          GWS_DCHECK((!isIPv6 && localSockAddr.ss_family == AF_INET) || (isIPv6 && localSockAddr.ss_family == AF_INET6));
+        } else {
+          GWS_DNOT_REACHED();
+        }
+
+        int noSigPipe = 1;
+        setsockopt(socket, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));  // Make sure this socket cannot generate SIG_PIPE
+
+        GCDWebServerConnection* connection = [(GCDWebServerConnection*)[self->_connectionClass alloc] initWithServer:self localAddress:localAddress remoteAddress:remoteAddress socket:socket];  // Connection will automatically retain itself while opened
+        [connection self];  // Prevent compiler from complaining about unused variable / useless statement
+      } else {
+        GWS_LOG_ERROR(@"Failed accepting %s socket: %s (%i)", isIPv6 ? "IPv6" : "IPv4", strerror(errno), errno);
+      }
+    }
+  });
+  return source;
+}
+
+- (BOOL)_start:(NSError**)error {
+  GWS_DCHECK(_source4 == NULL);
+
+  NSUInteger port = [(NSNumber*)_GetOption(_options, GCDWebServerOption_Port, @0) unsignedIntegerValue];
+  BOOL bindToLocalhost = [(NSNumber*)_GetOption(_options, GCDWebServerOption_BindToLocalhost, @NO) boolValue];
+  NSUInteger maxPendingConnections = [(NSNumber*)_GetOption(_options, GCDWebServerOption_MaxPendingConnections, @16) unsignedIntegerValue];
+
+  struct sockaddr_in addr4;
+  bzero(&addr4, sizeof(addr4));
+  addr4.sin_len = sizeof(addr4);
+  addr4.sin_family = AF_INET;
+  addr4.sin_port = htons(port);
+  addr4.sin_addr.s_addr = bindToLocalhost ? htonl(INADDR_LOOPBACK) : htonl(INADDR_ANY);
+  int listeningSocket4 = [self _createListeningSocket:NO localAddress:&addr4 length:sizeof(addr4) maxPendingConnections:maxPendingConnections error:error];
+  if (listeningSocket4 <= 0) {
+    return NO;
+  }
+  if (port == 0) {
+    struct sockaddr_in addr;
+    socklen_t addrlen = sizeof(addr);
+    if (getsockname(listeningSocket4, (struct sockaddr*)&addr, &addrlen) == 0) {
+      port = ntohs(addr.sin_port);
+    } else {
+      GWS_LOG_ERROR(@"Failed retrieving socket address: %s (%i)", strerror(errno), errno);
+    }
+  }
+
+  struct sockaddr_in6 addr6;
+  bzero(&addr6, sizeof(addr6));
+  addr6.sin6_len = sizeof(addr6);
+  addr6.sin6_family = AF_INET6;
+  addr6.sin6_port = htons(port);
+  addr6.sin6_addr = bindToLocalhost ? in6addr_loopback : in6addr_any;
+  int listeningSocket6 = [self _createListeningSocket:YES localAddress:&addr6 length:sizeof(addr6) maxPendingConnections:maxPendingConnections error:error];
+  if (listeningSocket6 <= 0) {
+    close(listeningSocket4);
+    return NO;
+  }
+
+  _serverName = [(NSString*)_GetOption(_options, GCDWebServerOption_ServerName, NSStringFromClass([self class])) copy];
+  NSString* authenticationMethod = _GetOption(_options, GCDWebServerOption_AuthenticationMethod, nil);
+  if ([authenticationMethod isEqualToString:GCDWebServerAuthenticationMethod_Basic]) {
+    _authenticationRealm = [(NSString*)_GetOption(_options, GCDWebServerOption_AuthenticationRealm, _serverName) copy];
+    _authenticationBasicAccounts = [[NSMutableDictionary alloc] init];
+    NSDictionary* accounts = _GetOption(_options, GCDWebServerOption_AuthenticationAccounts, @{});
+    [accounts enumerateKeysAndObjectsUsingBlock:^(NSString* username, NSString* password, BOOL* stop) {
+      [self->_authenticationBasicAccounts setObject:_EncodeBase64([NSString stringWithFormat:@"%@:%@", username, password]) forKey:username];
+    }];
+  } else if ([authenticationMethod isEqualToString:GCDWebServerAuthenticationMethod_DigestAccess]) {
+    _authenticationRealm = [(NSString*)_GetOption(_options, GCDWebServerOption_AuthenticationRealm, _serverName) copy];
+    _authenticationDigestAccounts = [[NSMutableDictionary alloc] init];
+    NSDictionary* accounts = _GetOption(_options, GCDWebServerOption_AuthenticationAccounts, @{});
+    [accounts enumerateKeysAndObjectsUsingBlock:^(NSString* username, NSString* password, BOOL* stop) {
+      [self->_authenticationDigestAccounts setObject:GCDWebServerComputeMD5Digest(@"%@:%@:%@", username, self->_authenticationRealm, password) forKey:username];
+    }];
+  }
+  _connectionClass = _GetOption(_options, GCDWebServerOption_ConnectionClass, [GCDWebServerConnection class]);
+  _shouldAutomaticallyMapHEADToGET = [(NSNumber*)_GetOption(_options, GCDWebServerOption_AutomaticallyMapHEADToGET, @YES) boolValue];
+  _disconnectDelay = [(NSNumber*)_GetOption(_options, GCDWebServerOption_ConnectedStateCoalescingInterval, @1.0) doubleValue];
+  _dispatchQueuePriority = [(NSNumber*)_GetOption(_options, GCDWebServerOption_DispatchQueuePriority, @(DISPATCH_QUEUE_PRIORITY_DEFAULT)) longValue];
+
+  _source4 = [self _createDispatchSourceWithListeningSocket:listeningSocket4 isIPv6:NO];
+  _source6 = [self _createDispatchSourceWithListeningSocket:listeningSocket6 isIPv6:YES];
+  _port = port;
+  _bindToLocalhost = bindToLocalhost;
+
+  NSString* bonjourName = _GetOption(_options, GCDWebServerOption_BonjourName, nil);
+  NSString* bonjourType = _GetOption(_options, GCDWebServerOption_BonjourType, @"_http._tcp");
+  if (bonjourName) {
+    _registrationService = CFNetServiceCreate(kCFAllocatorDefault, CFSTR("local."), (__bridge CFStringRef)bonjourType, (__bridge CFStringRef)(bonjourName.length ? bonjourName : _serverName), (SInt32)_port);
+    if (_registrationService) {
+      CFNetServiceClientContext context = {0, (__bridge void*)self, NULL, NULL, NULL};
+
+      CFNetServiceSetClient(_registrationService, _NetServiceRegisterCallBack, &context);
+      CFNetServiceScheduleWithRunLoop(_registrationService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+      CFStreamError streamError = {0};
+      
+      NSDictionary* txtDataDictionary = _GetOption(_options, GCDWebServerOption_BonjourTXTData, nil);
+      if (txtDataDictionary != nil) {
+        NSUInteger count = txtDataDictionary.count;
+        CFStringRef keys[count];
+        CFStringRef values[count];
+        NSUInteger index = 0;
+        for (NSString *key in txtDataDictionary) {
+          NSString *value = txtDataDictionary[key];
+          keys[index] = (__bridge CFStringRef)(key);
+          values[index] = (__bridge CFStringRef)(value);
+          index ++;
+        }
+        CFDictionaryRef txtDictionary = CFDictionaryCreate(CFAllocatorGetDefault(), (void *)keys, (void *)values, count, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        if (txtDictionary != NULL) {
+          CFDataRef txtData = CFNetServiceCreateTXTDataWithDictionary(nil, txtDictionary);
+          Boolean setTXTDataResult = CFNetServiceSetTXTData(_registrationService, txtData);
+          if (!setTXTDataResult) {
+            GWS_LOG_ERROR(@"Failed setting TXTData");
+          }
+        }
+      }
+      
+      CFNetServiceRegisterWithOptions(_registrationService, 0, &streamError);
+
+      _resolutionService = CFNetServiceCreateCopy(kCFAllocatorDefault, _registrationService);
+      if (_resolutionService) {
+        CFNetServiceSetClient(_resolutionService, _NetServiceResolveCallBack, &context);
+        CFNetServiceScheduleWithRunLoop(_resolutionService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+      } else {
+        GWS_LOG_ERROR(@"Failed creating CFNetService for resolution");
+      }
+    } else {
+      GWS_LOG_ERROR(@"Failed creating CFNetService for registration");
+    }
+  }
+
+  if ([(NSNumber*)_GetOption(_options, GCDWebServerOption_RequestNATPortMapping, @NO) boolValue]) {
+    DNSServiceErrorType status = DNSServiceNATPortMappingCreate(&_dnsService, 0, 0, kDNSServiceProtocol_TCP, htons(port), htons(port), 0, _DNSServiceCallBack, (__bridge void*)self);
+    if (status == kDNSServiceErr_NoError) {
+      CFSocketContext context = {0, (__bridge void*)self, NULL, NULL, NULL};
+      _dnsSocket = CFSocketCreateWithNative(kCFAllocatorDefault, DNSServiceRefSockFD(_dnsService), kCFSocketReadCallBack, _SocketCallBack, &context);
+      if (_dnsSocket) {
+        CFSocketSetSocketFlags(_dnsSocket, CFSocketGetSocketFlags(_dnsSocket) & ~kCFSocketCloseOnInvalidate);
+        _dnsSource = CFSocketCreateRunLoopSource(kCFAllocatorDefault, _dnsSocket, 0);
+        if (_dnsSource) {
+          CFRunLoopAddSource(CFRunLoopGetMain(), _dnsSource, kCFRunLoopCommonModes);
+        } else {
+          GWS_LOG_ERROR(@"Failed creating CFRunLoopSource");
+          GWS_DNOT_REACHED();
+        }
+      } else {
+        GWS_LOG_ERROR(@"Failed creating CFSocket");
+        GWS_DNOT_REACHED();
+      }
+    } else {
+      GWS_LOG_ERROR(@"Failed creating NAT port mapping (%i)", status);
+    }
+  }
+
+  dispatch_resume(_source4);
+  dispatch_resume(_source6);
+  GWS_LOG_INFO(@"%@ started on port %i and reachable at %@", [self class], (int)_port, self.serverURL);
+  if ([_delegate respondsToSelector:@selector(webServerDidStart:)]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self->_delegate webServerDidStart:self];
+    });
+  }
+
+  return YES;
+}
+
+- (void)_stop {
+  GWS_DCHECK(_source4 != NULL);
+
+  if (_dnsService) {
+    _dnsAddress = nil;
+    _dnsPort = 0;
+    if (_dnsSource) {
+      CFRunLoopSourceInvalidate(_dnsSource);
+      CFRelease(_dnsSource);
+      _dnsSource = NULL;
+    }
+    if (_dnsSocket) {
+      CFRelease(_dnsSocket);
+      _dnsSocket = NULL;
+    }
+    DNSServiceRefDeallocate(_dnsService);
+    _dnsService = NULL;
+  }
+
+  if (_registrationService) {
+    if (_resolutionService) {
+      CFNetServiceUnscheduleFromRunLoop(_resolutionService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+      CFNetServiceSetClient(_resolutionService, NULL, NULL);
+      CFNetServiceCancel(_resolutionService);
+      CFRelease(_resolutionService);
+      _resolutionService = NULL;
+    }
+    CFNetServiceUnscheduleFromRunLoop(_registrationService, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+    CFNetServiceSetClient(_registrationService, NULL, NULL);
+    CFNetServiceCancel(_registrationService);
+    CFRelease(_registrationService);
+    _registrationService = NULL;
+  }
+
+  dispatch_source_cancel(_source6);
+  dispatch_source_cancel(_source4);
+  dispatch_group_wait(_sourceGroup, DISPATCH_TIME_FOREVER);  // Wait until the cancellation handlers have been called which guarantees the listening sockets are closed
+#if !OS_OBJECT_USE_OBJC_RETAIN_RELEASE
+  dispatch_release(_source6);
+#endif
+  _source6 = NULL;
+#if !OS_OBJECT_USE_OBJC_RETAIN_RELEASE
+  dispatch_release(_source4);
+#endif
+  _source4 = NULL;
+  _port = 0;
+  _bindToLocalhost = NO;
+
+  _serverName = nil;
+  _authenticationRealm = nil;
+  _authenticationBasicAccounts = nil;
+  _authenticationDigestAccounts = nil;
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (self->_disconnectTimer) {
+      CFRunLoopTimerInvalidate(self->_disconnectTimer);
+      CFRelease(self->_disconnectTimer);
+      self->_disconnectTimer = NULL;
+      [self _didDisconnect];
+    }
+  });
+
+  GWS_LOG_INFO(@"%@ stopped", [self class]);
+  if ([_delegate respondsToSelector:@selector(webServerDidStop:)]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self->_delegate webServerDidStop:self];
+    });
+  }
+}
+
+#if TARGET_OS_IPHONE
+
+- (void)_didEnterBackground:(NSNotification*)notification {
+  GWS_DCHECK([NSThread isMainThread]);
+  GWS_LOG_DEBUG(@"Did enter background");
+  if ((_backgroundTask == UIBackgroundTaskInvalid) && _source4) {
+    [self _stop];
+  }
+}
+
+- (void)_willEnterForeground:(NSNotification*)notification {
+  GWS_DCHECK([NSThread isMainThread]);
+  GWS_LOG_DEBUG(@"Will enter foreground");
+  if (!_source4) {
+    [self _start:NULL];  // TODO: There's probably nothing we can do on failure
+  }
+}
+
+#endif
+
+- (BOOL)startWithOptions:(NSDictionary<NSString*, id>*)options error:(NSError**)error {
+  if (_options == nil) {
+    _options = options ? [options copy] : @{};
+#if TARGET_OS_IPHONE
+    _suspendInBackground = [(NSNumber*)_GetOption(_options, GCDWebServerOption_AutomaticallySuspendInBackground, @YES) boolValue];
+    if (((_suspendInBackground == NO) || ([[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground)) && ![self _start:error])
+#else
+    if (![self _start:error])
+#endif
+    {
+      _options = nil;
+      return NO;
+    }
+#if TARGET_OS_IPHONE
+    if (_suspendInBackground) {
+      [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+      [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_willEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
+    }
+#endif
+    return YES;
+  } else {
+    GWS_DNOT_REACHED();
+  }
+  return NO;
+}
+
+- (BOOL)isRunning {
+  return (_options ? YES : NO);
+}
+
+- (void)stop {
+  if (_options) {
+#if TARGET_OS_IPHONE
+    if (_suspendInBackground) {
+      [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+      [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
+    }
+#endif
+    if (_source4) {
+      [self _stop];
+    }
+    _options = nil;
+  } else {
+    GWS_DNOT_REACHED();
+  }
+}
+
+@end
+
+@implementation GCDWebServer (Extensions)
+
+- (NSURL*)serverURL {
+  if (_source4) {
+    NSString* ipAddress = _bindToLocalhost ? @"localhost" : GCDWebServerGetPrimaryIPAddress(NO);  // We can't really use IPv6 anyway as it doesn't work great with HTTP URLs in practice
+    if (ipAddress) {
+      if (_port != 80) {
+        return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", ipAddress, (int)_port]];
+      } else {
+        return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", ipAddress]];
+      }
+    }
+  }
+  return nil;
+}
+
+- (NSURL*)bonjourServerURL {
+  if (_source4 && _resolutionService) {
+    NSString* name = (__bridge NSString*)CFNetServiceGetTargetHost(_resolutionService);
+    if (name.length) {
+      name = [name substringToIndex:(name.length - 1)];  // Strip trailing period at end of domain
+      if (_port != 80) {
+        return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", name, (int)_port]];
+      } else {
+        return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", name]];
+      }
+    }
+  }
+  return nil;
+}
+
+- (NSURL*)publicServerURL {
+  if (_source4 && _dnsService && _dnsAddress && _dnsPort) {
+    if (_dnsPort != 80) {
+      return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@:%i/", _dnsAddress, (int)_dnsPort]];
+    } else {
+      return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/", _dnsAddress]];
+    }
+  }
+  return nil;
+}
+
+- (BOOL)start {
+  return [self startWithPort:kDefaultPort bonjourName:@""];
+}
+
+- (BOOL)startWithPort:(NSUInteger)port bonjourName:(NSString*)name {
+  NSMutableDictionary* options = [NSMutableDictionary dictionary];
+  [options setObject:[NSNumber numberWithInteger:port] forKey:GCDWebServerOption_Port];
+  [options setValue:name forKey:GCDWebServerOption_BonjourName];
+  return [self startWithOptions:options error:NULL];
+}
+
+#if !TARGET_OS_IPHONE
+
+- (BOOL)runWithPort:(NSUInteger)port bonjourName:(NSString*)name {
+  NSMutableDictionary* options = [NSMutableDictionary dictionary];
+  [options setObject:[NSNumber numberWithInteger:port] forKey:GCDWebServerOption_Port];
+  [options setValue:name forKey:GCDWebServerOption_BonjourName];
+  return [self runWithOptions:options error:NULL];
+}
+
+- (BOOL)runWithOptions:(NSDictionary<NSString*, id>*)options error:(NSError**)error {
+  GWS_DCHECK([NSThread isMainThread]);
+  BOOL success = NO;
+  _run = YES;
+  void (*termHandler)(int) = signal(SIGTERM, _SignalHandler);
+  void (*intHandler)(int) = signal(SIGINT, _SignalHandler);
+  if ((termHandler != SIG_ERR) && (intHandler != SIG_ERR)) {
+    if ([self startWithOptions:options error:error]) {
+      while (_run) {
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1.0, true);
+      }
+      [self stop];
+      success = YES;
+    }
+    _ExecuteMainThreadRunLoopSources();
+    signal(SIGINT, intHandler);
+    signal(SIGTERM, termHandler);
+  }
+  return success;
+}
+
+#endif
+
+@end
+
+@implementation GCDWebServer (Handlers)
+
+- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
+  [self addDefaultHandlerForMethod:method
+                      requestClass:aClass
+                 asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
+                   completionBlock(block(request));
+                 }];
+}
+
+- (void)addDefaultHandlerForMethod:(NSString*)method requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
+  [self
+      addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
+        if (![requestMethod isEqualToString:method]) {
+          return nil;
+        }
+        return [(GCDWebServerRequest*)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+      }
+             asyncProcessBlock:block];
+}
+
+- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
+  [self addHandlerForMethod:method
+                       path:path
+               requestClass:aClass
+          asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
+            completionBlock(block(request));
+          }];
+}
+
+- (void)addHandlerForMethod:(NSString*)method path:(NSString*)path requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
+  if ([path hasPrefix:@"/"] && [aClass isSubclassOfClass:[GCDWebServerRequest class]]) {
+    [self
+        addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
+          if (![requestMethod isEqualToString:method]) {
+            return nil;
+          }
+          if ([urlPath caseInsensitiveCompare:path] != NSOrderedSame) {
+            return nil;
+          }
+          return [(GCDWebServerRequest*)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+        }
+               asyncProcessBlock:block];
+  } else {
+    GWS_DNOT_REACHED();
+  }
+}
+
+- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass processBlock:(GCDWebServerProcessBlock)block {
+  [self addHandlerForMethod:method
+                  pathRegex:regex
+               requestClass:aClass
+          asyncProcessBlock:^(GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock) {
+            completionBlock(block(request));
+          }];
+}
+
+- (void)addHandlerForMethod:(NSString*)method pathRegex:(NSString*)regex requestClass:(Class)aClass asyncProcessBlock:(GCDWebServerAsyncProcessBlock)block {
+  NSRegularExpression* expression = [NSRegularExpression regularExpressionWithPattern:regex options:NSRegularExpressionCaseInsensitive error:NULL];
+  if (expression && [aClass isSubclassOfClass:[GCDWebServerRequest class]]) {
+    [self
+        addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
+          if (![requestMethod isEqualToString:method]) {
+            return nil;
+          }
+
+          NSArray* matches = [expression matchesInString:urlPath options:0 range:NSMakeRange(0, urlPath.length)];
+          if (matches.count == 0) {
+            return nil;
+          }
+
+          NSMutableArray* captures = [NSMutableArray array];
+          for (NSTextCheckingResult* result in matches) {
+            // Start at 1; index 0 is the whole string
+            for (NSUInteger i = 1; i < result.numberOfRanges; i++) {
+              NSRange range = [result rangeAtIndex:i];
+              // range is {NSNotFound, 0} "if one of the capture groups did not participate in this particular match"
+              // see discussion in -[NSRegularExpression firstMatchInString:options:range:]
+              if (range.location != NSNotFound) {
+                [captures addObject:[urlPath substringWithRange:range]];
+              }
+            }
+          }
+
+          GCDWebServerRequest* request = [(GCDWebServerRequest*)[aClass alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+          [request setAttribute:captures forKey:GCDWebServerRequestAttribute_RegexCaptures];
+          return request;
+        }
+               asyncProcessBlock:block];
+  } else {
+    GWS_DNOT_REACHED();
+  }
+}
+
+@end
+
+@implementation GCDWebServer (GETHandlers)
+
+- (void)addGETHandlerForPath:(NSString*)path staticData:(NSData*)staticData contentType:(NSString*)contentType cacheAge:(NSUInteger)cacheAge {
+  [self addHandlerForMethod:@"GET"
+                       path:path
+               requestClass:[GCDWebServerRequest class]
+               processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                 GCDWebServerResponse* response = [GCDWebServerDataResponse responseWithData:staticData contentType:contentType];
+                 response.cacheControlMaxAge = cacheAge;
+                 return response;
+               }];
+}
+
+- (void)addGETHandlerForPath:(NSString*)path filePath:(NSString*)filePath isAttachment:(BOOL)isAttachment cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests {
+  [self addHandlerForMethod:@"GET"
+                       path:path
+               requestClass:[GCDWebServerRequest class]
+               processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+                 GCDWebServerResponse* response = nil;
+                 if (allowRangeRequests) {
+                   response = [GCDWebServerFileResponse responseWithFile:filePath byteRange:request.byteRange isAttachment:isAttachment];
+                   [response setValue:@"bytes" forAdditionalHeader:@"Accept-Ranges"];
+                 } else {
+                   response = [GCDWebServerFileResponse responseWithFile:filePath isAttachment:isAttachment];
+                 }
+                 response.cacheControlMaxAge = cacheAge;
+                 return response;
+               }];
+}
+
+- (GCDWebServerResponse*)_responseWithContentsOfDirectory:(NSString*)path {
+  NSArray* contents = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:NULL] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
+  if (contents == nil) {
+    return nil;
+  }
+  NSMutableString* html = [NSMutableString string];
+  [html appendString:@"<!DOCTYPE html>\n"];
+  [html appendString:@"<html><head><meta charset=\"utf-8\"></head><body>\n"];
+  [html appendString:@"<ul>\n"];
+  for (NSString* entry in contents) {
+    if (![entry hasPrefix:@"."]) {
+      NSString* type = [[[NSFileManager defaultManager] attributesOfItemAtPath:[path stringByAppendingPathComponent:entry] error:NULL] objectForKey:NSFileType];
+      GWS_DCHECK(type);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      NSString* escapedFile = [entry stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+#pragma clang diagnostic pop
+      GWS_DCHECK(escapedFile);
+      if ([type isEqualToString:NSFileTypeRegular]) {
+        [html appendFormat:@"<li><a href=\"%@\">%@</a></li>\n", escapedFile, entry];
+      } else if ([type isEqualToString:NSFileTypeDirectory]) {
+        [html appendFormat:@"<li><a href=\"%@/\">%@/</a></li>\n", escapedFile, entry];
+      }
+    }
+  }
+  [html appendString:@"</ul>\n"];
+  [html appendString:@"</body></html>\n"];
+  return [GCDWebServerDataResponse responseWithHTML:html];
+}
+
+- (void)addGETHandlerForBasePath:(NSString*)basePath directoryPath:(NSString*)directoryPath indexFilename:(NSString*)indexFilename cacheAge:(NSUInteger)cacheAge allowRangeRequests:(BOOL)allowRangeRequests {
+  if ([basePath hasPrefix:@"/"] && [basePath hasSuffix:@"/"]) {
+    GCDWebServer* __unsafe_unretained server = self;
+    [self
+        addHandlerWithMatchBlock:^GCDWebServerRequest*(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery) {
+          if (![requestMethod isEqualToString:@"GET"]) {
+            return nil;
+          }
+          if (![urlPath hasPrefix:basePath]) {
+            return nil;
+          }
+          return [[GCDWebServerRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:urlPath query:urlQuery];
+        }
+        processBlock:^GCDWebServerResponse*(GCDWebServerRequest* request) {
+          GCDWebServerResponse* response = nil;
+          NSString* filePath = [directoryPath stringByAppendingPathComponent:GCDWebServerNormalizePath([request.path substringFromIndex:basePath.length])];
+          NSString* fileType = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:NULL] fileType];
+          if (fileType) {
+            if ([fileType isEqualToString:NSFileTypeDirectory]) {
+              if (indexFilename) {
+                NSString* indexPath = [filePath stringByAppendingPathComponent:indexFilename];
+                NSString* indexType = [[[NSFileManager defaultManager] attributesOfItemAtPath:indexPath error:NULL] fileType];
+                if ([indexType isEqualToString:NSFileTypeRegular]) {
+                  return [GCDWebServerFileResponse responseWithFile:indexPath];
+                }
+              }
+              response = [server _responseWithContentsOfDirectory:filePath];
+            } else if ([fileType isEqualToString:NSFileTypeRegular]) {
+              if (allowRangeRequests) {
+                response = [GCDWebServerFileResponse responseWithFile:filePath byteRange:request.byteRange];
+                [response setValue:@"bytes" forAdditionalHeader:@"Accept-Ranges"];
+              } else {
+                response = [GCDWebServerFileResponse responseWithFile:filePath];
+              }
+            }
+          }
+          if (response) {
+            response.cacheControlMaxAge = cacheAge;
+          } else {
+            response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_NotFound];
+          }
+          return response;
+        }];
+  } else {
+    GWS_DNOT_REACHED();
+  }
+}
+
+@end
+
+@implementation GCDWebServer (Logging)
+
++ (void)setLogLevel:(int)level {
+#if defined(__GCDWEBSERVER_LOGGING_FACILITY_XLFACILITY__)
+  [XLSharedFacility setMinLogLevel:level];
+#elif defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
+  GCDWebServerLogLevel = level;
+#endif
+}
+
++ (void)setBuiltInLogger:(GCDWebServerBuiltInLoggerBlock)block {
+#if defined(__GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__)
+  _builtInLoggerBlock = block;
+#else
+  GWS_DNOT_REACHED();  // Built-in logger must be enabled in order to override
+#endif
+}
+
+- (void)logVerbose:(NSString*)format, ... {
+  va_list arguments;
+  va_start(arguments, format);
+  GWS_LOG_VERBOSE(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+  va_end(arguments);
+}
+
+- (void)logInfo:(NSString*)format, ... {
+  va_list arguments;
+  va_start(arguments, format);
+  GWS_LOG_INFO(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+  va_end(arguments);
+}
+
+- (void)logWarning:(NSString*)format, ... {
+  va_list arguments;
+  va_start(arguments, format);
+  GWS_LOG_WARNING(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+  va_end(arguments);
+}
+
+- (void)logError:(NSString*)format, ... {
+  va_list arguments;
+  va_start(arguments, format);
+  GWS_LOG_ERROR(@"%@", [[NSString alloc] initWithFormat:format arguments:arguments]);
+  va_end(arguments);
+}
+
+@end
+
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+
+@implementation GCDWebServer (Testing)
+
+- (void)setRecordingEnabled:(BOOL)flag {
+  _recording = flag;
+}
+
+- (BOOL)isRecordingEnabled {
+  return _recording;
+}
+
+static CFHTTPMessageRef _CreateHTTPMessageFromData(NSData* data, BOOL isRequest) {
+  CFHTTPMessageRef message = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, isRequest);
+  if (CFHTTPMessageAppendBytes(message, data.bytes, data.length)) {
+    return message;
+  }
+  CFRelease(message);
+  return NULL;
+}
+
+static CFHTTPMessageRef _CreateHTTPMessageFromPerformingRequest(NSData* inData, NSUInteger port) {
+  CFHTTPMessageRef response = NULL;
+  int httpSocket = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (httpSocket > 0) {
+    struct sockaddr_in addr4;
+    bzero(&addr4, sizeof(addr4));
+    addr4.sin_len = sizeof(addr4);
+    addr4.sin_family = AF_INET;
+    addr4.sin_port = htons(port);
+    addr4.sin_addr.s_addr = htonl(INADDR_ANY);
+    if (connect(httpSocket, (void*)&addr4, sizeof(addr4)) == 0) {
+      if (write(httpSocket, inData.bytes, inData.length) == (ssize_t)inData.length) {
+        NSMutableData* outData = [[NSMutableData alloc] initWithLength:(256 * 1024)];
+        NSUInteger length = 0;
+        while (1) {
+          ssize_t result = read(httpSocket, (char*)outData.mutableBytes + length, outData.length - length);
+          if (result < 0) {
+            length = NSUIntegerMax;
+            break;
+          } else if (result == 0) {
+            break;
+          }
+          length += result;
+          if (length >= outData.length) {
+            outData.length = 2 * outData.length;
+          }
+        }
+        if (length != NSUIntegerMax) {
+          outData.length = length;
+          response = _CreateHTTPMessageFromData(outData, NO);
+        } else {
+          GWS_DNOT_REACHED();
+        }
+      }
+    }
+    close(httpSocket);
+  }
+  return response;
+}
+
+static void _LogResult(NSString* format, ...) {
+  va_list arguments;
+  va_start(arguments, format);
+  NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
+  va_end(arguments);
+  fprintf(stdout, "%s\n", [message UTF8String]);
+}
+
+- (NSInteger)runTestsWithOptions:(NSDictionary<NSString*, id>*)options inDirectory:(NSString*)path {
+  GWS_DCHECK([NSThread isMainThread]);
+  NSArray* ignoredHeaders = @[ @"Date", @"Etag" ];  // Dates are always different by definition and ETags depend on file system node IDs
+  NSInteger result = -1;
+  if ([self startWithOptions:options error:NULL]) {
+    _ExecuteMainThreadRunLoopSources();
+
+    result = 0;
+    NSArray* files = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:path error:NULL] sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
+    for (NSString* requestFile in files) {
+      if (![requestFile hasSuffix:@".request"]) {
+        continue;
+      }
+      @autoreleasepool {
+        NSString* index = [[requestFile componentsSeparatedByString:@"-"] firstObject];
+        BOOL success = NO;
+        NSData* requestData = [NSData dataWithContentsOfFile:[path stringByAppendingPathComponent:requestFile]];
+        if (requestData) {
+          CFHTTPMessageRef request = _CreateHTTPMessageFromData(requestData, YES);
+          if (request) {
+            NSString* requestMethod = CFBridgingRelease(CFHTTPMessageCopyRequestMethod(request));
+            NSURL* requestURL = CFBridgingRelease(CFHTTPMessageCopyRequestURL(request));
+            _LogResult(@"[%i] %@ %@", (int)[index integerValue], requestMethod, requestURL.path);
+            NSString* prefix = [index stringByAppendingString:@"-"];
+            for (NSString* responseFile in files) {
+              if ([responseFile hasPrefix:prefix] && [responseFile hasSuffix:@".response"]) {
+                NSData* responseData = [NSData dataWithContentsOfFile:[path stringByAppendingPathComponent:responseFile]];
+                if (responseData) {
+                  CFHTTPMessageRef expectedResponse = _CreateHTTPMessageFromData(responseData, NO);
+                  if (expectedResponse) {
+                    CFHTTPMessageRef actualResponse = _CreateHTTPMessageFromPerformingRequest(requestData, self.port);
+                    if (actualResponse) {
+                      success = YES;
+
+                      CFIndex expectedStatusCode = CFHTTPMessageGetResponseStatusCode(expectedResponse);
+                      CFIndex actualStatusCode = CFHTTPMessageGetResponseStatusCode(actualResponse);
+                      if (actualStatusCode != expectedStatusCode) {
+                        _LogResult(@"  Status code not matching:\n    Expected: %i\n      Actual: %i", (int)expectedStatusCode, (int)actualStatusCode);
+                        success = NO;
+                      }
+
+                      NSDictionary* expectedHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(expectedResponse));
+                      NSDictionary* actualHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(actualResponse));
+                      for (NSString* expectedHeader in expectedHeaders) {
+                        if ([ignoredHeaders containsObject:expectedHeader]) {
+                          continue;
+                        }
+                        NSString* expectedValue = [expectedHeaders objectForKey:expectedHeader];
+                        NSString* actualValue = [actualHeaders objectForKey:expectedHeader];
+                        if (![actualValue isEqualToString:expectedValue]) {
+                          _LogResult(@"  Header '%@' not matching:\n    Expected: \"%@\"\n      Actual: \"%@\"", expectedHeader, expectedValue, actualValue);
+                          success = NO;
+                        }
+                      }
+                      for (NSString* actualHeader in actualHeaders) {
+                        if (![expectedHeaders objectForKey:actualHeader]) {
+                          _LogResult(@"  Header '%@' not matching:\n    Expected: \"%@\"\n      Actual: \"%@\"", actualHeader, nil, [actualHeaders objectForKey:actualHeader]);
+                          success = NO;
+                        }
+                      }
+
+                      NSString* expectedContentLength = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(expectedResponse, CFSTR("Content-Length")));
+                      NSData* expectedBody = CFBridgingRelease(CFHTTPMessageCopyBody(expectedResponse));
+                      NSString* actualContentLength = CFBridgingRelease(CFHTTPMessageCopyHeaderFieldValue(actualResponse, CFSTR("Content-Length")));
+                      NSData* actualBody = CFBridgingRelease(CFHTTPMessageCopyBody(actualResponse));
+                      if ([actualContentLength isEqualToString:expectedContentLength] && (actualBody.length > expectedBody.length)) {  // Handle web browser closing connection before retrieving entire body (e.g. when playing a video file)
+                        actualBody = [actualBody subdataWithRange:NSMakeRange(0, expectedBody.length)];
+                      }
+                      if ((actualBody && expectedBody && ![actualBody isEqualToData:expectedBody]) || (actualBody && !expectedBody) || (!actualBody && expectedBody)) {
+                        _LogResult(@"  Bodies not matching:\n    Expected: %lu bytes\n      Actual: %lu bytes", (unsigned long)expectedBody.length, (unsigned long)actualBody.length);
+                        success = NO;
+#if !TARGET_OS_IPHONE
+#if DEBUG
+                        if (GCDWebServerIsTextContentType((NSString*)[expectedHeaders objectForKey:@"Content-Type"])) {
+                          NSString* expectedPath = [NSTemporaryDirectory() stringByAppendingPathComponent:(NSString*)[[[NSProcessInfo processInfo] globallyUniqueString] stringByAppendingPathExtension:@"txt"]];
+                          NSString* actualPath = [NSTemporaryDirectory() stringByAppendingPathComponent:(NSString*)[[[NSProcessInfo processInfo] globallyUniqueString] stringByAppendingPathExtension:@"txt"]];
+                          if ([expectedBody writeToFile:expectedPath atomically:YES] && [actualBody writeToFile:actualPath atomically:YES]) {
+                            NSTask* task = [[NSTask alloc] init];
+                            [task setLaunchPath:@"/usr/bin/opendiff"];
+                            [task setArguments:@[ expectedPath, actualPath ]];
+                            [task launch];
+                          }
+                        }
+#endif
+#endif
+                      }
+
+                      CFRelease(actualResponse);
+                    }
+                    CFRelease(expectedResponse);
+                  }
+                } else {
+                  GWS_DNOT_REACHED();
+                }
+                break;
+              }
+            }
+            CFRelease(request);
+          }
+        } else {
+          GWS_DNOT_REACHED();
+        }
+        _LogResult(@"");
+        if (!success) {
+          ++result;
+        }
+      }
+      _ExecuteMainThreadRunLoopSources();
+    }
+
+    [self stop];
+
+    _ExecuteMainThreadRunLoopSources();
+  }
+  return result;
+}
+
+@end
+
+#endif

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerConnection.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerConnection.h
@@ -1,0 +1,183 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class GCDWebServerHandler;
+
+/**
+ *  The GCDWebServerConnection class is instantiated by GCDWebServer to handle
+ *  each new HTTP connection. Each instance stays alive until the connection is
+ *  closed.
+ *
+ *  You cannot use this class directly, but it is made public so you can
+ *  subclass it to override some hooks. Use the GCDWebServerOption_ConnectionClass
+ *  option for GCDWebServer to install your custom subclass.
+ *
+ *  @warning The GCDWebServerConnection retains the GCDWebServer until the
+ *  connection is closed.
+ */
+@interface GCDWebServerConnection : NSObject
+
+/**
+ *  Returns the GCDWebServer that owns the connection.
+ */
+@property(nonatomic, readonly) GCDWebServer* server;
+
+/**
+ *  Returns YES if the connection is using IPv6.
+ */
+@property(nonatomic, readonly, getter=isUsingIPv6) BOOL usingIPv6;
+
+/**
+ *  Returns the address of the local peer (i.e. server) of the connection
+ *  as a raw "struct sockaddr".
+ */
+@property(nonatomic, readonly) NSData* localAddressData;
+
+/**
+ *  Returns the address of the local peer (i.e. server) of the connection
+ *  as a string.
+ */
+@property(nonatomic, readonly) NSString* localAddressString;
+
+/**
+ *  Returns the address of the remote peer (i.e. client) of the connection
+ *  as a raw "struct sockaddr".
+ */
+@property(nonatomic, readonly) NSData* remoteAddressData;
+
+/**
+ *  Returns the address of the remote peer (i.e. client) of the connection
+ *  as a string.
+ */
+@property(nonatomic, readonly) NSString* remoteAddressString;
+
+/**
+ *  Returns the total number of bytes received from the remote peer (i.e. client)
+ *  so far.
+ */
+@property(nonatomic, readonly) NSUInteger totalBytesRead;
+
+/**
+ *  Returns the total number of bytes sent to the remote peer (i.e. client) so far.
+ */
+@property(nonatomic, readonly) NSUInteger totalBytesWritten;
+
+@end
+
+/**
+ *  Hooks to customize the behavior of GCDWebServer HTTP connections.
+ *
+ *  @warning These methods can be called on any GCD thread.
+ *  Be sure to also call "super" when overriding them.
+ */
+@interface GCDWebServerConnection (Subclassing)
+
+/**
+ *  This method is called when the connection is opened.
+ *
+ *  Return NO to reject the connection e.g. after validating the local
+ *  or remote address.
+ */
+- (BOOL)open;
+
+/**
+ *  This method is called whenever data has been received
+ *  from the remote peer (i.e. client).
+ *
+ *  @warning Do not attempt to modify this data.
+ */
+- (void)didReadBytes:(const void*)bytes length:(NSUInteger)length;
+
+/**
+ *  This method is called whenever data has been sent
+ *  to the remote peer (i.e. client).
+ *
+ *  @warning Do not attempt to modify this data.
+ */
+- (void)didWriteBytes:(const void*)bytes length:(NSUInteger)length;
+
+/**
+ *  This method is called after the HTTP headers have been received to
+ *  allow replacing the request URL by another one.
+ *
+ *  The default implementation returns the original URL.
+ */
+- (NSURL*)rewriteRequestURL:(NSURL*)url withMethod:(NSString*)method headers:(NSDictionary<NSString*, NSString*>*)headers;
+
+/**
+ *  Assuming a valid HTTP request was received, this method is called before
+ *  the request is processed.
+ *
+ *  Return a non-nil GCDWebServerResponse to bypass the request processing entirely.
+ *
+ *  The default implementation checks for HTTP authentication if applicable
+ *  and returns a barebone 401 status code response if authentication failed.
+ */
+- (nullable GCDWebServerResponse*)preflightRequest:(GCDWebServerRequest*)request;
+
+/**
+ *  Assuming a valid HTTP request was received and -preflightRequest: returned nil,
+ *  this method is called to process the request by executing the handler's
+ *  process block.
+ */
+- (void)processRequest:(GCDWebServerRequest*)request completion:(GCDWebServerCompletionBlock)completion;
+
+/**
+ *  Assuming a valid HTTP request was received and either -preflightRequest:
+ *  or -processRequest:completion: returned a non-nil GCDWebServerResponse,
+ *  this method is called to override the response.
+ *
+ *  You can either modify the current response and return it, or return a
+ *  completely new one.
+ *
+ *  The default implementation replaces any response matching the "ETag" or
+ *  "Last-Modified-Date" header of the request by a barebone "Not-Modified" (304)
+ *  one.
+ */
+- (GCDWebServerResponse*)overrideResponse:(GCDWebServerResponse*)response forRequest:(GCDWebServerRequest*)request;
+
+/**
+ *  This method is called if any error happens while validing or processing
+ *  the request or if no GCDWebServerResponse was generated during processing.
+ *
+ *  @warning If the request was invalid (e.g. the HTTP headers were malformed),
+ *  the "request" argument will be nil.
+ */
+- (void)abortRequest:(nullable GCDWebServerRequest*)request withStatusCode:(NSInteger)statusCode;
+
+/**
+ *  Called when the connection is closed.
+ */
+- (void)close;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerConnection.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerConnection.m
@@ -1,0 +1,843 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import <TargetConditionals.h>
+#import <netdb.h>
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+#import <libkern/OSAtomic.h>
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+#define kHeadersReadCapacity (1 * 1024)
+#define kBodyReadCapacity (256 * 1024)
+
+typedef void (^ReadDataCompletionBlock)(BOOL success);
+typedef void (^ReadHeadersCompletionBlock)(NSData* extraData);
+typedef void (^ReadBodyCompletionBlock)(BOOL success);
+
+typedef void (^WriteDataCompletionBlock)(BOOL success);
+typedef void (^WriteHeadersCompletionBlock)(BOOL success);
+typedef void (^WriteBodyCompletionBlock)(BOOL success);
+
+static NSData* _CRLFData = nil;
+static NSData* _CRLFCRLFData = nil;
+static NSData* _continueData = nil;
+static NSData* _lastChunkData = nil;
+static NSString* _digestAuthenticationNonce = nil;
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+static int32_t _connectionCounter = 0;
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GCDWebServerConnection (Read)
+- (void)readData:(NSMutableData*)data withLength:(NSUInteger)length completionBlock:(ReadDataCompletionBlock)block;
+- (void)readHeaders:(NSMutableData*)headersData withCompletionBlock:(ReadHeadersCompletionBlock)block;
+- (void)readBodyWithRemainingLength:(NSUInteger)length completionBlock:(ReadBodyCompletionBlock)block;
+- (void)readNextBodyChunk:(NSMutableData*)chunkData completionBlock:(ReadBodyCompletionBlock)block;
+@end
+
+@interface GCDWebServerConnection (Write)
+- (void)writeData:(NSData*)data withCompletionBlock:(WriteDataCompletionBlock)block;
+- (void)writeHeadersWithCompletionBlock:(WriteHeadersCompletionBlock)block;
+- (void)writeBodyWithCompletionBlock:(WriteBodyCompletionBlock)block;
+@end
+
+NS_ASSUME_NONNULL_END
+
+@implementation GCDWebServerConnection {
+  CFSocketNativeHandle _socket;
+  BOOL _virtualHEAD;
+
+  CFHTTPMessageRef _requestMessage;
+  GCDWebServerRequest* _request;
+  GCDWebServerHandler* _handler;
+  CFHTTPMessageRef _responseMessage;
+  GCDWebServerResponse* _response;
+  NSInteger _statusCode;
+
+  BOOL _opened;
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  NSUInteger _connectionIndex;
+  NSString* _requestPath;
+  int _requestFD;
+  NSString* _responsePath;
+  int _responseFD;
+#endif
+}
+
++ (void)initialize {
+  if (_CRLFData == nil) {
+    _CRLFData = [[NSData alloc] initWithBytes:"\r\n" length:2];
+    GWS_DCHECK(_CRLFData);
+  }
+  if (_CRLFCRLFData == nil) {
+    _CRLFCRLFData = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
+    GWS_DCHECK(_CRLFCRLFData);
+  }
+  if (_continueData == nil) {
+    CFHTTPMessageRef message = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 100, NULL, kCFHTTPVersion1_1);
+    _continueData = CFBridgingRelease(CFHTTPMessageCopySerializedMessage(message));
+    CFRelease(message);
+    GWS_DCHECK(_continueData);
+  }
+  if (_lastChunkData == nil) {
+    _lastChunkData = [[NSData alloc] initWithBytes:"0\r\n\r\n" length:5];
+  }
+  if (_digestAuthenticationNonce == nil) {
+    CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
+    _digestAuthenticationNonce = GCDWebServerComputeMD5Digest(@"%@", CFBridgingRelease(CFUUIDCreateString(kCFAllocatorDefault, uuid)));
+    CFRelease(uuid);
+  }
+}
+
+- (BOOL)isUsingIPv6 {
+  const struct sockaddr* localSockAddr = _localAddressData.bytes;
+  return (localSockAddr->sa_family == AF_INET6);
+}
+
+- (void)_initializeResponseHeadersWithStatusCode:(NSInteger)statusCode {
+  _statusCode = statusCode;
+  _responseMessage = CFHTTPMessageCreateResponse(kCFAllocatorDefault, statusCode, NULL, kCFHTTPVersion1_1);
+  CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Connection"), CFSTR("Close"));
+  CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Server"), (__bridge CFStringRef)_server.serverName);
+  CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Date"), (__bridge CFStringRef)GCDWebServerFormatRFC822([NSDate date]));
+}
+
+- (void)_startProcessingRequest {
+  GWS_DCHECK(_responseMessage == NULL);
+
+  GCDWebServerResponse* preflightResponse = [self preflightRequest:_request];
+  if (preflightResponse) {
+    [self _finishProcessingRequest:preflightResponse];
+  } else {
+    [self processRequest:_request
+              completion:^(GCDWebServerResponse* processResponse) {
+                [self _finishProcessingRequest:processResponse];
+              }];
+  }
+}
+
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+- (void)_finishProcessingRequest:(GCDWebServerResponse*)response {
+  GWS_DCHECK(_responseMessage == NULL);
+  BOOL hasBody = NO;
+
+  if (response) {
+    response = [self overrideResponse:response forRequest:_request];
+  }
+  if (response) {
+    if ([response hasBody]) {
+      [response prepareForReading];
+      hasBody = !_virtualHEAD;
+    }
+    NSError* error = nil;
+    if (hasBody && ![response performOpen:&error]) {
+      GWS_LOG_ERROR(@"Failed opening response body for socket %i: %@", _socket, error);
+    } else {
+      _response = response;
+    }
+  }
+
+  if (_response) {
+    [self _initializeResponseHeadersWithStatusCode:_response.statusCode];
+    if (_response.lastModifiedDate) {
+      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Last-Modified"), (__bridge CFStringRef)GCDWebServerFormatRFC822((NSDate*)_response.lastModifiedDate));
+    }
+    if (_response.eTag) {
+      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("ETag"), (__bridge CFStringRef)_response.eTag);
+    }
+    if ((_response.statusCode >= 200) && (_response.statusCode < 300)) {
+      if (_response.cacheControlMaxAge > 0) {
+        CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Cache-Control"), (__bridge CFStringRef)[NSString stringWithFormat:@"max-age=%i, public", (int)_response.cacheControlMaxAge]);
+      } else {
+        CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Cache-Control"), CFSTR("no-cache"));
+      }
+    }
+    if (_response.contentType != nil) {
+      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Content-Type"), (__bridge CFStringRef)GCDWebServerNormalizeHeaderValue(_response.contentType));
+    }
+    if (_response.contentLength != NSUIntegerMax) {
+      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Content-Length"), (__bridge CFStringRef)[NSString stringWithFormat:@"%lu", (unsigned long)_response.contentLength]);
+    }
+    if (_response.usesChunkedTransferEncoding) {
+      CFHTTPMessageSetHeaderFieldValue(_responseMessage, CFSTR("Transfer-Encoding"), CFSTR("chunked"));
+    }
+    [_response.additionalHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL* stop) {
+      CFHTTPMessageSetHeaderFieldValue(self->_responseMessage, (__bridge CFStringRef)key, (__bridge CFStringRef)obj);
+    }];
+    [self writeHeadersWithCompletionBlock:^(BOOL success) {
+      if (success) {
+        if (hasBody) {
+          [self writeBodyWithCompletionBlock:^(BOOL successInner) {
+            [self->_response performClose];  // TODO: There's nothing we can do on failure as headers have already been sent
+          }];
+        }
+      } else if (hasBody) {
+        [self->_response performClose];
+      }
+    }];
+  } else {
+    [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+  }
+}
+
+- (void)_readBodyWithLength:(NSUInteger)length initialData:(NSData*)initialData {
+  NSError* error = nil;
+  if (![_request performOpen:&error]) {
+    GWS_LOG_ERROR(@"Failed opening request body for socket %i: %@", _socket, error);
+    [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+    return;
+  }
+
+  if (initialData.length) {
+    if (![_request performWriteData:initialData error:&error]) {
+      GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", _socket, error);
+      if (![_request performClose:&error]) {
+        GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, error);
+      }
+      [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+      return;
+    }
+    length -= initialData.length;
+  }
+
+  if (length) {
+    [self readBodyWithRemainingLength:length
+                      completionBlock:^(BOOL success) {
+                        NSError* localError = nil;
+                        if ([self->_request performClose:&localError]) {
+                          [self _startProcessingRequest];
+                        } else {
+                          GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", self->_socket, error);
+                          [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+                        }
+                      }];
+  } else {
+    if ([_request performClose:&error]) {
+      [self _startProcessingRequest];
+    } else {
+      GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", _socket, error);
+      [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+    }
+  }
+}
+
+- (void)_readChunkedBodyWithInitialData:(NSData*)initialData {
+  NSError* error = nil;
+  if (![_request performOpen:&error]) {
+    GWS_LOG_ERROR(@"Failed opening request body for socket %i: %@", _socket, error);
+    [self abortRequest:_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+    return;
+  }
+
+  NSMutableData* chunkData = [[NSMutableData alloc] initWithData:initialData];
+  [self readNextBodyChunk:chunkData
+          completionBlock:^(BOOL success) {
+            NSError* localError = nil;
+            if ([self->_request performClose:&localError]) {
+              [self _startProcessingRequest];
+            } else {
+              GWS_LOG_ERROR(@"Failed closing request body for socket %i: %@", self->_socket, error);
+              [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+            }
+          }];
+}
+
+- (void)_readRequestHeaders {
+  _requestMessage = CFHTTPMessageCreateEmpty(kCFAllocatorDefault, true);
+  NSMutableData* headersData = [[NSMutableData alloc] initWithCapacity:kHeadersReadCapacity];
+  [self readHeaders:headersData
+      withCompletionBlock:^(NSData* extraData) {
+        if (extraData) {
+          NSString* requestMethod = CFBridgingRelease(CFHTTPMessageCopyRequestMethod(self->_requestMessage));  // Method verbs are case-sensitive and uppercase
+          if (self->_server.shouldAutomaticallyMapHEADToGET && [requestMethod isEqualToString:@"HEAD"]) {
+            requestMethod = @"GET";
+            self->_virtualHEAD = YES;
+          }
+          NSDictionary* requestHeaders = CFBridgingRelease(CFHTTPMessageCopyAllHeaderFields(self->_requestMessage));  // Header names are case-insensitive but CFHTTPMessageCopyAllHeaderFields() will standardize the common ones
+          NSURL* requestURL = CFBridgingRelease(CFHTTPMessageCopyRequestURL(self->_requestMessage));
+          if (requestURL) {
+            requestURL = [self rewriteRequestURL:requestURL withMethod:requestMethod headers:requestHeaders];
+            GWS_DCHECK(requestURL);
+          }
+          NSString* urlPath = requestURL ? CFBridgingRelease(CFURLCopyPath((CFURLRef)requestURL)) : nil;  // Don't use -[NSURL path] which strips the ending slash
+          if (urlPath == nil) {
+            urlPath = @"/";  // CFURLCopyPath() returns NULL for a relative URL with path "//" contrary to -[NSURL path] which returns "/"
+          }
+          NSString* requestPath = urlPath ? GCDWebServerUnescapeURLString(urlPath) : nil;
+          NSString* queryString = requestURL ? CFBridgingRelease(CFURLCopyQueryString((CFURLRef)requestURL, NULL)) : nil;  // Don't use -[NSURL query] to make sure query is not unescaped;
+          NSDictionary* requestQuery = queryString ? GCDWebServerParseURLEncodedForm(queryString) : @{};
+          if (requestMethod && requestURL && requestHeaders && requestPath && requestQuery) {
+            for (self->_handler in self->_server.handlers) {
+              self->_request = self->_handler.matchBlock(requestMethod, requestURL, requestHeaders, requestPath, requestQuery);
+              if (self->_request) {
+                break;
+              }
+            }
+            if (self->_request) {
+              self->_request.localAddressData = self.localAddressData;
+              self->_request.remoteAddressData = self.remoteAddressData;
+              if ([self->_request hasBody]) {
+                [self->_request prepareForWriting];
+                if (self->_request.usesChunkedTransferEncoding || (extraData.length <= self->_request.contentLength)) {
+                  NSString* expectHeader = [requestHeaders objectForKey:@"Expect"];
+                  if (expectHeader) {
+                    if ([expectHeader caseInsensitiveCompare:@"100-continue"] == NSOrderedSame) {  // TODO: Actually validate request before continuing
+                      [self writeData:_continueData
+                          withCompletionBlock:^(BOOL success) {
+                            if (success) {
+                              if (self->_request.usesChunkedTransferEncoding) {
+                                [self _readChunkedBodyWithInitialData:extraData];
+                              } else {
+                                [self _readBodyWithLength:self->_request.contentLength initialData:extraData];
+                              }
+                            }
+                          }];
+                    } else {
+                      GWS_LOG_ERROR(@"Unsupported 'Expect' / 'Content-Length' header combination on socket %i", self->_socket);
+                      [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_ExpectationFailed];
+                    }
+                  } else {
+                    if (self->_request.usesChunkedTransferEncoding) {
+                      [self _readChunkedBodyWithInitialData:extraData];
+                    } else {
+                      [self _readBodyWithLength:self->_request.contentLength initialData:extraData];
+                    }
+                  }
+                } else {
+                  GWS_LOG_ERROR(@"Unexpected 'Content-Length' header value on socket %i", self->_socket);
+                  [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_BadRequest];
+                }
+              } else {
+                [self _startProcessingRequest];
+              }
+            } else {
+              self->_request = [[GCDWebServerRequest alloc] initWithMethod:requestMethod url:requestURL headers:requestHeaders path:requestPath query:requestQuery];
+              GWS_DCHECK(self->_request);
+              [self abortRequest:self->_request withStatusCode:kGCDWebServerHTTPStatusCode_NotImplemented];
+            }
+          } else {
+            [self abortRequest:nil withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+            GWS_DNOT_REACHED();
+          }
+        } else {
+          [self abortRequest:nil withStatusCode:kGCDWebServerHTTPStatusCode_InternalServerError];
+        }
+      }];
+}
+
+- (instancetype)initWithServer:(GCDWebServer*)server localAddress:(NSData*)localAddress remoteAddress:(NSData*)remoteAddress socket:(CFSocketNativeHandle)socket {
+  if ((self = [super init])) {
+    _server = server;
+    _localAddressData = localAddress;
+    _remoteAddressData = remoteAddress;
+    _socket = socket;
+    GWS_LOG_DEBUG(@"Did open connection on socket %i", _socket);
+
+    [_server willStartConnection:self];
+
+    if (![self open]) {
+      close(_socket);
+      return nil;
+    }
+    _opened = YES;
+
+    [self _readRequestHeaders];
+  }
+  return self;
+}
+
+- (NSString*)localAddressString {
+  return GCDWebServerStringFromSockAddr(_localAddressData.bytes, YES);
+}
+
+- (NSString*)remoteAddressString {
+  return GCDWebServerStringFromSockAddr(_remoteAddressData.bytes, YES);
+}
+
+- (void)dealloc {
+  int result = close(_socket);
+  if (result != 0) {
+    GWS_LOG_ERROR(@"Failed closing socket %i for connection: %s (%i)", _socket, strerror(errno), errno);
+  } else {
+    GWS_LOG_DEBUG(@"Did close connection on socket %i", _socket);
+  }
+
+  if (_opened) {
+    [self close];
+  }
+
+  [_server didEndConnection:self];
+
+  if (_requestMessage) {
+    CFRelease(_requestMessage);
+  }
+
+  if (_responseMessage) {
+    CFRelease(_responseMessage);
+  }
+}
+
+@end
+
+@implementation GCDWebServerConnection (Read)
+
+- (void)readData:(NSMutableData*)data withLength:(NSUInteger)length completionBlock:(ReadDataCompletionBlock)block {
+  dispatch_read(_socket, length, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^(dispatch_data_t buffer, int error) {
+    @autoreleasepool {
+      if (error == 0) {
+        size_t size = dispatch_data_get_size(buffer);
+        if (size > 0) {
+          NSUInteger originalLength = data.length;
+          dispatch_data_apply(buffer, ^bool(dispatch_data_t region, size_t chunkOffset, const void* chunkBytes, size_t chunkSize) {
+            [data appendBytes:chunkBytes length:chunkSize];
+            return true;
+          });
+          [self didReadBytes:((char*)data.bytes + originalLength) length:(data.length - originalLength)];
+          block(YES);
+        } else {
+          if (self->_totalBytesRead > 0) {
+            GWS_LOG_ERROR(@"No more data available on socket %i", self->_socket);
+          } else {
+            GWS_LOG_WARNING(@"No data received from socket %i", self->_socket);
+          }
+          block(NO);
+        }
+      } else {
+        GWS_LOG_ERROR(@"Error while reading from socket %i: %s (%i)", self->_socket, strerror(error), error);
+        block(NO);
+      }
+    }
+  });
+}
+
+- (void)readHeaders:(NSMutableData*)headersData withCompletionBlock:(ReadHeadersCompletionBlock)block {
+  GWS_DCHECK(_requestMessage);
+  [self readData:headersData
+           withLength:NSUIntegerMax
+      completionBlock:^(BOOL success) {
+        if (success) {
+          NSRange range = [headersData rangeOfData:_CRLFCRLFData options:0 range:NSMakeRange(0, headersData.length)];
+          if (range.location == NSNotFound) {
+            [self readHeaders:headersData withCompletionBlock:block];
+          } else {
+            NSUInteger length = range.location + range.length;
+            if (CFHTTPMessageAppendBytes(self->_requestMessage, headersData.bytes, length)) {
+              if (CFHTTPMessageIsHeaderComplete(self->_requestMessage)) {
+                block([headersData subdataWithRange:NSMakeRange(length, headersData.length - length)]);
+              } else {
+                GWS_LOG_ERROR(@"Failed parsing request headers from socket %i", self->_socket);
+                block(nil);
+              }
+            } else {
+              GWS_LOG_ERROR(@"Failed appending request headers data from socket %i", self->_socket);
+              block(nil);
+            }
+          }
+        } else {
+          block(nil);
+        }
+      }];
+}
+
+- (void)readBodyWithRemainingLength:(NSUInteger)length completionBlock:(ReadBodyCompletionBlock)block {
+  GWS_DCHECK([_request hasBody] && ![_request usesChunkedTransferEncoding]);
+  NSMutableData* bodyData = [[NSMutableData alloc] initWithCapacity:kBodyReadCapacity];
+  [self readData:bodyData
+           withLength:length
+      completionBlock:^(BOOL success) {
+        if (success) {
+          if (bodyData.length <= length) {
+            NSError* error = nil;
+            if ([self->_request performWriteData:bodyData error:&error]) {
+              NSUInteger remainingLength = length - bodyData.length;
+              if (remainingLength) {
+                [self readBodyWithRemainingLength:remainingLength completionBlock:block];
+              } else {
+                block(YES);
+              }
+            } else {
+              GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", self->_socket, error);
+              block(NO);
+            }
+          } else {
+            GWS_LOG_ERROR(@"Unexpected extra content reading request body on socket %i", self->_socket);
+            block(NO);
+            GWS_DNOT_REACHED();
+          }
+        } else {
+          block(NO);
+        }
+      }];
+}
+
+static inline NSUInteger _ScanHexNumber(const void* bytes, NSUInteger size) {
+  char buffer[size + 1];
+  bcopy(bytes, buffer, size);
+  buffer[size] = 0;
+  char* end = NULL;
+  long result = strtol(buffer, &end, 16);
+  return ((end != NULL) && (*end == 0) && (result >= 0) ? result : NSNotFound);
+}
+
+- (void)readNextBodyChunk:(NSMutableData*)chunkData completionBlock:(ReadBodyCompletionBlock)block {
+  GWS_DCHECK([_request hasBody] && [_request usesChunkedTransferEncoding]);
+
+  while (1) {
+    NSRange range = [chunkData rangeOfData:_CRLFData options:0 range:NSMakeRange(0, chunkData.length)];
+    if (range.location == NSNotFound) {
+      break;
+    }
+    NSRange extensionRange = [chunkData rangeOfData:[NSData dataWithBytes:";" length:1] options:0 range:NSMakeRange(0, range.location)];  // Ignore chunk extensions
+    NSUInteger length = _ScanHexNumber((char*)chunkData.bytes, extensionRange.location != NSNotFound ? extensionRange.location : range.location);
+    if (length != NSNotFound) {
+      if (length) {
+        if (chunkData.length < range.location + range.length + length + 2) {
+          break;
+        }
+        const char* ptr = (char*)chunkData.bytes + range.location + range.length + length;
+        if ((*ptr == '\r') && (*(ptr + 1) == '\n')) {
+          NSError* error = nil;
+          if ([_request performWriteData:[chunkData subdataWithRange:NSMakeRange(range.location + range.length, length)] error:&error]) {
+            [chunkData replaceBytesInRange:NSMakeRange(0, range.location + range.length + length + 2) withBytes:NULL length:0];
+          } else {
+            GWS_LOG_ERROR(@"Failed writing request body on socket %i: %@", _socket, error);
+            block(NO);
+            return;
+          }
+        } else {
+          GWS_LOG_ERROR(@"Missing terminating CRLF sequence for chunk reading request body on socket %i", _socket);
+          block(NO);
+          return;
+        }
+      } else {
+        NSRange trailerRange = [chunkData rangeOfData:_CRLFCRLFData options:0 range:NSMakeRange(range.location, chunkData.length - range.location)];  // Ignore trailers
+        if (trailerRange.location != NSNotFound) {
+          block(YES);
+          return;
+        }
+      }
+    } else {
+      GWS_LOG_ERROR(@"Invalid chunk length reading request body on socket %i", _socket);
+      block(NO);
+      return;
+    }
+  }
+
+  [self readData:chunkData
+           withLength:NSUIntegerMax
+      completionBlock:^(BOOL success) {
+        if (success) {
+          [self readNextBodyChunk:chunkData completionBlock:block];
+        } else {
+          block(NO);
+        }
+      }];
+}
+
+@end
+
+@implementation GCDWebServerConnection (Write)
+
+- (void)writeData:(NSData*)data withCompletionBlock:(WriteDataCompletionBlock)block {
+  dispatch_data_t buffer = dispatch_data_create(data.bytes, data.length, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^{
+    [data self];  // Keeps ARC from releasing data too early
+  });
+  dispatch_write(_socket, buffer, dispatch_get_global_queue(_server.dispatchQueuePriority, 0), ^(dispatch_data_t remainingData, int error) {
+    @autoreleasepool {
+      if (error == 0) {
+        GWS_DCHECK(remainingData == NULL);
+        [self didWriteBytes:data.bytes length:data.length];
+        block(YES);
+      } else {
+        GWS_LOG_ERROR(@"Error while writing to socket %i: %s (%i)", self->_socket, strerror(error), error);
+        block(NO);
+      }
+    }
+  });
+#if !OS_OBJECT_USE_OBJC_RETAIN_RELEASE
+  dispatch_release(buffer);
+#endif
+}
+
+- (void)writeHeadersWithCompletionBlock:(WriteHeadersCompletionBlock)block {
+  GWS_DCHECK(_responseMessage);
+  CFDataRef data = CFHTTPMessageCopySerializedMessage(_responseMessage);
+  [self writeData:(__bridge NSData*)data withCompletionBlock:block];
+  CFRelease(data);
+}
+
+- (void)writeBodyWithCompletionBlock:(WriteBodyCompletionBlock)block {
+  GWS_DCHECK([_response hasBody]);
+  [_response performReadDataWithCompletion:^(NSData* data, NSError* error) {
+    if (data) {
+      if (data.length) {
+        if (self->_response.usesChunkedTransferEncoding) {
+          const char* hexString = [[NSString stringWithFormat:@"%lx", (unsigned long)data.length] UTF8String];
+          size_t hexLength = strlen(hexString);
+          NSData* chunk = [NSMutableData dataWithLength:(hexLength + 2 + data.length + 2)];
+          if (chunk == nil) {
+            GWS_LOG_ERROR(@"Failed allocating memory for response body chunk for socket %i: %@", self->_socket, error);
+            block(NO);
+            return;
+          }
+          char* ptr = (char*)[(NSMutableData*)chunk mutableBytes];
+          bcopy(hexString, ptr, hexLength);
+          ptr += hexLength;
+          *ptr++ = '\r';
+          *ptr++ = '\n';
+          bcopy(data.bytes, ptr, data.length);
+          ptr += data.length;
+          *ptr++ = '\r';
+          *ptr = '\n';
+          data = chunk;
+        }
+        [self writeData:data
+            withCompletionBlock:^(BOOL success) {
+              if (success) {
+                [self writeBodyWithCompletionBlock:block];
+              } else {
+                block(NO);
+              }
+            }];
+      } else {
+        if (self->_response.usesChunkedTransferEncoding) {
+          [self writeData:_lastChunkData
+              withCompletionBlock:^(BOOL success) {
+                block(success);
+              }];
+        } else {
+          block(YES);
+        }
+      }
+    } else {
+      GWS_LOG_ERROR(@"Failed reading response body for socket %i: %@", self->_socket, error);
+      block(NO);
+    }
+  }];
+}
+
+@end
+
+@implementation GCDWebServerConnection (Subclassing)
+
+- (BOOL)open {
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  if (_server.recordingEnabled) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    _connectionIndex = OSAtomicIncrement32(&_connectionCounter);
+#pragma clang diagnostic pop
+
+    _requestPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+    _requestFD = open([_requestPath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    GWS_DCHECK(_requestFD > 0);
+
+    _responsePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+    _responseFD = open([_responsePath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    GWS_DCHECK(_responseFD > 0);
+  }
+#endif
+
+  return YES;
+}
+
+- (void)didReadBytes:(const void*)bytes length:(NSUInteger)length {
+  GWS_LOG_DEBUG(@"Connection received %lu bytes on socket %i", (unsigned long)length, _socket);
+  _totalBytesRead += length;
+
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  if ((_requestFD > 0) && (write(_requestFD, bytes, length) != (ssize_t)length)) {
+    GWS_LOG_ERROR(@"Failed recording request data: %s (%i)", strerror(errno), errno);
+    close(_requestFD);
+    _requestFD = 0;
+  }
+#endif
+}
+
+- (void)didWriteBytes:(const void*)bytes length:(NSUInteger)length {
+  GWS_LOG_DEBUG(@"Connection sent %lu bytes on socket %i", (unsigned long)length, _socket);
+  _totalBytesWritten += length;
+
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  if ((_responseFD > 0) && (write(_responseFD, bytes, length) != (ssize_t)length)) {
+    GWS_LOG_ERROR(@"Failed recording response data: %s (%i)", strerror(errno), errno);
+    close(_responseFD);
+    _responseFD = 0;
+  }
+#endif
+}
+
+- (NSURL*)rewriteRequestURL:(NSURL*)url withMethod:(NSString*)method headers:(NSDictionary<NSString*, NSString*>*)headers {
+  return url;
+}
+
+// https://tools.ietf.org/html/rfc2617
+- (GCDWebServerResponse*)preflightRequest:(GCDWebServerRequest*)request {
+  GWS_LOG_DEBUG(@"Connection on socket %i preflighting request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
+  GCDWebServerResponse* response = nil;
+  if (_server.authenticationBasicAccounts) {
+    __block BOOL authenticated = NO;
+    NSString* authorizationHeader = [request.headers objectForKey:@"Authorization"];
+    if ([authorizationHeader hasPrefix:@"Basic "]) {
+      NSString* basicAccount = [authorizationHeader substringFromIndex:6];
+      [_server.authenticationBasicAccounts enumerateKeysAndObjectsUsingBlock:^(NSString* username, NSString* digest, BOOL* stop) {
+        if ([basicAccount isEqualToString:digest]) {
+          authenticated = YES;
+          *stop = YES;
+        }
+      }];
+    }
+    if (!authenticated) {
+      response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Unauthorized];
+      [response setValue:[NSString stringWithFormat:@"Basic realm=\"%@\"", _server.authenticationRealm] forAdditionalHeader:@"WWW-Authenticate"];
+    }
+  } else if (_server.authenticationDigestAccounts) {
+    BOOL authenticated = NO;
+    BOOL isStaled = NO;
+    NSString* authorizationHeader = [request.headers objectForKey:@"Authorization"];
+    if ([authorizationHeader hasPrefix:@"Digest "]) {
+      NSString* realm = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"realm");
+      if (realm && [_server.authenticationRealm isEqualToString:realm]) {
+        NSString* nonce = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"nonce");
+        if ([nonce isEqualToString:_digestAuthenticationNonce]) {
+          NSString* username = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"username");
+          NSString* uri = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"uri");
+          NSString* actualResponse = GCDWebServerExtractHeaderValueParameter(authorizationHeader, @"response");
+          NSString* ha1 = [_server.authenticationDigestAccounts objectForKey:username];
+          NSString* ha2 = GCDWebServerComputeMD5Digest(@"%@:%@", request.method, uri);  // We cannot use "request.path" as the query string is required
+          NSString* expectedResponse = GCDWebServerComputeMD5Digest(@"%@:%@:%@", ha1, _digestAuthenticationNonce, ha2);
+          if ([actualResponse isEqualToString:expectedResponse]) {
+            authenticated = YES;
+          }
+        } else if (nonce.length) {
+          isStaled = YES;
+        }
+      }
+    }
+    if (!authenticated) {
+      response = [GCDWebServerResponse responseWithStatusCode:kGCDWebServerHTTPStatusCode_Unauthorized];
+      [response setValue:[NSString stringWithFormat:@"Digest realm=\"%@\", nonce=\"%@\"%@", _server.authenticationRealm, _digestAuthenticationNonce, isStaled ? @", stale=TRUE" : @""] forAdditionalHeader:@"WWW-Authenticate"];  // TODO: Support Quality of Protection ("qop")
+    }
+  }
+  return response;
+}
+
+- (void)processRequest:(GCDWebServerRequest*)request completion:(GCDWebServerCompletionBlock)completion {
+  GWS_LOG_DEBUG(@"Connection on socket %i processing request \"%@ %@\" with %lu bytes body", _socket, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead);
+  _handler.asyncProcessBlock(request, [completion copy]);
+}
+
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.26
+static inline BOOL _CompareResources(NSString* responseETag, NSString* requestETag, NSDate* responseLastModified, NSDate* requestLastModified) {
+  if (requestLastModified && responseLastModified) {
+    if ([responseLastModified compare:requestLastModified] != NSOrderedDescending) {
+      return YES;
+    }
+  }
+  if (requestETag && responseETag) {  // Per the specs "If-None-Match" must be checked after "If-Modified-Since"
+    if ([requestETag isEqualToString:@"*"]) {
+      return YES;
+    }
+    if ([responseETag isEqualToString:requestETag]) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
+- (GCDWebServerResponse*)overrideResponse:(GCDWebServerResponse*)response forRequest:(GCDWebServerRequest*)request {
+  if ((response.statusCode >= 200) && (response.statusCode < 300) && _CompareResources(response.eTag, request.ifNoneMatch, response.lastModifiedDate, request.ifModifiedSince)) {
+    NSInteger code = [request.method isEqualToString:@"HEAD"] || [request.method isEqualToString:@"GET"] ? kGCDWebServerHTTPStatusCode_NotModified : kGCDWebServerHTTPStatusCode_PreconditionFailed;
+    GCDWebServerResponse* newResponse = [GCDWebServerResponse responseWithStatusCode:code];
+    newResponse.cacheControlMaxAge = response.cacheControlMaxAge;
+    newResponse.lastModifiedDate = response.lastModifiedDate;
+    newResponse.eTag = response.eTag;
+    GWS_DCHECK(newResponse);
+    return newResponse;
+  }
+  return response;
+}
+
+- (void)abortRequest:(GCDWebServerRequest*)request withStatusCode:(NSInteger)statusCode {
+  GWS_DCHECK(_responseMessage == NULL);
+  GWS_DCHECK((statusCode >= 400) && (statusCode < 600));
+  [self _initializeResponseHeadersWithStatusCode:statusCode];
+  [self writeHeadersWithCompletionBlock:^(BOOL success){
+      // Nothing more to do
+  }];
+  GWS_LOG_DEBUG(@"Connection aborted with status code %i on socket %i", (int)statusCode, _socket);
+}
+
+- (void)close {
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  if (_requestPath) {
+    BOOL success = NO;
+    NSError* error = nil;
+    if (_requestFD > 0) {
+      close(_requestFD);
+      NSString* name = [NSString stringWithFormat:@"%03lu-%@.request", (unsigned long)_connectionIndex, _virtualHEAD ? @"HEAD" : _request.method];
+      success = [[NSFileManager defaultManager] moveItemAtPath:_requestPath toPath:[[[NSFileManager defaultManager] currentDirectoryPath] stringByAppendingPathComponent:name] error:&error];
+    }
+    if (!success) {
+      GWS_LOG_ERROR(@"Failed saving recorded request: %@", error);
+      GWS_DNOT_REACHED();
+    }
+    unlink([_requestPath fileSystemRepresentation]);
+  }
+
+  if (_responsePath) {
+    BOOL success = NO;
+    NSError* error = nil;
+    if (_responseFD > 0) {
+      close(_responseFD);
+      NSString* name = [NSString stringWithFormat:@"%03lu-%i.response", (unsigned long)_connectionIndex, (int)_statusCode];
+      success = [[NSFileManager defaultManager] moveItemAtPath:_responsePath toPath:[[[NSFileManager defaultManager] currentDirectoryPath] stringByAppendingPathComponent:name] error:&error];
+    }
+    if (!success) {
+      GWS_LOG_ERROR(@"Failed saving recorded response: %@", error);
+      GWS_DNOT_REACHED();
+    }
+    unlink([_responsePath fileSystemRepresentation]);
+  }
+#endif
+
+  if (_request) {
+    GWS_LOG_VERBOSE(@"[%@] %@ %i \"%@ %@\" (%lu | %lu)", self.localAddressString, self.remoteAddressString, (int)_statusCode, _virtualHEAD ? @"HEAD" : _request.method, _request.path, (unsigned long)_totalBytesRead, (unsigned long)_totalBytesWritten);
+  } else {
+    GWS_LOG_VERBOSE(@"[%@] %@ %i \"(invalid request)\" (%lu | %lu)", self.localAddressString, self.remoteAddressString, (int)_statusCode, (unsigned long)_totalBytesRead, (unsigned long)_totalBytesWritten);
+  }
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerFunctions.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerFunctions.h
@@ -1,0 +1,114 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ *  Converts a file extension to the corresponding MIME type.
+ *  If there is no match, "application/octet-stream" is returned.
+ *
+ *  Overrides allow to customize the built-in mapping from extensions to MIME
+ *  types. Keys of the dictionary must be lowercased file extensions without
+ *  the period, and the values must be the corresponding MIME types.
+ */
+NSString* GCDWebServerGetMimeTypeForExtension(NSString* extension, NSDictionary<NSString*, NSString*>* _Nullable overrides);
+
+/**
+ *  Add percent-escapes to a string so it can be used in a URL.
+ *  The legal characters ":@/?&=+" are also escaped to ensure compatibility
+ *  with URL encoded forms and URL queries.
+ */
+NSString* _Nullable GCDWebServerEscapeURLString(NSString* string);
+
+/**
+ *  Unescapes a URL percent-encoded string.
+ */
+NSString* _Nullable GCDWebServerUnescapeURLString(NSString* string);
+
+/**
+ *  Extracts the unescaped names and values from an
+ *  "application/x-www-form-urlencoded" form.
+ *  http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1
+ */
+NSDictionary<NSString*, NSString*>* GCDWebServerParseURLEncodedForm(NSString* form);
+
+/**
+ *  On OS X, returns the IPv4 or IPv6 address as a string of the primary
+ *  connected service or nil if not available.
+ *  
+ *  On iOS, returns the IPv4 or IPv6 address as a string of the WiFi
+ *  interface if connected or nil otherwise.
+ */
+NSString* _Nullable GCDWebServerGetPrimaryIPAddress(BOOL useIPv6);
+
+/**
+ *  Converts a date into a string using RFC822 formatting.
+ *  https://tools.ietf.org/html/rfc822#section-5
+ *  https://tools.ietf.org/html/rfc1123#section-5.2.14
+ */
+NSString* GCDWebServerFormatRFC822(NSDate* date);
+
+/**
+ *  Converts a RFC822 formatted string into a date.
+ *  https://tools.ietf.org/html/rfc822#section-5
+ *  https://tools.ietf.org/html/rfc1123#section-5.2.14
+ *
+ *  @warning Timezones other than GMT are not supported by this function.
+ */
+NSDate* _Nullable GCDWebServerParseRFC822(NSString* string);
+
+/**
+ *  Converts a date into a string using IOS 8601 formatting.
+ *  http://tools.ietf.org/html/rfc3339#section-5.6
+ */
+NSString* GCDWebServerFormatISO8601(NSDate* date);
+
+/**
+ *  Converts a ISO 8601 formatted string into a date.
+ *  http://tools.ietf.org/html/rfc3339#section-5.6
+ *
+ *  @warning Only "calendar" variant is supported at this time and timezones
+ *  other than GMT are not supported either.
+ */
+NSDate* _Nullable GCDWebServerParseISO8601(NSString* string);
+
+/**
+ *  Removes "//", "/./" and "/../" components from path as well as any trailing slash.
+ */
+NSString* GCDWebServerNormalizePath(NSString* path);
+
+#ifdef __cplusplus
+}
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerFunctions.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerFunctions.m
@@ -1,0 +1,340 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import <TargetConditionals.h>
+#if TARGET_OS_IPHONE
+#import <CoreServices/CoreServices.h>
+#else
+#import <SystemConfiguration/SystemConfiguration.h>
+#endif
+#import <CommonCrypto/CommonDigest.h>
+
+#import <ifaddrs.h>
+#import <net/if.h>
+#import <netdb.h>
+
+#import "GCDWebServerPrivate.h"
+
+static NSDateFormatter* _dateFormatterRFC822 = nil;
+static NSDateFormatter* _dateFormatterISO8601 = nil;
+static dispatch_queue_t _dateFormatterQueue = NULL;
+
+// TODO: Handle RFC 850 and ANSI C's asctime() format
+void GCDWebServerInitializeFunctions() {
+  GWS_DCHECK([NSThread isMainThread]);  // NSDateFormatter should be initialized on main thread
+  if (_dateFormatterRFC822 == nil) {
+    _dateFormatterRFC822 = [[NSDateFormatter alloc] init];
+    _dateFormatterRFC822.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+    _dateFormatterRFC822.dateFormat = @"EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'";
+    _dateFormatterRFC822.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+    GWS_DCHECK(_dateFormatterRFC822);
+  }
+  if (_dateFormatterISO8601 == nil) {
+    _dateFormatterISO8601 = [[NSDateFormatter alloc] init];
+    _dateFormatterISO8601.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+    _dateFormatterISO8601.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'+00:00'";
+    _dateFormatterISO8601.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+    GWS_DCHECK(_dateFormatterISO8601);
+  }
+  if (_dateFormatterQueue == NULL) {
+    _dateFormatterQueue = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
+    GWS_DCHECK(_dateFormatterQueue);
+  }
+}
+
+NSString* GCDWebServerNormalizeHeaderValue(NSString* value) {
+  if (value) {
+    NSRange range = [value rangeOfString:@";"];  // Assume part before ";" separator is case-insensitive
+    if (range.location != NSNotFound) {
+      value = [[[value substringToIndex:range.location] lowercaseString] stringByAppendingString:[value substringFromIndex:range.location]];
+    } else {
+      value = [value lowercaseString];
+    }
+  }
+  return value;
+}
+
+NSString* GCDWebServerTruncateHeaderValue(NSString* value) {
+  if (value) {
+    NSRange range = [value rangeOfString:@";"];
+    if (range.location != NSNotFound) {
+      return [value substringToIndex:range.location];
+    }
+  }
+  return value;
+}
+
+NSString* GCDWebServerExtractHeaderValueParameter(NSString* value, NSString* name) {
+  NSString* parameter = nil;
+  if (value) {
+    NSScanner* scanner = [[NSScanner alloc] initWithString:value];
+    [scanner setCaseSensitive:NO];  // Assume parameter names are case-insensitive
+    NSString* string = [NSString stringWithFormat:@"%@=", name];
+    if ([scanner scanUpToString:string intoString:NULL]) {
+      [scanner scanString:string intoString:NULL];
+      if ([scanner scanString:@"\"" intoString:NULL]) {
+        [scanner scanUpToString:@"\"" intoString:&parameter];
+      } else {
+        [scanner scanUpToCharactersFromSet:[NSCharacterSet whitespaceCharacterSet] intoString:&parameter];
+      }
+    }
+  }
+  return parameter;
+}
+
+// http://www.w3schools.com/tags/ref_charactersets.asp
+NSStringEncoding GCDWebServerStringEncodingFromCharset(NSString* charset) {
+  NSStringEncoding encoding = kCFStringEncodingInvalidId;
+  if (charset) {
+    encoding = CFStringConvertEncodingToNSStringEncoding(CFStringConvertIANACharSetNameToEncoding((CFStringRef)charset));
+  }
+  return (encoding != kCFStringEncodingInvalidId ? encoding : NSUTF8StringEncoding);
+}
+
+NSString* GCDWebServerFormatRFC822(NSDate* date) {
+  __block NSString* string;
+  dispatch_sync(_dateFormatterQueue, ^{
+    string = [_dateFormatterRFC822 stringFromDate:date];
+  });
+  return string;
+}
+
+NSDate* GCDWebServerParseRFC822(NSString* string) {
+  __block NSDate* date;
+  dispatch_sync(_dateFormatterQueue, ^{
+    date = [_dateFormatterRFC822 dateFromString:string];
+  });
+  return date;
+}
+
+NSString* GCDWebServerFormatISO8601(NSDate* date) {
+  __block NSString* string;
+  dispatch_sync(_dateFormatterQueue, ^{
+    string = [_dateFormatterISO8601 stringFromDate:date];
+  });
+  return string;
+}
+
+NSDate* GCDWebServerParseISO8601(NSString* string) {
+  __block NSDate* date;
+  dispatch_sync(_dateFormatterQueue, ^{
+    date = [_dateFormatterISO8601 dateFromString:string];
+  });
+  return date;
+}
+
+BOOL GCDWebServerIsTextContentType(NSString* type) {
+  return ([type hasPrefix:@"text/"] || [type hasPrefix:@"application/json"] || [type hasPrefix:@"application/xml"]);
+}
+
+NSString* GCDWebServerDescribeData(NSData* data, NSString* type) {
+  if (GCDWebServerIsTextContentType(type)) {
+    NSString* charset = GCDWebServerExtractHeaderValueParameter(type, @"charset");
+    NSString* string = [[NSString alloc] initWithData:data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+    if (string) {
+      return string;
+    }
+  }
+  return [NSString stringWithFormat:@"<%lu bytes>", (unsigned long)data.length];
+}
+
+NSString* GCDWebServerGetMimeTypeForExtension(NSString* extension, NSDictionary<NSString*, NSString*>* overrides) {
+  NSDictionary* builtInOverrides = @{@"css" : @"text/css"};
+  NSString* mimeType = nil;
+  extension = [extension lowercaseString];
+  if (extension.length) {
+    mimeType = [overrides objectForKey:extension];
+    if (mimeType == nil) {
+      mimeType = [builtInOverrides objectForKey:extension];
+    }
+    if (mimeType == nil) {
+      CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
+      if (uti) {
+        mimeType = CFBridgingRelease(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
+        CFRelease(uti);
+      }
+    }
+  }
+  return mimeType ? mimeType : kGCDWebServerDefaultMimeType;
+}
+
+NSString* GCDWebServerEscapeURLString(NSString* string) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  return CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (CFStringRef)string, NULL, CFSTR(":@/?&=+"), kCFStringEncodingUTF8));
+#pragma clang diagnostic pop
+}
+
+NSString* GCDWebServerUnescapeURLString(NSString* string) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  return CFBridgingRelease(CFURLCreateStringByReplacingPercentEscapesUsingEncoding(kCFAllocatorDefault, (CFStringRef)string, CFSTR(""), kCFStringEncodingUTF8));
+#pragma clang diagnostic pop
+}
+
+NSDictionary<NSString*, NSString*>* GCDWebServerParseURLEncodedForm(NSString* form) {
+  NSMutableDictionary* parameters = [NSMutableDictionary dictionary];
+  NSScanner* scanner = [[NSScanner alloc] initWithString:form];
+  [scanner setCharactersToBeSkipped:nil];
+  while (1) {
+    NSString* key = nil;
+    if (![scanner scanUpToString:@"=" intoString:&key] || [scanner isAtEnd]) {
+      break;
+    }
+    [scanner setScanLocation:([scanner scanLocation] + 1)];
+
+    NSString* value = nil;
+    [scanner scanUpToString:@"&" intoString:&value];
+    if (value == nil) {
+      value = @"";
+    }
+
+    key = [key stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+    NSString* unescapedKey = key ? GCDWebServerUnescapeURLString(key) : nil;
+    value = [value stringByReplacingOccurrencesOfString:@"+" withString:@" "];
+    NSString* unescapedValue = value ? GCDWebServerUnescapeURLString(value) : nil;
+    if (unescapedKey && unescapedValue) {
+      [parameters setObject:unescapedValue forKey:unescapedKey];
+    } else {
+      GWS_LOG_WARNING(@"Failed parsing URL encoded form for key \"%@\" and value \"%@\"", key, value);
+      GWS_DNOT_REACHED();
+    }
+
+    if ([scanner isAtEnd]) {
+      break;
+    }
+    [scanner setScanLocation:([scanner scanLocation] + 1)];
+  }
+  return parameters;
+}
+
+NSString* GCDWebServerStringFromSockAddr(const struct sockaddr* addr, BOOL includeService) {
+  char hostBuffer[NI_MAXHOST];
+  char serviceBuffer[NI_MAXSERV];
+  if (getnameinfo(addr, addr->sa_len, hostBuffer, sizeof(hostBuffer), serviceBuffer, sizeof(serviceBuffer), NI_NUMERICHOST | NI_NUMERICSERV | NI_NOFQDN) != 0) {
+#if DEBUG
+    GWS_DNOT_REACHED();
+#else
+    return @"";
+#endif
+  }
+  return includeService ? [NSString stringWithFormat:@"%s:%s", hostBuffer, serviceBuffer] : (NSString*)[NSString stringWithUTF8String:hostBuffer];
+}
+
+NSString* GCDWebServerGetPrimaryIPAddress(BOOL useIPv6) {
+  NSString* address = nil;
+#if TARGET_OS_IPHONE
+#if !TARGET_IPHONE_SIMULATOR && !TARGET_OS_TV
+  const char* primaryInterface = "en0";  // WiFi interface on iOS
+#endif
+#else
+  const char* primaryInterface = NULL;
+  SCDynamicStoreRef store = SCDynamicStoreCreate(kCFAllocatorDefault, CFSTR("GCDWebServer"), NULL, NULL);
+  if (store) {
+    CFPropertyListRef info = SCDynamicStoreCopyValue(store, CFSTR("State:/Network/Global/IPv4"));  // There is no equivalent for IPv6 but the primary interface should be the same
+    if (info) {
+      NSString* interface = [(__bridge NSDictionary*)info objectForKey:@"PrimaryInterface"];
+      if (interface) {
+        primaryInterface = [[NSString stringWithString:interface] UTF8String];  // Copy string to auto-release pool
+      }
+      CFRelease(info);
+    }
+    CFRelease(store);
+  }
+  if (primaryInterface == NULL) {
+    primaryInterface = "lo0";
+  }
+#endif
+  struct ifaddrs* list;
+  if (getifaddrs(&list) >= 0) {
+    for (struct ifaddrs* ifap = list; ifap; ifap = ifap->ifa_next) {
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_TV
+      // Assume en0 is Ethernet and en1 is WiFi since there is no way to use SystemConfiguration framework in iOS Simulator
+      // Assumption holds for Apple TV running tvOS
+      if (strcmp(ifap->ifa_name, "en0") && strcmp(ifap->ifa_name, "en1"))
+#else
+      if (strcmp(ifap->ifa_name, primaryInterface))
+#endif
+      {
+        continue;
+      }
+      if ((ifap->ifa_flags & IFF_UP) && ((!useIPv6 && (ifap->ifa_addr->sa_family == AF_INET)) || (useIPv6 && (ifap->ifa_addr->sa_family == AF_INET6)))) {
+        address = GCDWebServerStringFromSockAddr(ifap->ifa_addr, NO);
+        break;
+      }
+    }
+    freeifaddrs(list);
+  }
+  return address;
+}
+
+NSString* GCDWebServerComputeMD5Digest(NSString* format, ...) {
+  va_list arguments;
+  va_start(arguments, format);
+  const char* string = [[[NSString alloc] initWithFormat:format arguments:arguments] UTF8String];
+  va_end(arguments);
+  unsigned char md5[CC_MD5_DIGEST_LENGTH];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  CC_MD5(string, (CC_LONG)strlen(string), md5);
+#pragma clang diagnostic pop
+  char buffer[2 * CC_MD5_DIGEST_LENGTH + 1];
+  for (int i = 0; i < CC_MD5_DIGEST_LENGTH; ++i) {
+    unsigned char byte = md5[i];
+    unsigned char byteHi = (byte & 0xF0) >> 4;
+    buffer[2 * i + 0] = byteHi >= 10 ? 'a' + byteHi - 10 : '0' + byteHi;
+    unsigned char byteLo = byte & 0x0F;
+    buffer[2 * i + 1] = byteLo >= 10 ? 'a' + byteLo - 10 : '0' + byteLo;
+  }
+  buffer[2 * CC_MD5_DIGEST_LENGTH] = 0;
+  return (NSString*)[NSString stringWithUTF8String:buffer];
+}
+
+NSString* GCDWebServerNormalizePath(NSString* path) {
+  NSMutableArray* components = [[NSMutableArray alloc] init];
+  for (NSString* component in [path componentsSeparatedByString:@"/"]) {
+    if ([component isEqualToString:@".."]) {
+      // A path beginning with one or more parent components must stay pinned
+      // at the WebDAV root. The upstream implementation called
+      // -removeLastObject on an empty array here, allowing a malformed request
+      // to terminate the in-process server.
+      if (components.count) {
+        [components removeLastObject];
+      }
+    } else if (component.length && ![component isEqualToString:@"."]) {
+      [components addObject:component];
+    }
+  }
+  if (path.length && ([path characterAtIndex:0] == '/')) {
+    return [@"/" stringByAppendingString:[components componentsJoinedByString:@"/"]];  // Preserve initial slash
+  }
+  return [components componentsJoinedByString:@"/"];
+}

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerHTTPStatusCodes.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerHTTPStatusCodes.h
@@ -1,0 +1,116 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+// http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+
+#import <Foundation/Foundation.h>
+
+/**
+ *  Convenience constants for "informational" HTTP status codes.
+ */
+typedef NS_ENUM(NSInteger, GCDWebServerInformationalHTTPStatusCode) {
+  kGCDWebServerHTTPStatusCode_Continue = 100,
+  kGCDWebServerHTTPStatusCode_SwitchingProtocols = 101,
+  kGCDWebServerHTTPStatusCode_Processing = 102
+};
+
+/**
+ *  Convenience constants for "successful" HTTP status codes.
+ */
+typedef NS_ENUM(NSInteger, GCDWebServerSuccessfulHTTPStatusCode) {
+  kGCDWebServerHTTPStatusCode_OK = 200,
+  kGCDWebServerHTTPStatusCode_Created = 201,
+  kGCDWebServerHTTPStatusCode_Accepted = 202,
+  kGCDWebServerHTTPStatusCode_NonAuthoritativeInformation = 203,
+  kGCDWebServerHTTPStatusCode_NoContent = 204,
+  kGCDWebServerHTTPStatusCode_ResetContent = 205,
+  kGCDWebServerHTTPStatusCode_PartialContent = 206,
+  kGCDWebServerHTTPStatusCode_MultiStatus = 207,
+  kGCDWebServerHTTPStatusCode_AlreadyReported = 208
+};
+
+/**
+ *  Convenience constants for "redirection" HTTP status codes.
+ */
+typedef NS_ENUM(NSInteger, GCDWebServerRedirectionHTTPStatusCode) {
+  kGCDWebServerHTTPStatusCode_MultipleChoices = 300,
+  kGCDWebServerHTTPStatusCode_MovedPermanently = 301,
+  kGCDWebServerHTTPStatusCode_Found = 302,
+  kGCDWebServerHTTPStatusCode_SeeOther = 303,
+  kGCDWebServerHTTPStatusCode_NotModified = 304,
+  kGCDWebServerHTTPStatusCode_UseProxy = 305,
+  kGCDWebServerHTTPStatusCode_TemporaryRedirect = 307,
+  kGCDWebServerHTTPStatusCode_PermanentRedirect = 308
+};
+
+/**
+ *  Convenience constants for "client error" HTTP status codes.
+ */
+typedef NS_ENUM(NSInteger, GCDWebServerClientErrorHTTPStatusCode) {
+  kGCDWebServerHTTPStatusCode_BadRequest = 400,
+  kGCDWebServerHTTPStatusCode_Unauthorized = 401,
+  kGCDWebServerHTTPStatusCode_PaymentRequired = 402,
+  kGCDWebServerHTTPStatusCode_Forbidden = 403,
+  kGCDWebServerHTTPStatusCode_NotFound = 404,
+  kGCDWebServerHTTPStatusCode_MethodNotAllowed = 405,
+  kGCDWebServerHTTPStatusCode_NotAcceptable = 406,
+  kGCDWebServerHTTPStatusCode_ProxyAuthenticationRequired = 407,
+  kGCDWebServerHTTPStatusCode_RequestTimeout = 408,
+  kGCDWebServerHTTPStatusCode_Conflict = 409,
+  kGCDWebServerHTTPStatusCode_Gone = 410,
+  kGCDWebServerHTTPStatusCode_LengthRequired = 411,
+  kGCDWebServerHTTPStatusCode_PreconditionFailed = 412,
+  kGCDWebServerHTTPStatusCode_RequestEntityTooLarge = 413,
+  kGCDWebServerHTTPStatusCode_RequestURITooLong = 414,
+  kGCDWebServerHTTPStatusCode_UnsupportedMediaType = 415,
+  kGCDWebServerHTTPStatusCode_RequestedRangeNotSatisfiable = 416,
+  kGCDWebServerHTTPStatusCode_ExpectationFailed = 417,
+  kGCDWebServerHTTPStatusCode_UnprocessableEntity = 422,
+  kGCDWebServerHTTPStatusCode_Locked = 423,
+  kGCDWebServerHTTPStatusCode_FailedDependency = 424,
+  kGCDWebServerHTTPStatusCode_UpgradeRequired = 426,
+  kGCDWebServerHTTPStatusCode_PreconditionRequired = 428,
+  kGCDWebServerHTTPStatusCode_TooManyRequests = 429,
+  kGCDWebServerHTTPStatusCode_RequestHeaderFieldsTooLarge = 431
+};
+
+/**
+ *  Convenience constants for "server error" HTTP status codes.
+ */
+typedef NS_ENUM(NSInteger, GCDWebServerServerErrorHTTPStatusCode) {
+  kGCDWebServerHTTPStatusCode_InternalServerError = 500,
+  kGCDWebServerHTTPStatusCode_NotImplemented = 501,
+  kGCDWebServerHTTPStatusCode_BadGateway = 502,
+  kGCDWebServerHTTPStatusCode_ServiceUnavailable = 503,
+  kGCDWebServerHTTPStatusCode_GatewayTimeout = 504,
+  kGCDWebServerHTTPStatusCode_HTTPVersionNotSupported = 505,
+  kGCDWebServerHTTPStatusCode_InsufficientStorage = 507,
+  kGCDWebServerHTTPStatusCode_LoopDetected = 508,
+  kGCDWebServerHTTPStatusCode_NotExtended = 510,
+  kGCDWebServerHTTPStatusCode_NetworkAuthenticationRequired = 511
+};

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerPrivate.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerPrivate.h
@@ -1,0 +1,224 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <os/object.h>
+#import <sys/socket.h>
+
+/**
+ *  All GCDWebServer headers.
+ */
+
+#import "GCDWebServerHTTPStatusCodes.h"
+#import "GCDWebServerFunctions.h"
+
+#import "GCDWebServer.h"
+#import "GCDWebServerConnection.h"
+
+#import "GCDWebServerDataRequest.h"
+#import "GCDWebServerFileRequest.h"
+#import "GCDWebServerMultiPartFormRequest.h"
+#import "GCDWebServerURLEncodedFormRequest.h"
+
+#import "GCDWebServerDataResponse.h"
+#import "GCDWebServerErrorResponse.h"
+#import "GCDWebServerFileResponse.h"
+#import "GCDWebServerStreamedResponse.h"
+
+/**
+ *  Check if a custom logging facility should be used instead.
+ */
+
+#if defined(__GCDWEBSERVER_LOGGING_HEADER__)
+
+#define __GCDWEBSERVER_LOGGING_FACILITY_CUSTOM__
+
+#import __GCDWEBSERVER_LOGGING_HEADER__
+
+/**
+ *  Automatically detect if XLFacility is available and if so use it as a
+ *  logging facility.
+ */
+
+#elif defined(__has_include) && __has_include("XLFacilityMacros.h")
+
+#define __GCDWEBSERVER_LOGGING_FACILITY_XLFACILITY__
+
+#undef XLOG_TAG
+#define XLOG_TAG @"gcdwebserver.internal"
+
+#import "XLFacilityMacros.h"
+
+#define GWS_LOG_DEBUG(...) XLOG_DEBUG(__VA_ARGS__)
+#define GWS_LOG_VERBOSE(...) XLOG_VERBOSE(__VA_ARGS__)
+#define GWS_LOG_INFO(...) XLOG_INFO(__VA_ARGS__)
+#define GWS_LOG_WARNING(...) XLOG_WARNING(__VA_ARGS__)
+#define GWS_LOG_ERROR(...) XLOG_ERROR(__VA_ARGS__)
+
+#define GWS_DCHECK(__CONDITION__) XLOG_DEBUG_CHECK(__CONDITION__)
+#define GWS_DNOT_REACHED() XLOG_DEBUG_UNREACHABLE()
+
+/**
+ *  If all of the above fail, then use GCDWebServer built-in
+ *  logging facility.
+ */
+
+#else
+
+#define __GCDWEBSERVER_LOGGING_FACILITY_BUILTIN__
+
+typedef NS_ENUM(int, GCDWebServerLoggingLevel) {
+  kGCDWebServerLoggingLevel_Debug = 0,
+  kGCDWebServerLoggingLevel_Verbose,
+  kGCDWebServerLoggingLevel_Info,
+  kGCDWebServerLoggingLevel_Warning,
+  kGCDWebServerLoggingLevel_Error
+};
+
+extern GCDWebServerLoggingLevel GCDWebServerLogLevel;
+extern void GCDWebServerLogMessage(GCDWebServerLoggingLevel level, NSString* _Nonnull format, ...) NS_FORMAT_FUNCTION(2, 3);
+
+#if DEBUG
+#define GWS_LOG_DEBUG(...)                                                                                                             \
+  do {                                                                                                                                 \
+    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Debug) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Debug, __VA_ARGS__); \
+  } while (0)
+#else
+#define GWS_LOG_DEBUG(...)
+#endif
+#define GWS_LOG_VERBOSE(...)                                                                                                               \
+  do {                                                                                                                                     \
+    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Verbose) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Verbose, __VA_ARGS__); \
+  } while (0)
+#define GWS_LOG_INFO(...)                                                                                                            \
+  do {                                                                                                                               \
+    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Info) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Info, __VA_ARGS__); \
+  } while (0)
+#define GWS_LOG_WARNING(...)                                                                                                               \
+  do {                                                                                                                                     \
+    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Warning) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Warning, __VA_ARGS__); \
+  } while (0)
+#define GWS_LOG_ERROR(...)                                                                                                             \
+  do {                                                                                                                                 \
+    if (GCDWebServerLogLevel <= kGCDWebServerLoggingLevel_Error) GCDWebServerLogMessage(kGCDWebServerLoggingLevel_Error, __VA_ARGS__); \
+  } while (0)
+
+#endif
+
+/**
+ *  Consistency check macros used when building Debug only.
+ */
+
+#if !defined(GWS_DCHECK) || !defined(GWS_DNOT_REACHED)
+
+#if DEBUG
+
+#define GWS_DCHECK(__CONDITION__) \
+  do {                            \
+    if (!(__CONDITION__)) {       \
+      abort();                    \
+    }                             \
+  } while (0)
+#define GWS_DNOT_REACHED() abort()
+
+#else
+
+#define GWS_DCHECK(__CONDITION__)
+#define GWS_DNOT_REACHED()
+
+#endif
+
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  GCDWebServer internal constants and APIs.
+ */
+
+#define kGCDWebServerDefaultMimeType @"application/octet-stream"
+#define kGCDWebServerErrorDomain @"GCDWebServerErrorDomain"
+
+static inline BOOL GCDWebServerIsValidByteRange(NSRange range) {
+  return ((range.location != NSUIntegerMax) || (range.length > 0));
+}
+
+static inline NSError* GCDWebServerMakePosixError(int code) {
+  return [NSError errorWithDomain:NSPOSIXErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey : (NSString*)[NSString stringWithUTF8String:strerror(code)]}];
+}
+
+extern void GCDWebServerInitializeFunctions(void);
+extern NSString* _Nullable GCDWebServerNormalizeHeaderValue(NSString* _Nullable value);
+extern NSString* _Nullable GCDWebServerTruncateHeaderValue(NSString* _Nullable value);
+extern NSString* _Nullable GCDWebServerExtractHeaderValueParameter(NSString* _Nullable value, NSString* attribute);
+extern NSStringEncoding GCDWebServerStringEncodingFromCharset(NSString* charset);
+extern BOOL GCDWebServerIsTextContentType(NSString* type);
+extern NSString* GCDWebServerDescribeData(NSData* data, NSString* contentType);
+extern NSString* GCDWebServerComputeMD5Digest(NSString* format, ...) NS_FORMAT_FUNCTION(1, 2);
+extern NSString* GCDWebServerStringFromSockAddr(const struct sockaddr* addr, BOOL includeService);
+
+@interface GCDWebServerConnection ()
+- (instancetype)initWithServer:(GCDWebServer*)server localAddress:(NSData*)localAddress remoteAddress:(NSData*)remoteAddress socket:(CFSocketNativeHandle)socket;
+@end
+
+@interface GCDWebServer ()
+@property(nonatomic, readonly) NSMutableArray<GCDWebServerHandler*>* handlers;
+@property(nonatomic, readonly, nullable) NSString* serverName;
+@property(nonatomic, readonly, nullable) NSString* authenticationRealm;
+@property(nonatomic, readonly, nullable) NSMutableDictionary<NSString*, NSString*>* authenticationBasicAccounts;
+@property(nonatomic, readonly, nullable) NSMutableDictionary<NSString*, NSString*>* authenticationDigestAccounts;
+@property(nonatomic, readonly) BOOL shouldAutomaticallyMapHEADToGET;
+@property(nonatomic, readonly) dispatch_queue_priority_t dispatchQueuePriority;
+- (void)willStartConnection:(GCDWebServerConnection*)connection;
+- (void)didEndConnection:(GCDWebServerConnection*)connection;
+@end
+
+@interface GCDWebServerHandler : NSObject
+@property(nonatomic, readonly) GCDWebServerMatchBlock matchBlock;
+@property(nonatomic, readonly) GCDWebServerAsyncProcessBlock asyncProcessBlock;
+@end
+
+@interface GCDWebServerRequest ()
+@property(nonatomic, readonly) BOOL usesChunkedTransferEncoding;
+@property(nonatomic) NSData* localAddressData;
+@property(nonatomic) NSData* remoteAddressData;
+- (void)prepareForWriting;
+- (BOOL)performOpen:(NSError**)error;
+- (BOOL)performWriteData:(NSData*)data error:(NSError**)error;
+- (BOOL)performClose:(NSError**)error;
+- (void)setAttribute:(nullable id)attribute forKey:(NSString*)key;
+@end
+
+@interface GCDWebServerResponse ()
+@property(nonatomic, readonly) NSDictionary<NSString*, NSString*>* additionalHeaders;
+@property(nonatomic, readonly) BOOL usesChunkedTransferEncoding;
+- (void)prepareForReading;
+- (BOOL)performOpen:(NSError**)error;
+- (void)performReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block;
+- (void)performClose;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerRequest.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerRequest.h
@@ -1,0 +1,210 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  Attribute key to retrieve an NSArray containing NSStrings from a GCDWebServerRequest
+ *  with the contents of any regular expression captures done on the request path.
+ *
+ *  @warning This attribute will only be set on the request if adding a handler using 
+ *  -addHandlerForMethod:pathRegex:requestClass:processBlock:.
+ */
+extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
+
+/**
+ *  This protocol is used by the GCDWebServerConnection to communicate with
+ *  the GCDWebServerRequest and write the received HTTP body data.
+ *
+ *  Note that multiple GCDWebServerBodyWriter objects can be chained together
+ *  internally e.g. to automatically decode gzip encoded content before
+ *  passing it on to the GCDWebServerRequest.
+ *
+ *  @warning These methods can be called on any GCD thread.
+ */
+@protocol GCDWebServerBodyWriter <NSObject>
+
+/**
+ *  This method is called before any body data is received.
+ *
+ *  It should return YES on success or NO on failure and set the "error" argument
+ *  which is guaranteed to be non-NULL.
+ */
+- (BOOL)open:(NSError**)error;
+
+/**
+ *  This method is called whenever body data has been received.
+ *
+ *  It should return YES on success or NO on failure and set the "error" argument
+ *  which is guaranteed to be non-NULL.
+ */
+- (BOOL)writeData:(NSData*)data error:(NSError**)error;
+
+/**
+ *  This method is called after all body data has been received.
+ *
+ *  It should return YES on success or NO on failure and set the "error" argument
+ *  which is guaranteed to be non-NULL.
+ */
+- (BOOL)close:(NSError**)error;
+
+@end
+
+/**
+ *  The GCDWebServerRequest class is instantiated by the GCDWebServerConnection
+ *  after the HTTP headers have been received. Each instance wraps a single HTTP
+ *  request. If a body is present, the methods from the GCDWebServerBodyWriter
+ *  protocol will be called by the GCDWebServerConnection to receive it.
+ *
+ *  The default implementation of the GCDWebServerBodyWriter protocol on the class
+ *  simply ignores the body data.
+ *
+ *  @warning GCDWebServerRequest instances can be created and used on any GCD thread.
+ */
+@interface GCDWebServerRequest : NSObject <GCDWebServerBodyWriter>
+
+/**
+ *  Returns the HTTP method for the request.
+ */
+@property(nonatomic, readonly) NSString* method;
+
+/**
+ *  Returns the URL for the request.
+ */
+@property(nonatomic, readonly) NSURL* URL;
+
+/**
+ *  Returns the HTTP headers for the request.
+ */
+@property(nonatomic, readonly) NSDictionary<NSString*, NSString*>* headers;
+
+/**
+ *  Returns the path component of the URL for the request.
+ */
+@property(nonatomic, readonly) NSString* path;
+
+/**
+ *  Returns the parsed and unescaped query component of the URL for the request.
+ *
+ *  @warning This property will be nil if there is no query in the URL.
+ */
+@property(nonatomic, readonly, nullable) NSDictionary<NSString*, NSString*>* query;
+
+/**
+ *  Returns the content type for the body of the request parsed from the
+ *  "Content-Type" header.
+ *
+ *  This property will be nil if the request has no body or set to
+ *  "application/octet-stream" if a body is present but there was no
+ *  "Content-Type" header.
+ */
+@property(nonatomic, readonly, nullable) NSString* contentType;
+
+/**
+ *  Returns the content length for the body of the request parsed from the
+ *  "Content-Length" header.
+ *
+ *  This property will be set to "NSUIntegerMax" if the request has no body or
+ *  if there is a body but no "Content-Length" header, typically because
+ *  chunked transfer encoding is used.
+ */
+@property(nonatomic, readonly) NSUInteger contentLength;
+
+/**
+ *  Returns the parsed "If-Modified-Since" header or nil if absent or malformed.
+ */
+@property(nonatomic, readonly, nullable) NSDate* ifModifiedSince;
+
+/**
+ *  Returns the parsed "If-None-Match" header or nil if absent or malformed.
+ */
+@property(nonatomic, readonly, nullable) NSString* ifNoneMatch;
+
+/**
+ *  Returns the parsed "Range" header or (NSUIntegerMax, 0) if absent or malformed.
+ *  The range will be set to (offset, length) if expressed from the beginning
+ *  of the entity body, or (NSUIntegerMax, length) if expressed from its end.
+ */
+@property(nonatomic, readonly) NSRange byteRange;
+
+/**
+ *  Returns YES if the client supports gzip content encoding according to the
+ *  "Accept-Encoding" header.
+ */
+@property(nonatomic, readonly) BOOL acceptsGzipContentEncoding;
+
+/**
+ *  Returns the address of the local peer (i.e. server) for the request
+ *  as a raw "struct sockaddr".
+ */
+@property(nonatomic, readonly) NSData* localAddressData;
+
+/**
+ *  Returns the address of the local peer (i.e. server) for the request
+ *  as a string.
+ */
+@property(nonatomic, readonly) NSString* localAddressString;
+
+/**
+ *  Returns the address of the remote peer (i.e. client) for the request
+ *  as a raw "struct sockaddr".
+ */
+@property(nonatomic, readonly) NSData* remoteAddressData;
+
+/**
+ *  Returns the address of the remote peer (i.e. client) for the request
+ *  as a string.
+ */
+@property(nonatomic, readonly) NSString* remoteAddressString;
+
+/**
+ *  This method is the designated initializer for the class.
+ */
+- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary<NSString*, NSString*>*)headers path:(NSString*)path query:(nullable NSDictionary<NSString*, NSString*>*)query;
+
+/**
+ *  Convenience method that checks if the contentType property is defined.
+ */
+- (BOOL)hasBody;
+
+/**
+ *  Convenience method that checks if the byteRange property is defined.
+ */
+- (BOOL)hasByteRange;
+
+/**
+ *  Retrieves an attribute associated with this request using the given key.
+ *
+ *  @return The attribute value for the key.
+ */
+- (nullable id)attributeForKey:(NSString*)key;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerRequest.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerRequest.m
@@ -1,0 +1,303 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import <zlib.h>
+
+#import "GCDWebServerPrivate.h"
+
+NSString* const GCDWebServerRequestAttribute_RegexCaptures = @"GCDWebServerRequestAttribute_RegexCaptures";
+
+#define kZlibErrorDomain @"ZlibErrorDomain"
+#define kGZipInitialBufferSize (256 * 1024)
+
+@interface GCDWebServerBodyDecoder : NSObject <GCDWebServerBodyWriter>
+@end
+
+@interface GCDWebServerGZipDecoder : GCDWebServerBodyDecoder
+@end
+
+@implementation GCDWebServerBodyDecoder {
+  GCDWebServerRequest* __unsafe_unretained _request;
+  id<GCDWebServerBodyWriter> __unsafe_unretained _writer;
+}
+
+- (instancetype)initWithRequest:(GCDWebServerRequest* _Nonnull)request writer:(id<GCDWebServerBodyWriter> _Nonnull)writer {
+  if ((self = [super init])) {
+    _request = request;
+    _writer = writer;
+  }
+  return self;
+}
+
+- (BOOL)open:(NSError**)error {
+  return [_writer open:error];
+}
+
+- (BOOL)writeData:(NSData*)data error:(NSError**)error {
+  return [_writer writeData:data error:error];
+}
+
+- (BOOL)close:(NSError**)error {
+  return [_writer close:error];
+}
+
+@end
+
+@implementation GCDWebServerGZipDecoder {
+  z_stream _stream;
+  BOOL _finished;
+}
+
+- (BOOL)open:(NSError**)error {
+  int result = inflateInit2(&_stream, 15 + 16);
+  if (result != Z_OK) {
+    if (error) {
+      *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+    }
+    return NO;
+  }
+  if (![super open:error]) {
+    inflateEnd(&_stream);
+    return NO;
+  }
+  return YES;
+}
+
+- (BOOL)writeData:(NSData*)data error:(NSError**)error {
+  GWS_DCHECK(!_finished);
+  _stream.next_in = (Bytef*)data.bytes;
+  _stream.avail_in = (uInt)data.length;
+  NSMutableData* decodedData = [[NSMutableData alloc] initWithLength:kGZipInitialBufferSize];
+  if (decodedData == nil) {
+    GWS_DNOT_REACHED();
+    return NO;
+  }
+  NSUInteger length = 0;
+  while (1) {
+    NSUInteger maxLength = decodedData.length - length;
+    _stream.next_out = (Bytef*)((char*)decodedData.mutableBytes + length);
+    _stream.avail_out = (uInt)maxLength;
+    int result = inflate(&_stream, Z_NO_FLUSH);
+    if ((result != Z_OK) && (result != Z_STREAM_END)) {
+      if (error) {
+        *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+      }
+      return NO;
+    }
+    length += maxLength - _stream.avail_out;
+    if (_stream.avail_out > 0) {
+      if (result == Z_STREAM_END) {
+        _finished = YES;
+      }
+      break;
+    }
+    decodedData.length = 2 * decodedData.length;  // zlib has used all the output buffer so resize it and try again in case more data is available
+  }
+  decodedData.length = length;
+  BOOL success = length ? [super writeData:decodedData error:error] : YES;  // No need to call writer if we have no data yet
+  return success;
+}
+
+- (BOOL)close:(NSError**)error {
+  GWS_DCHECK(_finished);
+  inflateEnd(&_stream);
+  return [super close:error];
+}
+
+@end
+
+@implementation GCDWebServerRequest {
+  BOOL _opened;
+  NSMutableArray<GCDWebServerBodyDecoder*>* _decoders;
+  id<GCDWebServerBodyWriter> __unsafe_unretained _writer;
+  NSMutableDictionary<NSString*, id>* _attributes;
+}
+
+- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary<NSString*, NSString*>*)headers path:(NSString*)path query:(NSDictionary<NSString*, NSString*>*)query {
+  if ((self = [super init])) {
+    _method = [method copy];
+    _URL = url;
+    _headers = headers;
+    _path = [path copy];
+    _query = query;
+
+    _contentType = GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Content-Type"]);
+    _usesChunkedTransferEncoding = [GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Transfer-Encoding"]) isEqualToString:@"chunked"];
+    NSString* lengthHeader = [_headers objectForKey:@"Content-Length"];
+    if (lengthHeader) {
+      NSInteger length = [lengthHeader integerValue];
+      if (_usesChunkedTransferEncoding || (length < 0)) {
+        GWS_LOG_WARNING(@"Invalid 'Content-Length' header '%@' for '%@' request on \"%@\"", lengthHeader, _method, _URL);
+        GWS_DNOT_REACHED();
+        return nil;
+      }
+      _contentLength = length;
+      if (_contentType == nil) {
+        _contentType = kGCDWebServerDefaultMimeType;
+      }
+    } else if (_usesChunkedTransferEncoding) {
+      if (_contentType == nil) {
+        _contentType = kGCDWebServerDefaultMimeType;
+      }
+      _contentLength = NSUIntegerMax;
+    } else {
+      if (_contentType) {
+        GWS_LOG_WARNING(@"Ignoring 'Content-Type' header for '%@' request on \"%@\"", _method, _URL);
+        _contentType = nil;  // Content-Type without Content-Length or chunked-encoding doesn't make sense
+      }
+      _contentLength = NSUIntegerMax;
+    }
+
+    NSString* modifiedHeader = [_headers objectForKey:@"If-Modified-Since"];
+    if (modifiedHeader) {
+      _ifModifiedSince = [GCDWebServerParseRFC822(modifiedHeader) copy];
+    }
+    _ifNoneMatch = [_headers objectForKey:@"If-None-Match"];
+
+    _byteRange = NSMakeRange(NSUIntegerMax, 0);
+    NSString* rangeHeader = GCDWebServerNormalizeHeaderValue([_headers objectForKey:@"Range"]);
+    if (rangeHeader) {
+      if ([rangeHeader hasPrefix:@"bytes="]) {
+        NSArray* components = [[rangeHeader substringFromIndex:6] componentsSeparatedByString:@","];
+        if (components.count == 1) {
+          components = [(NSString*)[components firstObject] componentsSeparatedByString:@"-"];
+          if (components.count == 2) {
+            NSString* startString = [components objectAtIndex:0];
+            NSInteger startValue = [startString integerValue];
+            NSString* endString = [components objectAtIndex:1];
+            NSInteger endValue = [endString integerValue];
+            if (startString.length && (startValue >= 0) && endString.length && (endValue >= startValue)) {  // The second 500 bytes: "500-999"
+              _byteRange.location = startValue;
+              _byteRange.length = endValue - startValue + 1;
+            } else if (startString.length && (startValue >= 0)) {  // The bytes after 9500 bytes: "9500-"
+              _byteRange.location = startValue;
+              _byteRange.length = NSUIntegerMax;
+            } else if (endString.length && (endValue > 0)) {  // The final 500 bytes: "-500"
+              _byteRange.location = NSUIntegerMax;
+              _byteRange.length = endValue;
+            }
+          }
+        }
+      }
+      if ((_byteRange.location == NSUIntegerMax) && (_byteRange.length == 0)) {  // Ignore "Range" header if syntactically invalid
+        GWS_LOG_WARNING(@"Failed to parse 'Range' header \"%@\" for url: %@", rangeHeader, url);
+      }
+    }
+
+    if ([[_headers objectForKey:@"Accept-Encoding"] rangeOfString:@"gzip"].location != NSNotFound) {
+      _acceptsGzipContentEncoding = YES;
+    }
+
+    _decoders = [[NSMutableArray alloc] init];
+    _attributes = [[NSMutableDictionary alloc] init];
+  }
+  return self;
+}
+
+- (BOOL)hasBody {
+  return _contentType ? YES : NO;
+}
+
+- (BOOL)hasByteRange {
+  return GCDWebServerIsValidByteRange(_byteRange);
+}
+
+- (id)attributeForKey:(NSString*)key {
+  return [_attributes objectForKey:key];
+}
+
+- (BOOL)open:(NSError**)error {
+  return YES;
+}
+
+- (BOOL)writeData:(NSData*)data error:(NSError**)error {
+  return YES;
+}
+
+- (BOOL)close:(NSError**)error {
+  return YES;
+}
+
+- (void)prepareForWriting {
+  _writer = self;
+  if ([GCDWebServerNormalizeHeaderValue([self.headers objectForKey:@"Content-Encoding"]) isEqualToString:@"gzip"]) {
+    GCDWebServerGZipDecoder* decoder = [[GCDWebServerGZipDecoder alloc] initWithRequest:self writer:_writer];
+    [_decoders addObject:decoder];
+    _writer = decoder;
+  }
+}
+
+- (BOOL)performOpen:(NSError**)error {
+  GWS_DCHECK(_contentType);
+  GWS_DCHECK(_writer);
+  if (_opened) {
+    GWS_DNOT_REACHED();
+    return NO;
+  }
+  _opened = YES;
+  return [_writer open:error];
+}
+
+- (BOOL)performWriteData:(NSData*)data error:(NSError**)error {
+  GWS_DCHECK(_opened);
+  return [_writer writeData:data error:error];
+}
+
+- (BOOL)performClose:(NSError**)error {
+  GWS_DCHECK(_opened);
+  return [_writer close:error];
+}
+
+- (void)setAttribute:(id)attribute forKey:(NSString*)key {
+  [_attributes setValue:attribute forKey:key];
+}
+
+- (NSString*)localAddressString {
+  return GCDWebServerStringFromSockAddr(_localAddressData.bytes, YES);
+}
+
+- (NSString*)remoteAddressString {
+  return GCDWebServerStringFromSockAddr(_remoteAddressData.bytes, YES);
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithFormat:@"%@ %@", _method, _path];
+  for (NSString* argument in [[_query allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+    [description appendFormat:@"\n  %@ = %@", argument, [_query objectForKey:argument]];
+  }
+  [description appendString:@"\n"];
+  for (NSString* header in [[_headers allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+    [description appendFormat:@"\n%@: %@", header, [_headers objectForKey:header]];
+  }
+  return description;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerResponse.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerResponse.h
@@ -1,0 +1,212 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerBodyReaderCompletionBlock is passed by GCDWebServer to the
+ *  GCDWebServerBodyReader object when reading data from it asynchronously.
+ */
+typedef void (^GCDWebServerBodyReaderCompletionBlock)(NSData* _Nullable data, NSError* _Nullable error);
+
+/**
+ *  This protocol is used by the GCDWebServerConnection to communicate with
+ *  the GCDWebServerResponse and read the HTTP body data to send.
+ *
+ *  Note that multiple GCDWebServerBodyReader objects can be chained together
+ *  internally e.g. to automatically apply gzip encoding to the content before
+ *  passing it on to the GCDWebServerResponse.
+ *
+ *  @warning These methods can be called on any GCD thread.
+ */
+@protocol GCDWebServerBodyReader <NSObject>
+
+@required
+
+/**
+ *  This method is called before any body data is sent.
+ *
+ *  It should return YES on success or NO on failure and set the "error" argument
+ *  which is guaranteed to be non-NULL.
+ */
+- (BOOL)open:(NSError**)error;
+
+/**
+ *  This method is called whenever body data is sent.
+ *
+ *  It should return a non-empty NSData if there is body data available,
+ *  or an empty NSData there is no more body data, or nil on error and set
+ *  the "error" argument which is guaranteed to be non-NULL.
+ */
+- (nullable NSData*)readData:(NSError**)error;
+
+/**
+ *  This method is called after all body data has been sent.
+ */
+- (void)close;
+
+@optional
+
+/**
+ *  If this method is implemented, it will be preferred over -readData:.
+ *
+ *  It must call the passed block when data is available, passing a non-empty
+ *  NSData if there is body data available, or an empty NSData there is no more
+ *  body data, or nil on error and pass an NSError along.
+ */
+- (void)asyncReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block;
+
+@end
+
+/**
+ *  The GCDWebServerResponse class is used to wrap a single HTTP response.
+ *  It is instantiated by the handler of the GCDWebServer that handled the request.
+ *  If a body is present, the methods from the GCDWebServerBodyReader protocol
+ *  will be called by the GCDWebServerConnection to send it.
+ *
+ *  The default implementation of the GCDWebServerBodyReader protocol
+ *  on the class simply returns an empty body.
+ *
+ *  @warning GCDWebServerResponse instances can be created and used on any GCD thread.
+ */
+@interface GCDWebServerResponse : NSObject <GCDWebServerBodyReader>
+
+/**
+ *  Sets the content type for the body of the response.
+ *
+ *  The default value is nil i.e. the response has no body.
+ *
+ *  @warning This property must be set if a body is present.
+ */
+@property(nonatomic, copy, nullable) NSString* contentType;
+
+/**
+ *  Sets the content length for the body of the response. If a body is present
+ *  but this property is set to "NSUIntegerMax", this means the length of the body
+ *  cannot be known ahead of time. Chunked transfer encoding will be
+ *  automatically enabled by the GCDWebServerConnection to comply with HTTP/1.1
+ *  specifications.
+ *
+ *  The default value is "NSUIntegerMax" i.e. the response has no body or its length
+ *  is undefined.
+ */
+@property(nonatomic) NSUInteger contentLength;
+
+/**
+ *  Sets the HTTP status code for the response.
+ *
+ *  The default value is 200 i.e. "OK".
+ */
+@property(nonatomic) NSInteger statusCode;
+
+/**
+ *  Sets the caching hint for the response using the "Cache-Control" header.
+ *  This value is expressed in seconds.
+ *
+ *  The default value is 0 i.e. "no-cache".
+ */
+@property(nonatomic) NSUInteger cacheControlMaxAge;
+
+/**
+ *  Sets the last modified date for the response using the "Last-Modified" header.
+ *
+ *  The default value is nil.
+ */
+@property(nonatomic, nullable) NSDate* lastModifiedDate;
+
+/**
+ *  Sets the ETag for the response using the "ETag" header.
+ *
+ *  The default value is nil.
+ */
+@property(nonatomic, copy, nullable) NSString* eTag;
+
+/**
+ *  Enables gzip encoding for the response body.
+ *
+ *  The default value is NO.
+ *
+ *  @warning Enabling gzip encoding will remove any "Content-Length" header
+ *  since the length of the body is not known anymore. The client will still
+ *  be able to determine the body length when connection is closed per
+ *  HTTP/1.1 specifications.
+ */
+@property(nonatomic, getter=isGZipContentEncodingEnabled) BOOL gzipContentEncodingEnabled;
+
+/**
+ *  Creates an empty response.
+ */
++ (instancetype)response;
+
+/**
+ *  This method is the designated initializer for the class.
+ */
+- (instancetype)init;
+
+/**
+ *  Sets an additional HTTP header on the response.
+ *  Pass a nil value to remove an additional header.
+ *
+ *  @warning Do not attempt to override the primary headers used
+ *  by GCDWebServerResponse like "Content-Type", "ETag", etc...
+ */
+- (void)setValue:(nullable NSString*)value forAdditionalHeader:(NSString*)header;
+
+/**
+ *  Convenience method that checks if the contentType property is defined.
+ */
+- (BOOL)hasBody;
+
+@end
+
+@interface GCDWebServerResponse (Extensions)
+
+/**
+ *  Creates a empty response with a specific HTTP status code.
+ */
++ (instancetype)responseWithStatusCode:(NSInteger)statusCode;
+
+/**
+ *  Creates an HTTP redirect response to a new URL.
+ */
++ (instancetype)responseWithRedirect:(NSURL*)location permanent:(BOOL)permanent;
+
+/**
+ *  Initializes an empty response with a specific HTTP status code.
+ */
+- (instancetype)initWithStatusCode:(NSInteger)statusCode;
+
+/**
+ *  Initializes an HTTP redirect response to a new URL.
+ */
+- (instancetype)initWithRedirect:(NSURL*)location permanent:(BOOL)permanent;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerResponse.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServerResponse.m
@@ -1,0 +1,284 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import <zlib.h>
+
+#import "GCDWebServerPrivate.h"
+
+#define kZlibErrorDomain @"ZlibErrorDomain"
+#define kGZipInitialBufferSize (256 * 1024)
+
+@interface GCDWebServerBodyEncoder : NSObject <GCDWebServerBodyReader>
+@end
+
+@interface GCDWebServerGZipEncoder : GCDWebServerBodyEncoder
+@end
+
+@implementation GCDWebServerBodyEncoder {
+  GCDWebServerResponse* __unsafe_unretained _response;
+  id<GCDWebServerBodyReader> __unsafe_unretained _reader;
+}
+
+- (instancetype)initWithResponse:(GCDWebServerResponse* _Nonnull)response reader:(id<GCDWebServerBodyReader> _Nonnull)reader {
+  if ((self = [super init])) {
+    _response = response;
+    _reader = reader;
+  }
+  return self;
+}
+
+- (BOOL)open:(NSError**)error {
+  return [_reader open:error];
+}
+
+- (NSData*)readData:(NSError**)error {
+  return [_reader readData:error];
+}
+
+- (void)close {
+  [_reader close];
+}
+
+@end
+
+@implementation GCDWebServerGZipEncoder {
+  z_stream _stream;
+  BOOL _finished;
+}
+
+- (instancetype)initWithResponse:(GCDWebServerResponse* _Nonnull)response reader:(id<GCDWebServerBodyReader> _Nonnull)reader {
+  if ((self = [super initWithResponse:response reader:reader])) {
+    response.contentLength = NSUIntegerMax;  // Make sure "Content-Length" header is not set since we don't know it
+    [response setValue:@"gzip" forAdditionalHeader:@"Content-Encoding"];
+  }
+  return self;
+}
+
+- (BOOL)open:(NSError**)error {
+  int result = deflateInit2(&_stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+  if (result != Z_OK) {
+    if (error) {
+      *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+    }
+    return NO;
+  }
+  if (![super open:error]) {
+    deflateEnd(&_stream);
+    return NO;
+  }
+  return YES;
+}
+
+- (NSData*)readData:(NSError**)error {
+  NSMutableData* encodedData;
+  if (_finished) {
+    encodedData = [[NSMutableData alloc] init];
+  } else {
+    encodedData = [[NSMutableData alloc] initWithLength:kGZipInitialBufferSize];
+    if (encodedData == nil) {
+      GWS_DNOT_REACHED();
+      return nil;
+    }
+    NSUInteger length = 0;
+    do {
+      NSData* data = [super readData:error];
+      if (data == nil) {
+        return nil;
+      }
+      _stream.next_in = (Bytef*)data.bytes;
+      _stream.avail_in = (uInt)data.length;
+      while (1) {
+        NSUInteger maxLength = encodedData.length - length;
+        _stream.next_out = (Bytef*)((char*)encodedData.mutableBytes + length);
+        _stream.avail_out = (uInt)maxLength;
+        int result = deflate(&_stream, data.length ? Z_NO_FLUSH : Z_FINISH);
+        if (result == Z_STREAM_END) {
+          _finished = YES;
+        } else if (result != Z_OK) {
+          if (error) {
+            *error = [NSError errorWithDomain:kZlibErrorDomain code:result userInfo:nil];
+          }
+          return nil;
+        }
+        length += maxLength - _stream.avail_out;
+        if (_stream.avail_out > 0) {
+          break;
+        }
+        encodedData.length = 2 * encodedData.length;  // zlib has used all the output buffer so resize it and try again in case more data is available
+      }
+      GWS_DCHECK(_stream.avail_in == 0);
+    } while (length == 0);  // Make sure we don't return an empty NSData if not in finished state
+    encodedData.length = length;
+  }
+  return encodedData;
+}
+
+- (void)close {
+  deflateEnd(&_stream);
+  [super close];
+}
+
+@end
+
+@implementation GCDWebServerResponse {
+  BOOL _opened;
+  NSMutableArray<GCDWebServerBodyEncoder*>* _encoders;
+  id<GCDWebServerBodyReader> __unsafe_unretained _reader;
+}
+
++ (instancetype)response {
+  return [(GCDWebServerResponse*)[[self class] alloc] init];
+}
+
+- (instancetype)init {
+  if ((self = [super init])) {
+    _contentType = nil;
+    _contentLength = NSUIntegerMax;
+    _statusCode = kGCDWebServerHTTPStatusCode_OK;
+    _cacheControlMaxAge = 0;
+    _additionalHeaders = [[NSMutableDictionary alloc] init];
+    _encoders = [[NSMutableArray alloc] init];
+  }
+  return self;
+}
+
+- (void)setValue:(NSString*)value forAdditionalHeader:(NSString*)header {
+  [_additionalHeaders setValue:value forKey:header];
+}
+
+- (BOOL)hasBody {
+  return _contentType ? YES : NO;
+}
+
+- (BOOL)usesChunkedTransferEncoding {
+  return (_contentType != nil) && (_contentLength == NSUIntegerMax);
+}
+
+- (BOOL)open:(NSError**)error {
+  return YES;
+}
+
+- (NSData*)readData:(NSError**)error {
+  return [NSData data];
+}
+
+- (void)close {
+  ;
+}
+
+- (void)prepareForReading {
+  _reader = self;
+  if (_gzipContentEncodingEnabled) {
+    GCDWebServerGZipEncoder* encoder = [[GCDWebServerGZipEncoder alloc] initWithResponse:self reader:_reader];
+    [_encoders addObject:encoder];
+    _reader = encoder;
+  }
+}
+
+- (BOOL)performOpen:(NSError**)error {
+  GWS_DCHECK(_contentType);
+  GWS_DCHECK(_reader);
+  if (_opened) {
+    GWS_DNOT_REACHED();
+    return NO;
+  }
+  _opened = YES;
+  return [_reader open:error];
+}
+
+- (void)performReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block {
+  GWS_DCHECK(_opened);
+  if ([_reader respondsToSelector:@selector(asyncReadDataWithCompletion:)]) {
+    [_reader asyncReadDataWithCompletion:[block copy]];
+  } else {
+    NSError* error = nil;
+    NSData* data = [_reader readData:&error];
+    block(data, error);
+  }
+}
+
+- (void)performClose {
+  GWS_DCHECK(_opened);
+  [_reader close];
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithFormat:@"Status Code = %i", (int)_statusCode];
+  if (_contentType) {
+    [description appendFormat:@"\nContent Type = %@", _contentType];
+  }
+  if (_contentLength != NSUIntegerMax) {
+    [description appendFormat:@"\nContent Length = %lu", (unsigned long)_contentLength];
+  }
+  [description appendFormat:@"\nCache Control Max Age = %lu", (unsigned long)_cacheControlMaxAge];
+  if (_lastModifiedDate) {
+    [description appendFormat:@"\nLast Modified Date = %@", _lastModifiedDate];
+  }
+  if (_eTag) {
+    [description appendFormat:@"\nETag = %@", _eTag];
+  }
+  if (_additionalHeaders.count) {
+    [description appendString:@"\n"];
+    for (NSString* header in [[_additionalHeaders allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+      [description appendFormat:@"\n%@: %@", header, [_additionalHeaders objectForKey:header]];
+    }
+  }
+  return description;
+}
+
+@end
+
+@implementation GCDWebServerResponse (Extensions)
+
++ (instancetype)responseWithStatusCode:(NSInteger)statusCode {
+  return [(GCDWebServerResponse*)[self alloc] initWithStatusCode:statusCode];
+}
+
++ (instancetype)responseWithRedirect:(NSURL*)location permanent:(BOOL)permanent {
+  return [(GCDWebServerResponse*)[self alloc] initWithRedirect:location permanent:permanent];
+}
+
+- (instancetype)initWithStatusCode:(NSInteger)statusCode {
+  if ((self = [self init])) {
+    self.statusCode = statusCode;
+  }
+  return self;
+}
+
+- (instancetype)initWithRedirect:(NSURL*)location permanent:(BOOL)permanent {
+  if ((self = [self init])) {
+    self.statusCode = permanent ? kGCDWebServerHTTPStatusCode_MovedPermanently : kGCDWebServerHTTPStatusCode_TemporaryRedirect;
+    [self setValue:[location absoluteString] forAdditionalHeader:@"Location"];
+  }
+  return self;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerDataRequest.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerDataRequest.h
@@ -1,0 +1,64 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerDataRequest subclass of GCDWebServerRequest stores the body
+ *  of the HTTP request in memory.
+ */
+@interface GCDWebServerDataRequest : GCDWebServerRequest
+
+/**
+ *  Returns the data for the request body.
+ */
+@property(nonatomic, readonly) NSData* data;
+
+@end
+
+@interface GCDWebServerDataRequest (Extensions)
+
+/**
+ *  Returns the data for the request body interpreted as text. If the content
+ *  type of the body is not a text one, or if an error occurs, nil is returned.
+ *
+ *  The text encoding used to interpret the data is extracted from the
+ *  "Content-Type" header or defaults to UTF-8.
+ */
+@property(nonatomic, readonly, nullable) NSString* text;
+
+/**
+ *  Returns the data for the request body interpreted as a JSON object. If the
+ *  content type of the body is not JSON, or if an error occurs, nil is returned.
+ */
+@property(nonatomic, readonly, nullable) id jsonObject;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerDataRequest.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerDataRequest.m
@@ -1,0 +1,104 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+@interface GCDWebServerDataRequest ()
+@property(nonatomic) NSMutableData* data;
+@end
+
+@implementation GCDWebServerDataRequest {
+  NSString* _text;
+  id _jsonObject;
+}
+
+- (BOOL)open:(NSError**)error {
+  if (self.contentLength != NSUIntegerMax) {
+    _data = [[NSMutableData alloc] initWithCapacity:self.contentLength];
+  } else {
+    _data = [[NSMutableData alloc] init];
+  }
+  if (_data == nil) {
+    if (error) {
+      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Failed allocating memory"}];
+    }
+    return NO;
+  }
+  return YES;
+}
+
+- (BOOL)writeData:(NSData*)data error:(NSError**)error {
+  [_data appendData:data];
+  return YES;
+}
+
+- (BOOL)close:(NSError**)error {
+  return YES;
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithString:[super description]];
+  if (_data) {
+    [description appendString:@"\n\n"];
+    [description appendString:GCDWebServerDescribeData(_data, (NSString*)self.contentType)];
+  }
+  return description;
+}
+
+@end
+
+@implementation GCDWebServerDataRequest (Extensions)
+
+- (NSString*)text {
+  if (_text == nil) {
+    if ([self.contentType hasPrefix:@"text/"]) {
+      NSString* charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
+      _text = [[NSString alloc] initWithData:self.data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+    } else {
+      GWS_DNOT_REACHED();
+    }
+  }
+  return _text;
+}
+
+- (id)jsonObject {
+  if (_jsonObject == nil) {
+    NSString* mimeType = GCDWebServerTruncateHeaderValue(self.contentType);
+    if ([mimeType isEqualToString:@"application/json"] || [mimeType isEqualToString:@"text/json"] || [mimeType isEqualToString:@"text/javascript"]) {
+      _jsonObject = [NSJSONSerialization JSONObjectWithData:_data options:0 error:NULL];
+    } else {
+      GWS_DNOT_REACHED();
+    }
+  }
+  return _jsonObject;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerFileRequest.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerFileRequest.h
@@ -1,0 +1,49 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerFileRequest subclass of GCDWebServerRequest stores the body
+ *  of the HTTP request to a file on disk.
+ */
+@interface GCDWebServerFileRequest : GCDWebServerRequest
+
+/**
+ *  Returns the path to the temporary file containing the request body.
+ *
+ *  @warning This temporary file will be automatically deleted when the
+ *  GCDWebServerFileRequest is deallocated. If you want to preserve this file,
+ *  you must move it to a different location beforehand.
+ */
+@property(nonatomic, readonly) NSString* temporaryPath;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerFileRequest.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerFileRequest.m
@@ -1,0 +1,102 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+@implementation GCDWebServerFileRequest {
+  int _file;
+}
+
+- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary<NSString*, NSString*>*)headers path:(NSString*)path query:(NSDictionary<NSString*, NSString*>*)query {
+  if ((self = [super initWithMethod:method url:url headers:headers path:path query:query])) {
+    _temporaryPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  unlink([_temporaryPath fileSystemRepresentation]);
+}
+
+- (BOOL)open:(NSError**)error {
+  _file = open([_temporaryPath fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  if (_file <= 0) {
+    if (error) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
+    return NO;
+  }
+  return YES;
+}
+
+- (BOOL)writeData:(NSData*)data error:(NSError**)error {
+  if (write(_file, data.bytes, data.length) != (ssize_t)data.length) {
+    if (error) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
+    return NO;
+  }
+  return YES;
+}
+
+- (BOOL)close:(NSError**)error {
+  if (close(_file) < 0) {
+    if (error) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
+    return NO;
+  }
+#ifdef __GCDWEBSERVER_ENABLE_TESTING__
+  NSString* creationDateHeader = [self.headers objectForKey:@"X-GCDWebServer-CreationDate"];
+  if (creationDateHeader) {
+    NSDate* date = GCDWebServerParseISO8601(creationDateHeader);
+    if (!date || ![[NSFileManager defaultManager] setAttributes:@{NSFileCreationDate : date} ofItemAtPath:_temporaryPath error:error]) {
+      return NO;
+    }
+  }
+  NSString* modifiedDateHeader = [self.headers objectForKey:@"X-GCDWebServer-ModifiedDate"];
+  if (modifiedDateHeader) {
+    NSDate* date = GCDWebServerParseRFC822(modifiedDateHeader);
+    if (!date || ![[NSFileManager defaultManager] setAttributes:@{NSFileModificationDate : date} ofItemAtPath:_temporaryPath error:error]) {
+      return NO;
+    }
+  }
+#endif
+  return YES;
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithString:[super description]];
+  [description appendFormat:@"\n\n{%@}", _temporaryPath];
+  return description;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.h
@@ -1,0 +1,136 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerMultiPart class is an abstract class that wraps the content
+ *  of a part.
+ */
+@interface GCDWebServerMultiPart : NSObject
+
+/**
+ *  Returns the control name retrieved from the part headers.
+ */
+@property(nonatomic, readonly) NSString* controlName;
+
+/**
+ *  Returns the content type retrieved from the part headers or "text/plain"
+ *  if not available (per HTTP specifications).
+ */
+@property(nonatomic, readonly) NSString* contentType;
+
+/**
+ *  Returns the MIME type component of the content type for the part.
+ */
+@property(nonatomic, readonly) NSString* mimeType;
+
+@end
+
+/**
+ *  The GCDWebServerMultiPartArgument subclass of GCDWebServerMultiPart wraps
+ *  the content of a part as data in memory.
+ */
+@interface GCDWebServerMultiPartArgument : GCDWebServerMultiPart
+
+/**
+ *  Returns the data for the part.
+ */
+@property(nonatomic, readonly) NSData* data;
+
+/**
+ *  Returns the data for the part interpreted as text. If the content
+ *  type of the part is not a text one, or if an error occurs, nil is returned.
+ *
+ *  The text encoding used to interpret the data is extracted from the
+ *  "Content-Type" header or defaults to UTF-8.
+ */
+@property(nonatomic, readonly, nullable) NSString* string;
+
+@end
+
+/**
+ *  The GCDWebServerMultiPartFile subclass of GCDWebServerMultiPart wraps
+ *  the content of a part as a file on disk.
+ */
+@interface GCDWebServerMultiPartFile : GCDWebServerMultiPart
+
+/**
+ *  Returns the file name retrieved from the part headers.
+ */
+@property(nonatomic, readonly) NSString* fileName;
+
+/**
+ *  Returns the path to the temporary file containing the part data.
+ *
+ *  @warning This temporary file will be automatically deleted when the
+ *  GCDWebServerMultiPartFile is deallocated. If you want to preserve this file,
+ *  you must move it to a different location beforehand.
+ */
+@property(nonatomic, readonly) NSString* temporaryPath;
+
+@end
+
+/**
+ *  The GCDWebServerMultiPartFormRequest subclass of GCDWebServerRequest
+ *  parses the body of the HTTP request as a multipart encoded form.
+ */
+@interface GCDWebServerMultiPartFormRequest : GCDWebServerRequest
+
+/**
+ *  Returns the argument parts from the multipart encoded form as
+ *  name / GCDWebServerMultiPartArgument pairs.
+ */
+@property(nonatomic, readonly) NSArray<GCDWebServerMultiPartArgument*>* arguments;
+
+/**
+ *  Returns the files parts from the multipart encoded form as
+ *  name / GCDWebServerMultiPartFile pairs.
+ */
+@property(nonatomic, readonly) NSArray<GCDWebServerMultiPartFile*>* files;
+
+/**
+ *  Returns the MIME type for multipart encoded forms
+ *  i.e. "multipart/form-data".
+ */
++ (NSString*)mimeType;
+
+/**
+ *  Returns the first argument for a given control name or nil if not found.
+ */
+- (nullable GCDWebServerMultiPartArgument*)firstArgumentForControlName:(NSString*)name;
+
+/**
+ *  Returns the first file for a given control name or nil if not found.
+ */
+- (nullable GCDWebServerMultiPartFile*)firstFileForControlName:(NSString*)name;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerMultiPartFormRequest.m
@@ -1,0 +1,405 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+#define kMultiPartBufferSize (256 * 1024)
+
+typedef enum {
+  kParserState_Undefined = 0,
+  kParserState_Start,
+  kParserState_Headers,
+  kParserState_Content,
+  kParserState_End
+} ParserState;
+
+@interface GCDWebServerMIMEStreamParser : NSObject
+@end
+
+static NSData* _newlineData = nil;
+static NSData* _newlinesData = nil;
+static NSData* _dashNewlineData = nil;
+
+@implementation GCDWebServerMultiPart
+
+- (instancetype)initWithControlName:(NSString* _Nonnull)name contentType:(NSString* _Nonnull)type {
+  if ((self = [super init])) {
+    _controlName = [name copy];
+    _contentType = [type copy];
+    _mimeType = (NSString*)GCDWebServerTruncateHeaderValue(_contentType);
+  }
+  return self;
+}
+
+@end
+
+@implementation GCDWebServerMultiPartArgument
+
+- (instancetype)initWithControlName:(NSString* _Nonnull)name contentType:(NSString* _Nonnull)type data:(NSData* _Nonnull)data {
+  if ((self = [super initWithControlName:name contentType:type])) {
+    _data = data;
+
+    if ([self.contentType hasPrefix:@"text/"]) {
+      NSString* charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
+      _string = [[NSString alloc] initWithData:_data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+    }
+  }
+  return self;
+}
+
+- (NSString*)description {
+  return [NSString stringWithFormat:@"<%@ | '%@' | %lu bytes>", [self class], self.mimeType, (unsigned long)_data.length];
+}
+
+@end
+
+@implementation GCDWebServerMultiPartFile
+
+- (instancetype)initWithControlName:(NSString* _Nonnull)name contentType:(NSString* _Nonnull)type fileName:(NSString* _Nonnull)fileName temporaryPath:(NSString* _Nonnull)temporaryPath {
+  if ((self = [super initWithControlName:name contentType:type])) {
+    _fileName = [fileName copy];
+    _temporaryPath = [temporaryPath copy];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  unlink([_temporaryPath fileSystemRepresentation]);
+}
+
+- (NSString*)description {
+  return [NSString stringWithFormat:@"<%@ | '%@' | '%@>'", [self class], self.mimeType, _fileName];
+}
+
+@end
+
+@implementation GCDWebServerMIMEStreamParser {
+  NSData* _boundary;
+  NSString* _defaultcontrolName;
+  ParserState _state;
+  NSMutableData* _data;
+  NSMutableArray<GCDWebServerMultiPartArgument*>* _arguments;
+  NSMutableArray<GCDWebServerMultiPartFile*>* _files;
+
+  NSString* _controlName;
+  NSString* _fileName;
+  NSString* _contentType;
+  NSString* _tmpPath;
+  int _tmpFile;
+  GCDWebServerMIMEStreamParser* _subParser;
+}
+
++ (void)initialize {
+  if (_newlineData == nil) {
+    _newlineData = [[NSData alloc] initWithBytes:"\r\n" length:2];
+    GWS_DCHECK(_newlineData);
+  }
+  if (_newlinesData == nil) {
+    _newlinesData = [[NSData alloc] initWithBytes:"\r\n\r\n" length:4];
+    GWS_DCHECK(_newlinesData);
+  }
+  if (_dashNewlineData == nil) {
+    _dashNewlineData = [[NSData alloc] initWithBytes:"--\r\n" length:4];
+    GWS_DCHECK(_dashNewlineData);
+  }
+}
+
+- (instancetype)initWithBoundary:(NSString* _Nonnull)boundary defaultControlName:(NSString* _Nullable)name arguments:(NSMutableArray<GCDWebServerMultiPartArgument*>* _Nonnull)arguments files:(NSMutableArray<GCDWebServerMultiPartFile*>* _Nonnull)files {
+  NSData* data = boundary.length ? [[NSString stringWithFormat:@"--%@", boundary] dataUsingEncoding:NSASCIIStringEncoding] : nil;
+  if (data == nil) {
+    GWS_DNOT_REACHED();
+    return nil;
+  }
+  if ((self = [super init])) {
+    _boundary = data;
+    _defaultcontrolName = name;
+    _arguments = arguments;
+    _files = files;
+    _data = [[NSMutableData alloc] initWithCapacity:kMultiPartBufferSize];
+    _state = kParserState_Start;
+  }
+  return self;
+}
+
+- (void)dealloc {
+  if (_tmpFile > 0) {
+    close(_tmpFile);
+    unlink([_tmpPath fileSystemRepresentation]);
+  }
+}
+
+// http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2
+- (BOOL)_parseData {
+  BOOL success = YES;
+
+  if (_state == kParserState_Headers) {
+    NSRange range = [_data rangeOfData:_newlinesData options:0 range:NSMakeRange(0, _data.length)];
+    if (range.location != NSNotFound) {
+      _controlName = nil;
+      _fileName = nil;
+      _contentType = nil;
+      _tmpPath = nil;
+      _subParser = nil;
+      NSString* headers = [[NSString alloc] initWithData:[_data subdataWithRange:NSMakeRange(0, range.location)] encoding:NSUTF8StringEncoding];
+      if (headers) {
+        for (NSString* header in [headers componentsSeparatedByString:@"\r\n"]) {
+          NSRange subRange = [header rangeOfString:@":"];
+          if (subRange.location != NSNotFound) {
+            NSString* name = [header substringToIndex:subRange.location];
+            NSString* value = [[header substringFromIndex:(subRange.location + subRange.length)] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            if ([name caseInsensitiveCompare:@"Content-Type"] == NSOrderedSame) {
+              _contentType = GCDWebServerNormalizeHeaderValue(value);
+            } else if ([name caseInsensitiveCompare:@"Content-Disposition"] == NSOrderedSame) {
+              NSString* contentDisposition = GCDWebServerNormalizeHeaderValue(value);
+              if ([GCDWebServerTruncateHeaderValue(contentDisposition) isEqualToString:@"form-data"]) {
+                _controlName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"name");
+                _fileName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"filename");
+              } else if ([GCDWebServerTruncateHeaderValue(contentDisposition) isEqualToString:@"file"]) {
+                _controlName = _defaultcontrolName;
+                _fileName = GCDWebServerExtractHeaderValueParameter(contentDisposition, @"filename");
+              }
+            }
+          } else {
+            GWS_DNOT_REACHED();
+          }
+        }
+        if (_contentType == nil) {
+          _contentType = @"text/plain";
+        }
+      } else {
+        GWS_LOG_ERROR(@"Failed decoding headers in part of 'multipart/form-data'");
+        GWS_DNOT_REACHED();
+      }
+      if (_controlName) {
+        if ([GCDWebServerTruncateHeaderValue(_contentType) isEqualToString:@"multipart/mixed"]) {
+          NSString* boundary = GCDWebServerExtractHeaderValueParameter(_contentType, @"boundary");
+          _subParser = [[GCDWebServerMIMEStreamParser alloc] initWithBoundary:boundary defaultControlName:_controlName arguments:_arguments files:_files];
+          if (_subParser == nil) {
+            GWS_DNOT_REACHED();
+            success = NO;
+          }
+        } else if (_fileName) {
+          NSString* path = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSProcessInfo processInfo] globallyUniqueString]];
+          _tmpFile = open([path fileSystemRepresentation], O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+          if (_tmpFile > 0) {
+            _tmpPath = [path copy];
+          } else {
+            GWS_DNOT_REACHED();
+            success = NO;
+          }
+        }
+      } else {
+        GWS_DNOT_REACHED();
+        success = NO;
+      }
+
+      [_data replaceBytesInRange:NSMakeRange(0, range.location + range.length) withBytes:NULL length:0];
+      _state = kParserState_Content;
+    }
+  }
+
+  if ((_state == kParserState_Start) || (_state == kParserState_Content)) {
+    NSRange range = [_data rangeOfData:_boundary options:0 range:NSMakeRange(0, _data.length)];
+    if (range.location != NSNotFound) {
+      NSRange subRange = NSMakeRange(range.location + range.length, _data.length - range.location - range.length);
+      NSRange subRange1 = [_data rangeOfData:_newlineData options:NSDataSearchAnchored range:subRange];
+      NSRange subRange2 = [_data rangeOfData:_dashNewlineData options:NSDataSearchAnchored range:subRange];
+      if ((subRange1.location != NSNotFound) || (subRange2.location != NSNotFound)) {
+        if (_state == kParserState_Content) {
+          const void* dataBytes = _data.bytes;
+          NSUInteger dataLength = range.location - 2;
+          if (_subParser) {
+            if (![_subParser appendBytes:dataBytes length:(dataLength + 2)] || ![_subParser isAtEnd]) {
+              GWS_DNOT_REACHED();
+              success = NO;
+            }
+            _subParser = nil;
+          } else if (_tmpPath) {
+            ssize_t result = write(_tmpFile, dataBytes, dataLength);
+            if (result == (ssize_t)dataLength) {
+              if (close(_tmpFile) == 0) {
+                _tmpFile = 0;
+                GCDWebServerMultiPartFile* file = [[GCDWebServerMultiPartFile alloc] initWithControlName:_controlName contentType:_contentType fileName:_fileName temporaryPath:_tmpPath];
+                [_files addObject:file];
+              } else {
+                GWS_DNOT_REACHED();
+                success = NO;
+              }
+            } else {
+              GWS_DNOT_REACHED();
+              success = NO;
+            }
+            _tmpPath = nil;
+          } else {
+            NSData* data = [[NSData alloc] initWithBytes:(void*)dataBytes length:dataLength];
+            GCDWebServerMultiPartArgument* argument = [[GCDWebServerMultiPartArgument alloc] initWithControlName:_controlName contentType:_contentType data:data];
+            [_arguments addObject:argument];
+          }
+        }
+
+        if (subRange1.location != NSNotFound) {
+          [_data replaceBytesInRange:NSMakeRange(0, subRange1.location + subRange1.length) withBytes:NULL length:0];
+          _state = kParserState_Headers;
+          success = [self _parseData];
+        } else {
+          _state = kParserState_End;
+        }
+      }
+    } else {
+      NSUInteger margin = 2 * _boundary.length;
+      if (_data.length > margin) {
+        NSUInteger length = _data.length - margin;
+        if (_subParser) {
+          if ([_subParser appendBytes:_data.bytes length:length]) {
+            [_data replaceBytesInRange:NSMakeRange(0, length) withBytes:NULL length:0];
+          } else {
+            GWS_DNOT_REACHED();
+            success = NO;
+          }
+        } else if (_tmpPath) {
+          ssize_t result = write(_tmpFile, _data.bytes, length);
+          if (result == (ssize_t)length) {
+            [_data replaceBytesInRange:NSMakeRange(0, length) withBytes:NULL length:0];
+          } else {
+            GWS_DNOT_REACHED();
+            success = NO;
+          }
+        }
+      }
+    }
+  }
+
+  return success;
+}
+
+- (BOOL)appendBytes:(const void*)bytes length:(NSUInteger)length {
+  [_data appendBytes:bytes length:length];
+  return [self _parseData];
+}
+
+- (BOOL)isAtEnd {
+  return (_state == kParserState_End);
+}
+
+@end
+
+@interface GCDWebServerMultiPartFormRequest ()
+@property(nonatomic) NSMutableArray<GCDWebServerMultiPartArgument*>* arguments;
+@property(nonatomic) NSMutableArray<GCDWebServerMultiPartFile*>* files;
+@end
+
+@implementation GCDWebServerMultiPartFormRequest {
+  GCDWebServerMIMEStreamParser* _parser;
+}
+
++ (NSString*)mimeType {
+  return @"multipart/form-data";
+}
+
+- (instancetype)initWithMethod:(NSString*)method url:(NSURL*)url headers:(NSDictionary<NSString*, NSString*>*)headers path:(NSString*)path query:(NSDictionary<NSString*, NSString*>*)query {
+  if ((self = [super initWithMethod:method url:url headers:headers path:path query:query])) {
+    _arguments = [[NSMutableArray alloc] init];
+    _files = [[NSMutableArray alloc] init];
+  }
+  return self;
+}
+
+- (BOOL)open:(NSError**)error {
+  NSString* boundary = GCDWebServerExtractHeaderValueParameter(self.contentType, @"boundary");
+  _parser = [[GCDWebServerMIMEStreamParser alloc] initWithBoundary:boundary defaultControlName:nil arguments:_arguments files:_files];
+  if (_parser == nil) {
+    if (error) {
+      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Failed starting to parse multipart form data"}];
+    }
+    return NO;
+  }
+  return YES;
+}
+
+- (BOOL)writeData:(NSData*)data error:(NSError**)error {
+  if (![_parser appendBytes:data.bytes length:data.length]) {
+    if (error) {
+      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Failed continuing to parse multipart form data"}];
+    }
+    return NO;
+  }
+  return YES;
+}
+
+- (BOOL)close:(NSError**)error {
+  BOOL atEnd = [_parser isAtEnd];
+  _parser = nil;
+  if (!atEnd) {
+    if (error) {
+      *error = [NSError errorWithDomain:kGCDWebServerErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Failed finishing to parse multipart form data"}];
+    }
+    return NO;
+  }
+  return YES;
+}
+
+- (GCDWebServerMultiPartArgument*)firstArgumentForControlName:(NSString*)name {
+  for (GCDWebServerMultiPartArgument* argument in _arguments) {
+    if ([argument.controlName isEqualToString:name]) {
+      return argument;
+    }
+  }
+  return nil;
+}
+
+- (GCDWebServerMultiPartFile*)firstFileForControlName:(NSString*)name {
+  for (GCDWebServerMultiPartFile* file in _files) {
+    if ([file.controlName isEqualToString:name]) {
+      return file;
+    }
+  }
+  return nil;
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithString:[super description]];
+  if (_arguments.count) {
+    [description appendString:@"\n"];
+    for (GCDWebServerMultiPartArgument* argument in _arguments) {
+      [description appendFormat:@"\n%@ (%@)\n", argument.controlName, argument.contentType];
+      [description appendString:GCDWebServerDescribeData(argument.data, argument.contentType)];
+    }
+  }
+  if (_files.count) {
+    [description appendString:@"\n"];
+    for (GCDWebServerMultiPartFile* file in _files) {
+      [description appendFormat:@"\n%@ (%@): %@\n{%@}", file.controlName, file.contentType, file.fileName, file.temporaryPath];
+    }
+  }
+  return description;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.h
@@ -1,0 +1,55 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerDataRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerURLEncodedFormRequest subclass of GCDWebServerRequest
+ *  parses the body of the HTTP request as a URL encoded form using
+ *  GCDWebServerParseURLEncodedForm().
+ */
+@interface GCDWebServerURLEncodedFormRequest : GCDWebServerDataRequest
+
+/**
+ *  Returns the unescaped control names and values for the URL encoded form.
+ *
+ *  The text encoding used to interpret the data is extracted from the
+ *  "Content-Type" header or defaults to UTF-8.
+ */
+@property(nonatomic, readonly) NSDictionary<NSString*, NSString*>* arguments;
+
+/**
+ *  Returns the MIME type for URL encoded forms
+ *  i.e. "application/x-www-form-urlencoded".
+ */
++ (NSString*)mimeType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Requests/GCDWebServerURLEncodedFormRequest.m
@@ -1,0 +1,60 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+@implementation GCDWebServerURLEncodedFormRequest
+
++ (NSString*)mimeType {
+  return @"application/x-www-form-urlencoded";
+}
+
+- (BOOL)close:(NSError**)error {
+  if (![super close:error]) {
+    return NO;
+  }
+
+  NSString* charset = GCDWebServerExtractHeaderValueParameter(self.contentType, @"charset");
+  NSString* string = [[NSString alloc] initWithData:self.data encoding:GCDWebServerStringEncodingFromCharset(charset)];
+  _arguments = GCDWebServerParseURLEncodedForm(string);
+  return YES;
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithString:[super description]];
+  [description appendString:@"\n"];
+  for (NSString* argument in [[_arguments allKeys] sortedArrayUsingSelector:@selector(compare:)]) {
+    [description appendFormat:@"\n%@ = %@", argument, [_arguments objectForKey:argument]];
+  }
+  return description;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerDataResponse.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerDataResponse.h
@@ -1,0 +1,113 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerDataResponse subclass of GCDWebServerResponse reads the body
+ *  of the HTTP response from memory.
+ */
+@interface GCDWebServerDataResponse : GCDWebServerResponse
+@property(nonatomic, copy) NSString* contentType;  // Redeclare as non-null
+
+/**
+ *  Creates a response with data in memory and a given content type.
+ */
++ (instancetype)responseWithData:(NSData*)data contentType:(NSString*)type;
+
+/**
+ *  This method is the designated initializer for the class.
+ */
+- (instancetype)initWithData:(NSData*)data contentType:(NSString*)type;
+
+@end
+
+@interface GCDWebServerDataResponse (Extensions)
+
+/**
+ *  Creates a data response from text encoded using UTF-8.
+ */
++ (nullable instancetype)responseWithText:(NSString*)text;
+
+/**
+ *  Creates a data response from HTML encoded using UTF-8.
+ */
++ (nullable instancetype)responseWithHTML:(NSString*)html;
+
+/**
+ *  Creates a data response from an HTML template encoded using UTF-8.
+ *  See -initWithHTMLTemplate:variables: for details.
+ */
++ (nullable instancetype)responseWithHTMLTemplate:(NSString*)path variables:(NSDictionary<NSString*, NSString*>*)variables;
+
+/**
+ *  Creates a data response from a serialized JSON object and the default
+ *  "application/json" content type.
+ */
++ (nullable instancetype)responseWithJSONObject:(id)object;
+
+/**
+ *  Creates a data response from a serialized JSON object and a custom
+ *  content type.
+ */
++ (nullable instancetype)responseWithJSONObject:(id)object contentType:(NSString*)type;
+
+/**
+ *  Initializes a data response from text encoded using UTF-8.
+ */
+- (nullable instancetype)initWithText:(NSString*)text;
+
+/**
+ *  Initializes a data response from HTML encoded using UTF-8.
+ */
+- (nullable instancetype)initWithHTML:(NSString*)html;
+
+/**
+ *  Initializes a data response from an HTML template encoded using UTF-8.
+ *
+ *  All occurences of "%variable%" within the HTML template are replaced with
+ *  their corresponding values.
+ */
+- (nullable instancetype)initWithHTMLTemplate:(NSString*)path variables:(NSDictionary<NSString*, NSString*>*)variables;
+
+/**
+ *  Initializes a data response from a serialized JSON object and the default
+ *  "application/json" content type.
+ */
+- (nullable instancetype)initWithJSONObject:(id)object;
+
+/**
+ *  Initializes a data response from a serialized JSON object and a custom
+ *  content type.
+ */
+- (nullable instancetype)initWithJSONObject:(id)object contentType:(NSString*)type;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerDataResponse.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerDataResponse.m
@@ -1,0 +1,136 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+@implementation GCDWebServerDataResponse {
+  NSData* _data;
+  BOOL _done;
+}
+
+@dynamic contentType;
+
++ (instancetype)responseWithData:(NSData*)data contentType:(NSString*)type {
+  return [(GCDWebServerDataResponse*)[[self class] alloc] initWithData:data contentType:type];
+}
+
+- (instancetype)initWithData:(NSData*)data contentType:(NSString*)type {
+  if ((self = [super init])) {
+    _data = data;
+
+    self.contentType = type;
+    self.contentLength = data.length;
+  }
+  return self;
+}
+
+- (NSData*)readData:(NSError**)error {
+  NSData* data;
+  if (_done) {
+    data = [NSData data];
+  } else {
+    data = _data;
+    _done = YES;
+  }
+  return data;
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithString:[super description]];
+  [description appendString:@"\n\n"];
+  [description appendString:GCDWebServerDescribeData(_data, self.contentType)];
+  return description;
+}
+
+@end
+
+@implementation GCDWebServerDataResponse (Extensions)
+
++ (instancetype)responseWithText:(NSString*)text {
+  return [(GCDWebServerDataResponse*)[self alloc] initWithText:text];
+}
+
++ (instancetype)responseWithHTML:(NSString*)html {
+  return [(GCDWebServerDataResponse*)[self alloc] initWithHTML:html];
+}
+
++ (instancetype)responseWithHTMLTemplate:(NSString*)path variables:(NSDictionary<NSString*, NSString*>*)variables {
+  return [(GCDWebServerDataResponse*)[self alloc] initWithHTMLTemplate:path variables:variables];
+}
+
++ (instancetype)responseWithJSONObject:(id)object {
+  return [(GCDWebServerDataResponse*)[self alloc] initWithJSONObject:object];
+}
+
++ (instancetype)responseWithJSONObject:(id)object contentType:(NSString*)type {
+  return [(GCDWebServerDataResponse*)[self alloc] initWithJSONObject:object contentType:type];
+}
+
+- (instancetype)initWithText:(NSString*)text {
+  NSData* data = [text dataUsingEncoding:NSUTF8StringEncoding];
+  if (data == nil) {
+    GWS_DNOT_REACHED();
+    return nil;
+  }
+  return [self initWithData:data contentType:@"text/plain; charset=utf-8"];
+}
+
+- (instancetype)initWithHTML:(NSString*)html {
+  NSData* data = [html dataUsingEncoding:NSUTF8StringEncoding];
+  if (data == nil) {
+    GWS_DNOT_REACHED();
+    return nil;
+  }
+  return [self initWithData:data contentType:@"text/html; charset=utf-8"];
+}
+
+- (instancetype)initWithHTMLTemplate:(NSString*)path variables:(NSDictionary<NSString*, NSString*>*)variables {
+  NSMutableString* html = [[NSMutableString alloc] initWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
+  [variables enumerateKeysAndObjectsUsingBlock:^(NSString* key, NSString* value, BOOL* stop) {
+    [html replaceOccurrencesOfString:[NSString stringWithFormat:@"%%%@%%", key] withString:value options:0 range:NSMakeRange(0, html.length)];
+  }];
+  return [self initWithHTML:html];
+}
+
+- (instancetype)initWithJSONObject:(id)object {
+  return [self initWithJSONObject:object contentType:@"application/json"];
+}
+
+- (instancetype)initWithJSONObject:(id)object contentType:(NSString*)type {
+  NSData* data = [NSJSONSerialization dataWithJSONObject:object options:0 error:NULL];
+  if (data == nil) {
+    GWS_DNOT_REACHED();
+    return nil;
+  }
+  return [self initWithData:data contentType:type];
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerErrorResponse.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerErrorResponse.h
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerDataResponse.h"
+#import "GCDWebServerHTTPStatusCodes.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerDataResponse subclass of GCDWebServerDataResponse generates
+ *  an HTML body from an HTTP status code and an error message.
+ */
+@interface GCDWebServerErrorResponse : GCDWebServerDataResponse
+
+/**
+ *  Creates a client error response with the corresponding HTTP status code.
+ */
++ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);
+
+/**
+ *  Creates a server error response with the corresponding HTTP status code.
+ */
++ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);
+
+/**
+ *  Creates a client error response with the corresponding HTTP status code
+ *  and an underlying NSError.
+ */
++ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
+
+/**
+ *  Creates a server error response with the corresponding HTTP status code
+ *  and an underlying NSError.
+ */
++ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
+
+/**
+ *  Initializes a client error response with the corresponding HTTP status code.
+ */
+- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);
+
+/**
+ *  Initializes a server error response with the corresponding HTTP status code.
+ */
+- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString*)format, ... NS_FORMAT_FUNCTION(2, 3);
+
+/**
+ *  Initializes a client error response with the corresponding HTTP status code
+ *  and an underlying NSError.
+ */
+- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
+
+/**
+ *  Initializes a server error response with the corresponding HTTP status code
+ *  and an underlying NSError.
+ */
+- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(nullable NSError*)underlyingError message:(NSString*)format, ... NS_FORMAT_FUNCTION(3, 4);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerErrorResponse.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerErrorResponse.m
@@ -1,0 +1,124 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+@implementation GCDWebServerErrorResponse
+
++ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
+  GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
+  va_list arguments;
+  va_start(arguments, format);
+  GCDWebServerErrorResponse* response = [(GCDWebServerErrorResponse*)[self alloc] initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
+  va_end(arguments);
+  return response;
+}
+
++ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
+  GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
+  va_list arguments;
+  va_start(arguments, format);
+  GCDWebServerErrorResponse* response = [(GCDWebServerErrorResponse*)[self alloc] initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
+  va_end(arguments);
+  return response;
+}
+
++ (instancetype)responseWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(NSError*)underlyingError message:(NSString*)format, ... {
+  GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
+  va_list arguments;
+  va_start(arguments, format);
+  GCDWebServerErrorResponse* response = [(GCDWebServerErrorResponse*)[self alloc] initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
+  va_end(arguments);
+  return response;
+}
+
++ (instancetype)responseWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(NSError*)underlyingError message:(NSString*)format, ... {
+  GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
+  va_list arguments;
+  va_start(arguments, format);
+  GCDWebServerErrorResponse* response = [(GCDWebServerErrorResponse*)[self alloc] initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
+  va_end(arguments);
+  return response;
+}
+
+static inline NSString* _EscapeHTMLString(NSString* string) {
+  return [string stringByReplacingOccurrencesOfString:@"\"" withString:@"&quot;"];
+}
+
+- (instancetype)initWithStatusCode:(NSInteger)statusCode underlyingError:(NSError*)underlyingError messageFormat:(NSString*)format arguments:(va_list)arguments {
+  NSString* message = [[NSString alloc] initWithFormat:format arguments:arguments];
+  NSString* title = [NSString stringWithFormat:@"HTTP Error %i", (int)statusCode];
+  NSString* error = underlyingError ? [NSString stringWithFormat:@"[%@] %@ (%li)", underlyingError.domain, _EscapeHTMLString(underlyingError.localizedDescription), (long)underlyingError.code] : @"";
+  NSString* html = [NSString stringWithFormat:@"<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>%@</title></head><body><h1>%@: %@</h1><h3>%@</h3></body></html>",
+                                              title, title, _EscapeHTMLString(message), error];
+  if ((self = [self initWithHTML:html])) {
+    self.statusCode = statusCode;
+  }
+  return self;
+}
+
+- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
+  GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
+  va_list arguments;
+  va_start(arguments, format);
+  self = [self initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
+  va_end(arguments);
+  return self;
+}
+
+- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode message:(NSString*)format, ... {
+  GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
+  va_list arguments;
+  va_start(arguments, format);
+  self = [self initWithStatusCode:errorCode underlyingError:nil messageFormat:format arguments:arguments];
+  va_end(arguments);
+  return self;
+}
+
+- (instancetype)initWithClientError:(GCDWebServerClientErrorHTTPStatusCode)errorCode underlyingError:(NSError*)underlyingError message:(NSString*)format, ... {
+  GWS_DCHECK(((NSInteger)errorCode >= 400) && ((NSInteger)errorCode < 500));
+  va_list arguments;
+  va_start(arguments, format);
+  self = [self initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
+  va_end(arguments);
+  return self;
+}
+
+- (instancetype)initWithServerError:(GCDWebServerServerErrorHTTPStatusCode)errorCode underlyingError:(NSError*)underlyingError message:(NSString*)format, ... {
+  GWS_DCHECK(((NSInteger)errorCode >= 500) && ((NSInteger)errorCode < 600));
+  va_list arguments;
+  va_start(arguments, format);
+  self = [self initWithStatusCode:errorCode underlyingError:underlyingError messageFormat:format arguments:arguments];
+  va_end(arguments);
+  return self;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerFileResponse.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerFileResponse.h
@@ -1,0 +1,108 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerFileResponse subclass of GCDWebServerResponse reads the body
+ *  of the HTTP response from a file on disk.
+ *
+ *  It will automatically set the contentType, lastModifiedDate and eTag
+ *  properties of the GCDWebServerResponse according to the file extension and
+ *  metadata.
+ */
+@interface GCDWebServerFileResponse : GCDWebServerResponse
+@property(nonatomic, copy) NSString* contentType;  // Redeclare as non-null
+@property(nonatomic) NSDate* lastModifiedDate;  // Redeclare as non-null
+@property(nonatomic, copy) NSString* eTag;  // Redeclare as non-null
+
+/**
+ *  Creates a response with the contents of a file.
+ */
++ (nullable instancetype)responseWithFile:(NSString*)path;
+
+/**
+ *  Creates a response like +responseWithFile: and sets the "Content-Disposition"
+ *  HTTP header for a download if the "attachment" argument is YES.
+ */
++ (nullable instancetype)responseWithFile:(NSString*)path isAttachment:(BOOL)attachment;
+
+/**
+ *  Creates a response like +responseWithFile: but restricts the file contents
+ *  to a specific byte range.
+ *
+ *  See -initWithFile:byteRange: for details.
+ */
++ (nullable instancetype)responseWithFile:(NSString*)path byteRange:(NSRange)range;
+
+/**
+ *  Creates a response like +responseWithFile:byteRange: and sets the
+ *  "Content-Disposition" HTTP header for a download if the "attachment"
+ *  argument is YES.
+ */
++ (nullable instancetype)responseWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment;
+
+/**
+ *  Initializes a response with the contents of a file.
+ */
+- (nullable instancetype)initWithFile:(NSString*)path;
+
+/**
+ *  Initializes a response like +responseWithFile: and sets the
+ *  "Content-Disposition" HTTP header for a download if the "attachment"
+ *  argument is YES.
+ */
+- (nullable instancetype)initWithFile:(NSString*)path isAttachment:(BOOL)attachment;
+
+/**
+ *  Initializes a response like -initWithFile: but restricts the file contents
+ *  to a specific byte range. This range should be set to (NSUIntegerMax, 0) for
+ *  the full file, (offset, length) if expressed from the beginning of the file,
+ *  or (NSUIntegerMax, length) if expressed from the end of the file. The "offset"
+ *  and "length" values will be automatically adjusted to be compatible with the
+ *  actual size of the file.
+ *
+ *  This argument would typically be set to the value of the byteRange property
+ *  of the current GCDWebServerRequest.
+ */
+- (nullable instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range;
+
+/**
+ *  This method is the designated initializer for the class.
+ *
+ *  If MIME type overrides are specified, they allow to customize the built-in
+ *  mapping from extensions to MIME types. Keys of the dictionary must be lowercased
+ *  file extensions without the period, and the values must be the corresponding
+ *  MIME types.
+ */
+- (nullable instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment mimeTypeOverrides:(nullable NSDictionary<NSString*, NSString*>*)overrides;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerFileResponse.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerFileResponse.m
@@ -1,0 +1,185 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import <sys/stat.h>
+
+#import "GCDWebServerPrivate.h"
+
+#define kFileReadBufferSize (32 * 1024)
+
+@implementation GCDWebServerFileResponse {
+  NSString* _path;
+  NSUInteger _offset;
+  NSUInteger _size;
+  int _file;
+}
+
+@dynamic contentType, lastModifiedDate, eTag;
+
++ (instancetype)responseWithFile:(NSString*)path {
+  return [(GCDWebServerFileResponse*)[[self class] alloc] initWithFile:path];
+}
+
++ (instancetype)responseWithFile:(NSString*)path isAttachment:(BOOL)attachment {
+  return [(GCDWebServerFileResponse*)[[self class] alloc] initWithFile:path isAttachment:attachment];
+}
+
++ (instancetype)responseWithFile:(NSString*)path byteRange:(NSRange)range {
+  return [(GCDWebServerFileResponse*)[[self class] alloc] initWithFile:path byteRange:range];
+}
+
++ (instancetype)responseWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment {
+  return [(GCDWebServerFileResponse*)[[self class] alloc] initWithFile:path byteRange:range isAttachment:attachment mimeTypeOverrides:nil];
+}
+
+- (instancetype)initWithFile:(NSString*)path {
+  return [self initWithFile:path byteRange:NSMakeRange(NSUIntegerMax, 0) isAttachment:NO mimeTypeOverrides:nil];
+}
+
+- (instancetype)initWithFile:(NSString*)path isAttachment:(BOOL)attachment {
+  return [self initWithFile:path byteRange:NSMakeRange(NSUIntegerMax, 0) isAttachment:attachment mimeTypeOverrides:nil];
+}
+
+- (instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range {
+  return [self initWithFile:path byteRange:range isAttachment:NO mimeTypeOverrides:nil];
+}
+
+static inline NSDate* _NSDateFromTimeSpec(const struct timespec* t) {
+  return [NSDate dateWithTimeIntervalSince1970:((NSTimeInterval)t->tv_sec + (NSTimeInterval)t->tv_nsec / 1000000000.0)];
+}
+
+- (instancetype)initWithFile:(NSString*)path byteRange:(NSRange)range isAttachment:(BOOL)attachment mimeTypeOverrides:(NSDictionary<NSString*, NSString*>*)overrides {
+  struct stat info;
+  if (lstat([path fileSystemRepresentation], &info) || !(info.st_mode & S_IFREG)) {
+    GWS_DNOT_REACHED();
+    return nil;
+  }
+#ifndef __LP64__
+  if (info.st_size >= (off_t)4294967295) {  // In 32 bit mode, we can't handle files greater than 4 GiBs (don't use "NSUIntegerMax" here to avoid potential unsigned to signed conversion issues)
+    GWS_DNOT_REACHED();
+    return nil;
+  }
+#endif
+  NSUInteger fileSize = (NSUInteger)info.st_size;
+
+  BOOL hasByteRange = GCDWebServerIsValidByteRange(range);
+  if (hasByteRange) {
+    if (range.location != NSUIntegerMax) {
+      range.location = MIN(range.location, fileSize);
+      range.length = MIN(range.length, fileSize - range.location);
+    } else {
+      range.length = MIN(range.length, fileSize);
+      range.location = fileSize - range.length;
+    }
+    if (range.length == 0) {
+      return nil;  // TODO: Return 416 status code and "Content-Range: bytes */{file length}" header
+    }
+  } else {
+    range.location = 0;
+    range.length = fileSize;
+  }
+
+  if ((self = [super init])) {
+    _path = [path copy];
+    _offset = range.location;
+    _size = range.length;
+    if (hasByteRange) {
+      [self setStatusCode:kGCDWebServerHTTPStatusCode_PartialContent];
+      [self setValue:[NSString stringWithFormat:@"bytes %lu-%lu/%lu", (unsigned long)_offset, (unsigned long)(_offset + _size - 1), (unsigned long)fileSize] forAdditionalHeader:@"Content-Range"];
+      GWS_LOG_DEBUG(@"Using content bytes range [%lu-%lu] for file \"%@\"", (unsigned long)_offset, (unsigned long)(_offset + _size - 1), path);
+    }
+
+    if (attachment) {
+      NSString* fileName = [path lastPathComponent];
+      NSData* data = [[fileName stringByReplacingOccurrencesOfString:@"\"" withString:@""] dataUsingEncoding:NSISOLatin1StringEncoding allowLossyConversion:YES];
+      NSString* lossyFileName = data ? [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding] : nil;
+      if (lossyFileName) {
+        NSString* value = [NSString stringWithFormat:@"attachment; filename=\"%@\"; filename*=UTF-8''%@", lossyFileName, GCDWebServerEscapeURLString(fileName)];
+        [self setValue:value forAdditionalHeader:@"Content-Disposition"];
+      } else {
+        GWS_DNOT_REACHED();
+      }
+    }
+
+    self.contentType = GCDWebServerGetMimeTypeForExtension([_path pathExtension], overrides);
+    self.contentLength = _size;
+    self.lastModifiedDate = _NSDateFromTimeSpec(&info.st_mtimespec);
+    self.eTag = [NSString stringWithFormat:@"%llu/%li/%li", info.st_ino, info.st_mtimespec.tv_sec, info.st_mtimespec.tv_nsec];
+  }
+  return self;
+}
+
+- (BOOL)open:(NSError**)error {
+  _file = open([_path fileSystemRepresentation], O_NOFOLLOW | O_RDONLY);
+  if (_file <= 0) {
+    if (error) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
+    return NO;
+  }
+  if (lseek(_file, _offset, SEEK_SET) != (off_t)_offset) {
+    if (error) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
+    close(_file);
+    return NO;
+  }
+  return YES;
+}
+
+- (NSData*)readData:(NSError**)error {
+  size_t length = MIN((NSUInteger)kFileReadBufferSize, _size);
+  NSMutableData* data = [[NSMutableData alloc] initWithLength:length];
+  ssize_t result = read(_file, data.mutableBytes, length);
+  if (result < 0) {
+    if (error) {
+      *error = GCDWebServerMakePosixError(errno);
+    }
+    return nil;
+  }
+  if (result > 0) {
+    [data setLength:result];
+    _size -= result;
+  }
+  return data;
+}
+
+- (void)close {
+  close(_file);
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithString:[super description]];
+  [description appendFormat:@"\n\n{%@}", _path];
+  return description;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerStreamedResponse.h
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerStreamedResponse.h
@@ -1,0 +1,80 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "GCDWebServerResponse.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The GCDWebServerStreamBlock is called to stream the data for the HTTP body.
+ *  The block must return either a chunk of data, an empty NSData when done, or
+ *  nil on error and set the "error" argument which is guaranteed to be non-NULL.
+ */
+typedef NSData* _Nullable (^GCDWebServerStreamBlock)(NSError** error);
+
+/**
+ *  The GCDWebServerAsyncStreamBlock works like the GCDWebServerStreamBlock
+ *  except the streamed data can be returned at a later time allowing for
+ *  truly asynchronous generation of the data.
+ *
+ *  The block must call "completionBlock" passing the new chunk of data when ready,
+ *  an empty NSData when done, or nil on error and pass a NSError.
+ *
+ *  The block cannot call "completionBlock" more than once per invocation.
+ */
+typedef void (^GCDWebServerAsyncStreamBlock)(GCDWebServerBodyReaderCompletionBlock completionBlock);
+
+/**
+ *  The GCDWebServerStreamedResponse subclass of GCDWebServerResponse streams
+ *  the body of the HTTP response using a GCD block.
+ */
+@interface GCDWebServerStreamedResponse : GCDWebServerResponse
+@property(nonatomic, copy) NSString* contentType;  // Redeclare as non-null
+
+/**
+ *  Creates a response with streamed data and a given content type.
+ */
++ (instancetype)responseWithContentType:(NSString*)type streamBlock:(GCDWebServerStreamBlock)block;
+
+/**
+ *  Creates a response with async streamed data and a given content type.
+ */
++ (instancetype)responseWithContentType:(NSString*)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block;
+
+/**
+ *  Initializes a response with streamed data and a given content type.
+ */
+- (instancetype)initWithContentType:(NSString*)type streamBlock:(GCDWebServerStreamBlock)block;
+
+/**
+ *  This method is the designated initializer for the class.
+ */
+- (instancetype)initWithContentType:(NSString*)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerStreamedResponse.m
+++ b/ThirdParty/GCDWebServer/GCDWebServer/Responses/GCDWebServerStreamedResponse.m
@@ -1,0 +1,76 @@
+/*
+ Copyright (c) 2012-2019, Pierre-Olivier Latour
+ All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in the
+ documentation and/or other materials provided with the distribution.
+ * The name of Pierre-Olivier Latour may not be used to endorse
+ or promote products derived from this software without specific
+ prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if !__has_feature(objc_arc)
+#error GCDWebServer requires ARC
+#endif
+
+#import "GCDWebServerPrivate.h"
+
+@implementation GCDWebServerStreamedResponse {
+  GCDWebServerAsyncStreamBlock _block;
+}
+
+@dynamic contentType;
+
++ (instancetype)responseWithContentType:(NSString*)type streamBlock:(GCDWebServerStreamBlock)block {
+  return [(GCDWebServerStreamedResponse*)[[self class] alloc] initWithContentType:type streamBlock:block];
+}
+
++ (instancetype)responseWithContentType:(NSString*)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block {
+  return [(GCDWebServerStreamedResponse*)[[self class] alloc] initWithContentType:type asyncStreamBlock:block];
+}
+
+- (instancetype)initWithContentType:(NSString*)type streamBlock:(GCDWebServerStreamBlock)block {
+  return [self initWithContentType:type
+                  asyncStreamBlock:^(GCDWebServerBodyReaderCompletionBlock completionBlock) {
+                    NSError* error = nil;
+                    NSData* data = block(&error);
+                    completionBlock(data, error);
+                  }];
+}
+
+- (instancetype)initWithContentType:(NSString*)type asyncStreamBlock:(GCDWebServerAsyncStreamBlock)block {
+  if ((self = [super init])) {
+    _block = [block copy];
+
+    self.contentType = type;
+  }
+  return self;
+}
+
+- (void)asyncReadDataWithCompletion:(GCDWebServerBodyReaderCompletionBlock)block {
+  _block(block);
+}
+
+- (NSString*)description {
+  NSMutableString* description = [NSMutableString stringWithString:[super description]];
+  [description appendString:@"\n\n<STREAM>"];
+  return description;
+}
+
+@end

--- a/ThirdParty/GCDWebServer/LICENSE
+++ b/ThirdParty/GCDWebServer/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2012-2014, Pierre-Olivier Latour
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The name of Pierre-Olivier Latour may not be used to endorse
+      or promote products derived from this software without specific
+      prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ThirdParty/GCDWebServer/UPSTREAM.md
+++ b/ThirdParty/GCDWebServer/UPSTREAM.md
@@ -1,0 +1,12 @@
+# GCDWebServer provenance
+
+- Repository: `https://github.com/swisspol/GCDWebServer`
+- Commit: `c6d118f4ecc1d9c2c6130fe8522b50889e78524b`
+- Imported paths: `GCDWebServer/Core`, `GCDWebServer/Requests`,
+  `GCDWebServer/Responses`, and `GCDWebDAVServer`
+- License: BSD 3-Clause; see `LICENSE`
+
+FilzaSlop links the complete WebDAV server in-process because the jailed IPA
+cannot load Filza's jailbreak-only launch daemon. The path normalizer includes
+a local guard that keeps leading parent components pinned at the configured
+WebDAV root instead of throwing on an empty component stack.

--- a/ThirdPartyNotices/GCDWebServer-LICENSE
+++ b/ThirdPartyNotices/GCDWebServer-LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2012-2014, Pierre-Olivier Latour
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The name of Pierre-Olivier Latour may not be used to endorse
+      or promote products derived from this software without specific
+      prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL PIERRE-OLIVIER LATOUR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/WebDAVRuntimeFix.m
+++ b/WebDAVRuntimeFix.m
@@ -1,0 +1,501 @@
+@import Foundation;
+@import UIKit;
+
+#import <objc/runtime.h>
+#import <string.h>
+#import <CommonCrypto/CommonDigest.h>
+
+#import "FilzaDiagnostics.h"
+#import "GCDWebDAVServer.h"
+#import "GCDWebServerConnection.h"
+#import "GCDWebServerResponse.h"
+
+// Filza still carries two WebDAV launch modes:
+//
+//  1. a jailbreak-only launchd service under /usr/libexec/filza; and
+//  2. an in-process GCDWebDAVServer owned by TGPreferences.
+//
+// The MobileHouseArrest/sideloaded build cannot install or load the launchd
+// service. Keep Filza's own server, UI, authentication, DAV implementation and
+// root selection, but force launches through the in-process path.
+
+static NSString * const FilzaWebDAVEnabledKey = @"air-browser";
+static NSString * const FilzaWebDAVServiceKey = @"air-browser-service";
+static NSString * const FilzaWebDAVPortKey = @"air-port";
+static NSString * const FilzaWebDAVBonjourKey = @"air-browser-bonjour";
+static NSString * const FilzaWebDAVSecurityKey = @"air-browser-security";
+
+static void (*FilzaOriginalStartAirBrowser)(id, SEL) = NULL;
+static void (*FilzaOriginalStopAirBrowser)(id, SEL) = NULL;
+static SEL FilzaStartAirBrowserSelector;
+static SEL FilzaStopAirBrowserSelector;
+static BOOL FilzaWebDAVStartInFlight = NO;
+static GCDWebDAVServer *FilzaPinnedWebDAVServer = nil;
+static NSString *FilzaWebDAVAuthenticationUsername = nil;
+static NSString *FilzaWebDAVAuthenticationPasswordMD5 = nil;
+static BOOL FilzaWebDAVAuthenticationRequired = NO;
+
+@interface FilzaWebDAVConnection : GCDWebServerConnection
+@end
+
+static NSString *FilzaWebDAVMD5(NSString *value)
+{
+    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char digest[CC_MD5_DIGEST_LENGTH];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    CC_MD5(data.bytes, (CC_LONG)data.length, digest);
+#pragma clang diagnostic pop
+    NSMutableString *hex = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    for (NSUInteger index = 0; index < CC_MD5_DIGEST_LENGTH; index++) {
+        [hex appendFormat:@"%02x", digest[index]];
+    }
+    return hex;
+}
+
+static BOOL FilzaWebDAVConstantTimeEqual(NSString *left, NSString *right)
+{
+    NSData *leftData = [[left lowercaseString] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *rightData = [[right lowercaseString] dataUsingEncoding:NSUTF8StringEncoding];
+    if (leftData.length != rightData.length) return NO;
+    const uint8_t *leftBytes = leftData.bytes;
+    const uint8_t *rightBytes = rightData.bytes;
+    uint8_t difference = 0;
+    for (NSUInteger index = 0; index < leftData.length; index++) {
+        difference |= leftBytes[index] ^ rightBytes[index];
+    }
+    return difference == 0;
+}
+
+@implementation FilzaWebDAVConnection
+
+- (GCDWebServerResponse *)preflightRequest:(GCDWebServerRequest *)request
+{
+    GCDWebServerResponse *upstreamResponse = [super preflightRequest:request];
+    FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:@"request %@ %@ auth-required=%@",
+        request.method ?: @"?", request.path ?: @"/",
+        FilzaWebDAVAuthenticationRequired ? @"YES" : @"NO"]);
+    if (upstreamResponse || !FilzaWebDAVAuthenticationRequired) return upstreamResponse;
+
+    BOOL authenticated = NO;
+    NSString *authorization = request.headers[@"Authorization"];
+    if ([authorization hasPrefix:@"Basic "]) {
+        NSData *credentialData = [[NSData alloc] initWithBase64EncodedString:[authorization substringFromIndex:6]
+                                                                     options:0];
+        NSString *credential = [[NSString alloc] initWithData:credentialData encoding:NSUTF8StringEncoding];
+        NSRange separator = [credential rangeOfString:@":"];
+        if (separator.location != NSNotFound) {
+            NSString *username = [credential substringToIndex:separator.location];
+            NSString *password = [credential substringFromIndex:separator.location + 1];
+            authenticated = [username isEqualToString:FilzaWebDAVAuthenticationUsername] &&
+                            FilzaWebDAVConstantTimeEqual(FilzaWebDAVMD5(password),
+                                                        FilzaWebDAVAuthenticationPasswordMD5);
+        }
+    }
+
+    if (authenticated) {
+        FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:@"authenticated %@ %@",
+            request.method ?: @"?", request.path ?: @"/"]);
+        return nil;
+    }
+    FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:@"rejected unauthenticated %@ %@",
+        request.method ?: @"?", request.path ?: @"/"]);
+    GCDWebServerResponse *response = [GCDWebServerResponse responseWithStatusCode:401];
+    [response setValue:@"Basic realm=\"FilzaSlop WebDAV\"" forAdditionalHeader:@"WWW-Authenticate"];
+    return response;
+}
+
+@end
+
+static id FilzaWebDAVCallObject(id target, NSString *selectorName)
+{
+    SEL selector = NSSelectorFromString(selectorName);
+    if (!target || ![target respondsToSelector:selector]) return nil;
+    IMP implementation = [target methodForSelector:selector];
+    if (!implementation) return nil;
+    return ((id (*)(id, SEL))implementation)(target, selector);
+}
+
+static BOOL FilzaWebDAVCallBool(id target, NSString *selectorName)
+{
+    SEL selector = NSSelectorFromString(selectorName);
+    if (!target || ![target respondsToSelector:selector]) return NO;
+    IMP implementation = [target methodForSelector:selector];
+    if (!implementation) return NO;
+    return ((BOOL (*)(id, SEL))implementation)(target, selector);
+}
+
+static id FilzaWebDAVPreference(id preferences, NSString *key)
+{
+    SEL selector = NSSelectorFromString(@"objectForPreferenceKey:");
+    if (!preferences || ![preferences respondsToSelector:selector]) return nil;
+    IMP implementation = [preferences methodForSelector:selector];
+    if (!implementation) return nil;
+    return ((id (*)(id, SEL, id))implementation)(preferences, selector, key);
+}
+
+static id FilzaWebDAVSecurePreference(id preferences, NSString *key)
+{
+    SEL selector = NSSelectorFromString(@"objectForSecurePreferenceKey:");
+    if (!preferences || ![preferences respondsToSelector:selector]) return FilzaWebDAVPreference(preferences, key);
+    IMP implementation = [preferences methodForSelector:selector];
+    if (!implementation) return FilzaWebDAVPreference(preferences, key);
+    id value = ((id (*)(id, SEL, id))implementation)(preferences, selector, key);
+    return value ?: FilzaWebDAVPreference(preferences, key);
+}
+
+static BOOL FilzaWebDAVBoolPreference(id preferences, NSString *key)
+{
+    id value = FilzaWebDAVPreference(preferences, key);
+    return [value respondsToSelector:@selector(boolValue)] && [value boolValue];
+}
+
+static const char *FilzaWebDAVUnqualifiedType(const char *type)
+{
+    while (type && strchr("rnNoORV", type[0])) type++;
+    return type;
+}
+
+static BOOL FilzaWebDAVSetPreference(id preferences, NSString *key, id value)
+{
+    SEL selector = NSSelectorFromString(@"setObject:forPreferenceKey:notification:");
+    NSMethodSignature *signature = [preferences methodSignatureForSelector:selector];
+    if (!signature || signature.numberOfArguments < 5) return NO;
+
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.target = preferences;
+    invocation.selector = selector;
+
+    __unsafe_unretained id valueArgument = value;
+    __unsafe_unretained id keyArgument = key;
+    [invocation setArgument:&valueArgument atIndex:2];
+    [invocation setArgument:&keyArgument atIndex:3];
+
+    const char *notificationType = FilzaWebDAVUnqualifiedType([signature getArgumentTypeAtIndex:4]);
+    if (notificationType && notificationType[0] == '@') {
+        __unsafe_unretained id notification = nil;
+        [invocation setArgument:&notification atIndex:4];
+    } else if (notificationType && (notificationType[0] == 'B' || notificationType[0] == 'c')) {
+        BOOL notification = NO;
+        [invocation setArgument:&notification atIndex:4];
+    } else {
+        NSUInteger zero = 0;
+        [invocation setArgument:&zero atIndex:4];
+    }
+
+    @try {
+        [invocation invoke];
+        return YES;
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+                               [NSString stringWithFormat:@"could not update %@: %@",
+                                key, exception.reason ?: exception.name]);
+        return NO;
+    }
+}
+
+static id FilzaWebDAVSharedPreferences(void)
+{
+    Class preferencesClass = NSClassFromString(@"TGPreferences");
+    SEL selector = NSSelectorFromString(@"sharedInstance");
+    if (!preferencesClass || ![preferencesClass respondsToSelector:selector]) return nil;
+    IMP implementation = [preferencesClass methodForSelector:selector];
+    if (!implementation) return nil;
+    return ((id (*)(id, SEL))implementation)(preferencesClass, selector);
+}
+
+static void FilzaWebDAVWriteStatus(NSString *status)
+{
+    NSString *path = [FilzaDiagnosticsDirectory() stringByAppendingPathComponent:@"WebDAVStatus.txt"];
+    NSString *timestamp = [NSISO8601DateFormatter.new stringFromDate:NSDate.date];
+    NSString *contents = [NSString stringWithFormat:@"%@\n%@\n",
+                          timestamp ?: NSDate.date.description,
+                          status ?: @"unknown"];
+    [contents writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
+}
+
+static void FilzaWebDAVForceInProcessSettings(id preferences)
+{
+    BOOL changed = FilzaWebDAVSetPreference(preferences, FilzaWebDAVServiceKey, @NO);
+
+    id portValue = FilzaWebDAVPreference(preferences, FilzaWebDAVPortKey);
+    NSInteger port = [portValue respondsToSelector:@selector(integerValue)] ? [portValue integerValue] : 0;
+    if (port < 1 || port > 65535) {
+        FilzaWebDAVSetPreference(preferences, FilzaWebDAVPortKey, @11111);
+        port = 11111;
+    }
+
+    FilzaDiagnosticsAppend(@"WebDAV",
+                           [NSString stringWithFormat:@"selected in-process server mode port=%ld setting-updated=%@",
+                            (long)port, changed ? @"YES" : @"NO"]);
+}
+
+static NSString *FilzaWebDAVTrimmedLog(id value)
+{
+    if (!value) return @"";
+    NSString *text = [value isKindOfClass:NSString.class] ? value : [value description];
+    if (text.length > 1200) text = [text substringFromIndex:text.length - 1200];
+    return [text stringByReplacingOccurrencesOfString:@"\n" withString:@" | "];
+}
+
+static void FilzaWebDAVAssignServer(id preferences, GCDWebDAVServer *server)
+{
+    SEL selector = NSSelectorFromString(@"setHttpServer:");
+    if (![preferences respondsToSelector:selector]) return;
+    IMP implementation = [preferences methodForSelector:selector];
+    if (implementation) ((void (*)(id, SEL, id))implementation)(preferences, selector, server);
+}
+
+static BOOL FilzaWebDAVStartPinnedServer(id preferences)
+{
+    NSString *root = FilzaWebDAVCallObject(preferences, @"uploaderPath");
+    BOOL isDirectory = NO;
+    if (![root isKindOfClass:NSString.class] ||
+        ![NSFileManager.defaultManager fileExistsAtPath:root isDirectory:&isDirectory] ||
+        !isDirectory) {
+        root = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+    }
+    if (!root.length) root = NSHomeDirectory();
+
+    NSInteger port = [FilzaWebDAVPreference(preferences, FilzaWebDAVPortKey) integerValue];
+    if (port < 1 || port > 65535) port = 11111;
+    BOOL bonjour = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVBonjourKey);
+    BOOL security = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVSecurityKey);
+
+    NSString *username = FilzaWebDAVSecurePreference(preferences, @"air-username");
+    NSString *passwordMD5 = FilzaWebDAVSecurePreference(preferences, @"air-password-md5");
+    if (security && (!username.length || passwordMD5.length != 32)) {
+        NSString *failure = @"authentication is enabled but Filza's saved username/password hash is incomplete; refusing to expose an unauthenticated server";
+        FilzaDiagnosticsAppend(@"WebDAV", failure);
+        FilzaWebDAVWriteStatus(failure);
+        return NO;
+    }
+
+    FilzaWebDAVAuthenticationRequired = security;
+    FilzaWebDAVAuthenticationUsername = security ? [username copy] : nil;
+    FilzaWebDAVAuthenticationPasswordMD5 = security ? [[passwordMD5 lowercaseString] copy] : nil;
+
+    GCDWebDAVServer *server = FilzaPinnedWebDAVServer;
+    id filzaServer = FilzaWebDAVCallObject(preferences, @"httpServer");
+    if ([filzaServer isKindOfClass:GCDWebDAVServer.class]) server = filzaServer;
+    if (!server || ![server.uploadDirectory isEqualToString:root]) {
+        [server stop];
+        server = [[GCDWebDAVServer alloc] initWithUploadDirectory:root];
+    }
+    server.allowHiddenItems = YES;
+
+    NSMutableDictionary<NSString *, id> *options = [@{
+        GCDWebServerOption_Port: @(port),
+        GCDWebServerOption_ServerName: @"FilzaSlop WebDAV",
+        GCDWebServerOption_BindToLocalhost: @NO,
+        GCDWebServerOption_AutomaticallySuspendInBackground: @NO,
+        GCDWebServerOption_ConnectionClass: FilzaWebDAVConnection.class,
+        GCDWebServerOption_MaxPendingConnections: @16
+    } mutableCopy];
+    if (bonjour) {
+        options[GCDWebServerOption_BonjourName] = @"";
+        options[GCDWebServerOption_BonjourType] = @"_http._tcp.";
+    }
+
+    NSError *error = nil;
+    BOOL started = server.isRunning || [server startWithOptions:options error:&error];
+    if (!started) {
+        NSString *failure = [NSString stringWithFormat:@"pinned server failed to bind port %ld: %@",
+                             (long)port, error.localizedDescription ?: @"unknown error"];
+        FilzaDiagnosticsAppend(@"WebDAV", failure);
+        FilzaWebDAVWriteStatus(failure);
+        return NO;
+    }
+
+    FilzaPinnedWebDAVServer = server;
+    FilzaWebDAVAssignServer(preferences, server);
+    FilzaDiagnosticsAppend(@"WebDAV",
+                           [NSString stringWithFormat:@"pinned complete WebDAV server listening root=%@ url=%@ auth=%@",
+                            root, server.serverURL ?: @"unavailable", security ? @"YES" : @"NO"]);
+    return YES;
+}
+
+static void FilzaWebDAVReport(id preferences, NSString *reason, BOOL permitRetry);
+
+static void FilzaWebDAVRetry(id preferences, NSString *reason)
+{
+    if (!FilzaWebDAVBoolPreference(preferences, FilzaWebDAVEnabledKey)) return;
+
+    FilzaDiagnosticsAppend(@"WebDAV", @"server did not report listening; rebuilding the in-process server once");
+    FilzaWebDAVForceInProcessSettings(preferences);
+
+    @try {
+        if (!FilzaWebDAVCallBool(preferences, @"isServerStarted") && !FilzaPinnedWebDAVServer.isRunning) {
+            FilzaWebDAVStartPinnedServer(preferences);
+        }
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+                               [NSString stringWithFormat:@"retry exception: %@ | %@",
+                                exception.name, exception.reason ?: @"no reason"]);
+    }
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        FilzaWebDAVReport(preferences, [reason stringByAppendingString:@" retry"], NO);
+    });
+}
+
+static void FilzaWebDAVReport(id preferences, NSString *reason, BOOL permitRetry)
+{
+    if (!preferences) return;
+
+    BOOL enabled = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVEnabledKey);
+    BOOL started = FilzaWebDAVCallBool(preferences, @"isServerStarted") || FilzaPinnedWebDAVServer.isRunning;
+    id server = FilzaWebDAVCallObject(preferences, @"httpServer") ?: FilzaPinnedWebDAVServer;
+    id connectionURL = FilzaWebDAVCallObject(preferences, @"connectionUrl");
+    id hostnameURL = FilzaWebDAVCallObject(preferences, @"connectionUrlWithHostname");
+    id root = FilzaWebDAVCallObject(preferences, @"uploaderPath");
+    id port = FilzaWebDAVPreference(preferences, FilzaWebDAVPortKey) ?: @11111;
+    BOOL bonjour = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVBonjourKey);
+    BOOL security = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVSecurityKey);
+
+    NSString *summary = [NSString stringWithFormat:
+                         @"%@ enabled=%@ listening=%@ mode=in-process server=%@ port=%@ bonjour=%@ auth=%@ root=%@ url=%@ hostname-url=%@",
+                         reason ?: @"status",
+                         enabled ? @"YES" : @"NO",
+                         started ? @"YES" : @"NO",
+                         server ? NSStringFromClass([server class]) : @"nil",
+                         port,
+                         bonjour ? @"YES" : @"NO",
+                         security ? @"YES" : @"NO",
+                         root ?: @"unknown",
+                         connectionURL ?: @"unavailable",
+                         hostnameURL ?: @"unavailable"];
+    FilzaDiagnosticsAppend(@"WebDAV", summary);
+
+    NSString *serverLog = FilzaWebDAVTrimmedLog(FilzaWebDAVCallObject(preferences, @"readLog"));
+    if (!started && serverLog.length) {
+        summary = [summary stringByAppendingFormat:@"\nFilza server log: %@", serverLog];
+        FilzaDiagnosticsAppend(@"WebDAV", [@"Filza server log: " stringByAppendingString:serverLog]);
+    }
+    FilzaWebDAVWriteStatus(summary);
+
+    if (enabled && !started && permitRetry) FilzaWebDAVRetry(preferences, reason ?: @"start");
+}
+
+static void FilzaWebDAVStopAirBrowser(id preferences, SEL selector)
+{
+    @try {
+        if (FilzaOriginalStopAirBrowser) FilzaOriginalStopAirBrowser(preferences, selector);
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+                               [NSString stringWithFormat:@"stop exception: %@ | %@",
+                                exception.name, exception.reason ?: @"no reason"]);
+    }
+    [FilzaPinnedWebDAVServer stop];
+    FilzaPinnedWebDAVServer = nil;
+    FilzaWebDAVAuthenticationUsername = nil;
+    FilzaWebDAVAuthenticationPasswordMD5 = nil;
+    FilzaWebDAVAuthenticationRequired = NO;
+    FilzaWebDAVWriteStatus(@"WebDAV server stopped");
+    FilzaDiagnosticsAppend(@"WebDAV", @"in-process WebDAV server stopped");
+}
+
+static void FilzaWebDAVStartAirBrowser(id preferences, __unused SEL selector)
+{
+    if (!FilzaOriginalStartAirBrowser) return;
+    if (FilzaWebDAVStartInFlight) {
+        return;
+    }
+
+    FilzaWebDAVStartInFlight = YES;
+    FilzaWebDAVForceInProcessSettings(preferences);
+    FilzaDiagnosticsAppend(@"WebDAV", @"start requested; invoking pinned complete in-process WebDAV implementation");
+    @try {
+        BOOL started = FilzaWebDAVStartPinnedServer(preferences);
+        if (started) {
+            SEL disableIdleTimer = NSSelectorFromString(@"disableIdleTimer");
+            if ([preferences respondsToSelector:disableIdleTimer]) {
+                IMP implementation = [preferences methodForSelector:disableIdleTimer];
+                if (implementation) ((void (*)(id, SEL))implementation)(preferences, disableIdleTimer);
+            }
+            [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged" object:preferences];
+        }
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+                               [NSString stringWithFormat:@"start exception: %@ | %@",
+                                exception.name, exception.reason ?: @"no reason"]);
+    }
+    FilzaWebDAVStartInFlight = NO;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.8 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        FilzaWebDAVReport(preferences, @"after start", YES);
+    });
+}
+
+static void FilzaWebDAVResumeIfNeeded(NSString *reason)
+{
+    id preferences = FilzaWebDAVSharedPreferences();
+    if (!preferences) {
+        FilzaDiagnosticsAppend(@"WebDAV", @"TGPreferences is unavailable");
+        return;
+    }
+
+    FilzaWebDAVForceInProcessSettings(preferences);
+    BOOL enabled = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVEnabledKey);
+    BOOL started = FilzaWebDAVCallBool(preferences, @"isServerStarted");
+    if (enabled && !started && [preferences respondsToSelector:FilzaStartAirBrowserSelector]) {
+        IMP startImplementation = [preferences methodForSelector:FilzaStartAirBrowserSelector];
+        if (startImplementation) {
+            ((void (*)(id, SEL))startImplementation)(preferences, FilzaStartAirBrowserSelector);
+            return;
+        }
+    }
+    FilzaWebDAVReport(preferences, reason, NO);
+}
+
+static void FilzaWebDAVInstall(void)
+{
+    Class preferencesClass = NSClassFromString(@"TGPreferences");
+    FilzaStartAirBrowserSelector = NSSelectorFromString(@"startAirBrowser");
+    FilzaStopAirBrowserSelector = NSSelectorFromString(@"stopAirBrowser");
+    Method startMethod = class_getInstanceMethod(preferencesClass, FilzaStartAirBrowserSelector);
+    if (!preferencesClass || !startMethod) {
+        FilzaDiagnosticsAppend(@"WebDAV", @"TGPreferences.startAirBrowser hook unavailable");
+        return;
+    }
+
+    FilzaOriginalStartAirBrowser = (void (*)(id, SEL))method_getImplementation(startMethod);
+    method_setImplementation(startMethod, (IMP)FilzaWebDAVStartAirBrowser);
+    Method stopMethod = class_getInstanceMethod(preferencesClass, FilzaStopAirBrowserSelector);
+    if (stopMethod) {
+        FilzaOriginalStopAirBrowser = (void (*)(id, SEL))method_getImplementation(stopMethod);
+        method_setImplementation(stopMethod, (IMP)FilzaWebDAVStopAirBrowser);
+    }
+    FilzaDiagnosticsAppend(@"WebDAV", @"jailed in-process WebDAV lifecycle hook installed");
+
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    [center addObserverForName:UIApplicationDidFinishLaunchingNotification
+                        object:nil
+                         queue:NSOperationQueue.mainQueue
+                    usingBlock:^(__unused NSNotification *notification) {
+        FilzaWebDAVResumeIfNeeded(@"application launched");
+    }];
+    [center addObserverForName:UIApplicationDidBecomeActiveNotification
+                        object:nil
+                         queue:NSOperationQueue.mainQueue
+                    usingBlock:^(__unused NSNotification *notification) {
+        FilzaWebDAVResumeIfNeeded(@"application active");
+    }];
+    [center addObserverForName:UIApplicationDidEnterBackgroundNotification
+                        object:nil
+                         queue:NSOperationQueue.mainQueue
+                    usingBlock:^(__unused NSNotification *notification) {
+        FilzaWebDAVReport(FilzaWebDAVSharedPreferences(), @"application backgrounded; iOS may suspend the listener", NO);
+    }];
+}
+
+__attribute__((constructor)) static void FilzaWebDAVRuntimeInit(void)
+{
+    @autoreleasepool {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            FilzaWebDAVInstall();
+        });
+    }
+}


### PR DESCRIPTION
## What changed

- links the complete Gestalt Editor SwiftUI surface and its verified access/persistence bridge into the arm64 target
- adds a visible Gestalt Editor button beside Apps and Music in `TGMainView`
- routes all three static Home Screen quick actions, including Gestalt Editor
- replaces the inert ByeTunes launcher with the complete `ContentView` mounted directly in Music Library
- preserves staged startup diagnostics while removing the manual placeholder step
- makes CI fail unless both Swift host factories, toolbar route, quick-action types, and direct ByeTunes route are present in the dylib
- sets the packaged IPA version to 4.1 and corrects the README

## Root cause

The previous main build packaged a Gestalt shortcut label but its Apps/Music-only delegate hook did not handle that action. The Mond files and toolbar route also existed only on an unmerged branch and were not listed in the Makefile, so they were absent from the IPA. ByeTunes intentionally stopped at an inert launcher rather than mounting the complete application.

## Validation

- local source integration assertions
- shell syntax checks
- `git diff --check`
- real arm64 IPA workflow required before merge

## Summary by Sourcery

Integrate the complete Gestalt Editor surface and full ByeTunes SwiftUI application into the Filza arm64 build, wiring them into the main UI and quick-action routing while tightening CI and packaging guarantees.

New Features:
- Mount the full ByeTunes ContentView directly inside Filza’s Music Library, driven by a deferred Swift host controller.
- Expose the complete Gestalt Editor via a new toolbar button in TGMainView and a unified runtime route.
- Provide a SwiftUI-based MondGestalt editor surface for MobileGestalt with verified access, backup, and rich toggle/spoofing controls.

Bug Fixes:
- Ensure Music Library lifecycle hooks reliably replace the legacy implementation with the embedded ByeTunes UI instead of an inert launcher.
- Prevent duplicate Home Screen quick actions by filtering dynamic shortcut items against the three static Filza actions.

Enhancements:
- Refine ByeTunes startup diagnostics to record detailed Swift factory and ContentView construction stages without a manual placeholder step.
- Centralize Gestalt access and persistence in a verified bridge layer shared between the Mond editor and existing manager.
- Strengthen toolbar and quick-action routing so Gestalt Editor, Apps Manager, and Music Library all use consistent embedded hosts.

Build:
- Include MondGestaltView Swift sources and Gestalt toolbar/bridge Objective-C files in the FilzaApplySandboxExt target, and enforce their presence via Makefile preflight checks.
- Set the packaged IPA’s CFBundleShortVersionString to 4.1 and CFBundleVersion to the CI run number during Info.plist regeneration.

CI:
- Extend the verify-safe-fixes workflow to require Mond Gestalt files, Gestalt toolbar hooks, and complete ByeTunes arm64 integration in the built dylib, and to assert exactly three quick actions plus version metadata in Info.plist.

Documentation:
- Update README to describe the inline ByeTunes Music Library integration, the full Gestalt editor behavior and routes, the three fixed quick actions, and new IPA versioning expectations.

Tests:
- Augment CI artifact validation with string-level assertions for Gestalt toolbar diagnostics, Mond Gestalt host factories, and non-inert ByeTunes integration in the runtime dylib.

Chores:
- Credit the mond project in README acknowledgements for the integrated Gestalt editor behavior.