### PR TITLE
Remove Music/Gestalt loaders and fix WebDAV toggle

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -155,7 +155,12 @@ jobs:
           grep -aFq 'Gestalt Editor' "$DYLIB"
           grep -aFq 'MondGestaltHostFactory' "$DYLIB"
           grep -aFq 'Gestalt Editor toolbar hooks installed' "$DYLIB"
-          grep -aFq 'presented visible Gestalt loading screen immediately' "$DYLIB"
+          grep -aFq 'presented complete Gestalt Editor directly' "$DYLIB"
+          grep -aFq 'Device Spoofing Info' "$DYLIB"
+          grep -aFq 'iPadOS UI Warning' "$DYLIB"
+          grep -aFq 'Disable Dynamic Island' "$DYLIB"
+          ! grep -aFq 'Loading MobileGestalt' "$DYLIB"
+          ! grep -aFq 'Opening the complete Gestalt Editor' "$DYLIB"
           grep -aFq 'inserted in-app Gestalt Editor row beside Apps/Music' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.gestalt-manager' "$DYLIB"
           grep -aFq 'com.nightvibes33.filzaslop.apps-manager' "$DYLIB"
@@ -167,8 +172,15 @@ jobs:
           grep -aFq 'TGMainView direct full ByeTunes route installed' "$DYLIB"
           grep -aFq 'opened complete ByeTunes directly' "$DYLIB"
           grep -aFq 'complete ByeTunes host attached directly to Music Library' "$DYLIB"
-          grep -aFq 'before ContentView construction' "$DYLIB"
+          grep -aFq 'before direct Music Library ContentView construction' "$DYLIB"
+          grep -aFq 'direct Music Library SwiftUI host ready' "$DYLIB"
+          ! grep -aFq 'Starting ByeTunes' "$DYLIB"
+          ! grep -aFq 'before ByeTunes can connect' "$DYLIB"
+          ! grep -aFq 'Add ByeTunes Shortcut' "$DYLIB"
+          ! grep -aFq 'ByeTunes could not be created' "$DYLIB"
           grep -aFq 'jailed in-process WebDAV lifecycle hook installed' "$DYLIB"
+          grep -aFq 'WebDAV toggle hooks installed' "$DYLIB"
+          grep -aFq 'WebDAV checkbox action completed' "$DYLIB"
           grep -aFq 'server did not report listening; rebuilding the in-process server once' "$DYLIB"
           grep -aFq 'GCDWebDAVServer' "$DYLIB"
           grep -aFq 'PROPFIND' "$DYLIB"
@@ -223,8 +235,8 @@ jobs:
             cp -R .theos/byetunes-appintents/Metadata.appintents "$APP/Metadata.appintents"
           fi
 
-          plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open ByeTunes","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
-          plutil -replace CFBundleShortVersionString -string "4.2" "$APP/Info.plist"
+          plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open Music Library","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "4.3" "$APP/Info.plist"
           plutil -replace CFBundleVersion -string "${GITHUB_RUN_NUMBER}" "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
@@ -247,7 +259,7 @@ jobs:
           assert info.get('LSSupportsOpeningDocumentsInPlace') is True
           assert info.get('NSLocalNetworkUsageDescription')
           assert info.get('NSBonjourServices') == ['_http._tcp']
-          assert info.get('CFBundleShortVersionString') == '4.2'
+          assert info.get('CFBundleShortVersionString') == '4.3'
           assert str(info.get('CFBundleVersion', '')).isdigit()
           print('Verified exactly three quick actions and Files/Documents exposure flags')
           PY

--- a/ByeTunesEmbeddedHost.swift
+++ b/ByeTunesEmbeddedHost.swift
@@ -7,91 +7,34 @@ private final class ByeTunesEmbeddedNavigationController: UINavigationController
     }
 }
 
-private final class ByeTunesDeferredHostController: UIViewController {
-    private var hasStarted = false
-    private var hostedController: UIViewController?
-    private let statusLabel = UILabel()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        FilzaDiagnosticsWriteByeTunesStage("deferred Swift host UIKit shell viewDidLoad")
-        view.backgroundColor = .systemGroupedBackground
-
-        statusLabel.translatesAutoresizingMaskIntoConstraints = false
-        statusLabel.text = "Starting ByeTunes…"
-        statusLabel.textAlignment = .center
-        statusLabel.numberOfLines = 0
-        statusLabel.textColor = .secondaryLabel
-        view.addSubview(statusLabel)
-        NSLayoutConstraint.activate([
-            statusLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
-            statusLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
-            statusLabel.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor)
-        ])
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        startEmbeddedContentIfNeeded()
-    }
-
-    @objc(startEmbeddedContentIfNeeded)
-    func startEmbeddedContentIfNeeded() {
-        guard !hasStarted else { return }
-        hasStarted = true
-        FilzaDiagnosticsWriteByeTunesStage("complete ByeTunes ContentView startup scheduled")
-
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            FilzaDiagnosticsWriteByeTunesStage("before ContentView construction")
-            let root = ContentView()
-            FilzaDiagnosticsWriteByeTunesStage("ContentView constructed")
-
-            let host = UIHostingController(rootView: root)
-            FilzaDiagnosticsWriteByeTunesStage("UIHostingController constructed")
-            host.view.backgroundColor = .systemGroupedBackground
-
-            self.addChild(host)
-            FilzaDiagnosticsWriteByeTunesStage("before ByeTunes Swift host view materialization")
-            let hostedView = host.view!
-            FilzaDiagnosticsWriteByeTunesStage("ByeTunes Swift host view materialized")
-            hostedView.translatesAutoresizingMaskIntoConstraints = false
-            self.view.addSubview(hostedView)
-            NSLayoutConstraint.activate([
-                hostedView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-                hostedView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-                hostedView.topAnchor.constraint(equalTo: self.view.topAnchor),
-                hostedView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
-            ])
-            host.didMove(toParent: self)
-            self.hostedController = host
-            self.statusLabel.removeFromSuperview()
-            FilzaDiagnosticsWriteByeTunesStage("ByeTunes Swift host attached successfully")
-        }
-    }
+private func makeMusicLibraryHost() -> UIViewController {
+    FilzaDiagnosticsWriteByeTunesStage("before direct Music Library ContentView construction")
+    let root = ContentView()
+    FilzaDiagnosticsWriteByeTunesStage("direct Music Library ContentView constructed")
+    let host = UIHostingController(rootView: root)
+    host.title = "Music Library"
+    host.view.backgroundColor = .systemGroupedBackground
+    FilzaDiagnosticsWriteByeTunesStage("direct Music Library SwiftUI host ready")
+    return host
 }
 
-/// Hosts the complete ByeTunes application inside Filza without constructing
-/// ContentView inside the Objective-C factory call. The UIKit shell is attached
-/// first; ContentView and DeviceManager.shared are entered only after the shell
-/// reaches viewDidAppear, with a persistent breadcrumb at every boundary.
+/// Hosts the complete music application immediately. Its process-global device
+/// work is made inert by patch-byetunes-embedded.sh, so no intermediate UIKit
+/// loading controller or branded splash is needed.
 @objc(ByeTunesEmbeddedHostFactory)
 public final class ByeTunesEmbeddedHostFactory: NSObject {
     @objc(makeLibraryViewController)
     public static func makeLibraryViewController() -> UIViewController {
-        FilzaDiagnosticsWriteByeTunesStage("Swift ByeTunes factory entered")
-        let controller = ByeTunesDeferredHostController()
-        FilzaDiagnosticsWriteByeTunesStage("Swift ByeTunes factory returned deferred UIKit host")
-        return controller
+        FilzaDiagnosticsWriteByeTunesStage("direct Music Library factory entered")
+        return makeMusicLibraryHost()
     }
 
     @objc(makeViewController)
     public static func makeViewController() -> UIViewController {
-        FilzaDiagnosticsWriteByeTunesStage("standalone ByeTunes factory entered")
-        let deferred = ByeTunesDeferredHostController()
-        deferred.title = "ByeTunes"
-        let navigation = ByeTunesEmbeddedNavigationController(rootViewController: deferred)
-        deferred.navigationItem.leftBarButtonItem = UIBarButtonItem(
+        FilzaDiagnosticsWriteByeTunesStage("standalone Music Library factory entered")
+        let host = makeMusicLibraryHost()
+        let navigation = ByeTunesEmbeddedNavigationController(rootViewController: host)
+        host.navigationItem.leftBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .close,
             target: navigation,
             action: #selector(ByeTunesEmbeddedNavigationController.closeEmbeddedByeTunes)

--- a/ByeTunesFilzaLibraryEmbed.m
+++ b/ByeTunesFilzaLibraryEmbed.m
@@ -72,7 +72,7 @@ static void ByeTunesAttachCompleteHost(UIViewController *legacy)
     UIViewController *host = ByeTunesMakeSwiftController();
     if (!host) {
         ByeTunesShowFailure(legacy,
-            @"ByeTunes could not be created. See Files > FilzaSlop > FilzaSlop Logs.");
+            @"Music Library could not be created. See Files > FilzaSlop > FilzaSlop Logs.");
         return;
     }
 
@@ -108,7 +108,7 @@ static void ByeTunesAttachCompleteHost(UIViewController *legacy)
         [host.view removeFromSuperview];
         [host removeFromParentViewController];
         ByeTunesShowFailure(legacy,
-            @"ByeTunes failed while attaching. See Files > FilzaSlop > FilzaSlop Logs.");
+            @"Music Library failed while attaching. See Files > FilzaSlop > FilzaSlop Logs.");
     }
 }
 

--- a/ByeTunesMusicBridge.m
+++ b/ByeTunesMusicBridge.m
@@ -68,7 +68,7 @@ static BTMusicSession *BTConnect(NSString **error)
     NSString *pairingPath = BTExistingPairingFile();
     if (!pairingPath) {
         if (error) *error = [NSString stringWithFormat:
-            @"ByeTunes pairing file missing. Put rpPairingFile.plist in %@/pairing file and enable LocalDevVPN.",
+            @"Music Library pairing file missing. Put rpPairingFile.plist in %@/pairing file and enable LocalDevVPN.",
             BTDocumentsDirectory()];
         return nil;
     }
@@ -88,7 +88,7 @@ static BTMusicSession *BTConnect(NSString **error)
     address.sin_family = AF_INET;
     address.sin_port = htons(BTRPPairingPort);
     if (inet_pton(AF_INET, BTRPPairingHost.UTF8String, &address.sin_addr) != 1) {
-        if (error) *error = @"invalid ByeTunes RPPairing endpoint";
+        if (error) *error = @"invalid Music Library RPPairing endpoint";
         return nil;
     }
 
@@ -281,7 +281,7 @@ NSArray<NSDictionary *> *BTMusicLoadLibrary(NSString **error)
 static NSString *BTMusicCacheDirectory(void)
 {
     NSString *directory = [BTDocumentsDirectory()
-        stringByAppendingPathComponent:@"Device Storage/[ByeTunes] Music Cache"];
+        stringByAppendingPathComponent:@"Device Storage/Music Library Cache"];
     [NSFileManager.defaultManager createDirectoryAtPath:directory
                              withIntermediateDirectories:YES
                                               attributes:@{NSFilePosixPermissions: @0700}

--- a/FilzaMondBridge.m
+++ b/FilzaMondBridge.m
@@ -39,6 +39,17 @@ static UIViewController *FMActiveController(void)
     return controller;
 }
 
+static void FMShowUnavailable(UIViewController *source, NSString *message)
+{
+    UIAlertController *alert = [UIAlertController
+        alertControllerWithTitle:@"Gestalt Editor unavailable"
+        message:message
+        preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK"
+        style:UIAlertActionStyleDefault handler:nil]];
+    [source presentViewController:alert animated:YES completion:nil];
+}
+
 static UIViewController *FMCreateHost(NSString *path)
 {
     Class factory = NSClassFromString(@"MondGestaltHostFactory");
@@ -57,154 +68,39 @@ static UIViewController *FMCreateHost(NSString *path)
     return controller;
 }
 
-@interface FMDeferredGestaltController : UIViewController
-@property(nonatomic) BOOL resolutionStarted;
-@property(nonatomic, strong) UILabel *statusLabel;
-@property(nonatomic, strong) UIActivityIndicatorView *spinner;
-@property(nonatomic, strong) UIButton *retryButton;
-@property(nonatomic, strong) UIViewController *embeddedHost;
+@interface FMGestaltNavigationController : UINavigationController
 @end
 
-@implementation FMDeferredGestaltController
-
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    self.title = @"Gestalt Editor";
-    self.view.backgroundColor = UIColor.systemGroupedBackgroundColor;
-
-    self.spinner = [[UIActivityIndicatorView alloc]
-        initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
-    self.spinner.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.spinner startAnimating];
-
-    self.statusLabel = [UILabel new];
-    self.statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
-    self.statusLabel.text = @"Opening the complete Gestalt Editor…";
-    self.statusLabel.textAlignment = NSTextAlignmentCenter;
-    self.statusLabel.numberOfLines = 0;
-    self.statusLabel.textColor = UIColor.secondaryLabelColor;
-
-    self.retryButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    self.retryButton.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.retryButton setTitle:@"Retry" forState:UIControlStateNormal];
-    self.retryButton.hidden = YES;
-    [self.retryButton addTarget:self action:@selector(fm_retry)
-               forControlEvents:UIControlEventTouchUpInside];
-
-    [self.view addSubview:self.spinner];
-    [self.view addSubview:self.statusLabel];
-    [self.view addSubview:self.retryButton];
-    [NSLayoutConstraint activateConstraints:@[
-        [self.spinner.centerXAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.centerXAnchor],
-        [self.spinner.bottomAnchor constraintEqualToAnchor:self.statusLabel.topAnchor constant:-18.0],
-        [self.statusLabel.leadingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.leadingAnchor constant:24.0],
-        [self.statusLabel.trailingAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.trailingAnchor constant:-24.0],
-        [self.statusLabel.centerYAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.centerYAnchor],
-        [self.retryButton.topAnchor constraintEqualToAnchor:self.statusLabel.bottomAnchor constant:18.0],
-        [self.retryButton.centerXAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.centerXAnchor],
-    ]];
-    FilzaDiagnosticsAppend(@"Gestalt", @"visible Gestalt loading screen attached");
-}
-
-- (void)viewDidAppear:(BOOL)animated
-{
-    [super viewDidAppear:animated];
-    [self fm_startResolution];
-}
-
+@implementation FMGestaltNavigationController
 - (void)fm_close
 {
     [self dismissViewControllerAnimated:YES completion:nil];
 }
-
-- (void)fm_retry
-{
-    self.resolutionStarted = NO;
-    self.retryButton.hidden = YES;
-    self.statusLabel.text = @"Retrying MobileGestalt access…";
-    [self.spinner startAnimating];
-    [self fm_startResolution];
-}
-
-- (void)fm_startResolution
-{
-    if (self.resolutionStarted || self.embeddedHost) return;
-    self.resolutionStarted = YES;
-    FilzaDiagnosticsAppend(@"Gestalt", @"visible screen requesting verified MobileGestalt access");
-
-    __weak typeof(self) weakSelf = self;
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-        NSString *detail = nil;
-        NSString *path = FilzaGestaltResolvePath(&detail);
-        dispatch_async(dispatch_get_main_queue(), ^{
-            FMDeferredGestaltController *strongSelf = weakSelf;
-            if (!strongSelf) return;
-
-            if (!path.length) {
-                NSString *reason = detail ?: @"The MobileGestalt property list could not be opened.";
-                FilzaDiagnosticsAppend(@"Gestalt",
-                    [NSString stringWithFormat:@"MobileGestalt access failed on visible screen: %@", reason]);
-                [strongSelf.spinner stopAnimating];
-                strongSelf.statusLabel.text = [NSString stringWithFormat:
-                    @"Gestalt Editor could not access MobileGestalt.\n\n%@", reason];
-                strongSelf.retryButton.hidden = NO;
-                strongSelf.resolutionStarted = NO;
-                return;
-            }
-
-            FilzaDiagnosticsAppend(@"Gestalt",
-                [NSString stringWithFormat:@"verified MobileGestalt access: %@", detail ?: path]);
-            UIViewController *host = FMCreateHost(path);
-            if (!host) {
-                [strongSelf.spinner stopAnimating];
-                strongSelf.statusLabel.text =
-                    @"The complete embedded Gestalt Editor was not linked into this build.";
-                strongSelf.retryButton.hidden = NO;
-                strongSelf.resolutionStarted = NO;
-                return;
-            }
-
-            [strongSelf addChildViewController:host];
-            UIView *hostView = host.view;
-            hostView.translatesAutoresizingMaskIntoConstraints = NO;
-            [strongSelf.view addSubview:hostView];
-            [NSLayoutConstraint activateConstraints:@[
-                [hostView.leadingAnchor constraintEqualToAnchor:strongSelf.view.leadingAnchor],
-                [hostView.trailingAnchor constraintEqualToAnchor:strongSelf.view.trailingAnchor],
-                [hostView.topAnchor constraintEqualToAnchor:strongSelf.view.topAnchor],
-                [hostView.bottomAnchor constraintEqualToAnchor:strongSelf.view.bottomAnchor],
-            ]];
-            [host didMoveToParentViewController:strongSelf];
-            strongSelf.embeddedHost = host;
-            [strongSelf.spinner removeFromSuperview];
-            [strongSelf.statusLabel removeFromSuperview];
-            [strongSelf.retryButton removeFromSuperview];
-            FilzaDiagnosticsAppend(@"Gestalt",
-                [NSString stringWithFormat:@"attached complete Gestalt editor using %@", path]);
-        });
-    });
-}
-
 @end
 
-static void FMPresentDeferredHost(UIViewController *source)
+static BOOL FMPresentHost(UIViewController *source, NSString *path)
 {
-    FMDeferredGestaltController *controller = [FMDeferredGestaltController new];
+    UIViewController *controller = FMCreateHost(path);
+    if (!controller) {
+        FMShowUnavailable(source, @"The complete Gestalt Editor could not be created.");
+        return NO;
+    }
 
     UINavigationController *navigation = source.navigationController;
     if (navigation && !source.presentedViewController) {
         [navigation pushViewController:controller animated:YES];
     } else {
+        FMGestaltNavigationController *wrapper =
+            [[FMGestaltNavigationController alloc] initWithRootViewController:controller];
         controller.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
             initWithBarButtonSystemItem:UIBarButtonSystemItemClose
-            target:controller action:@selector(fm_close)];
-        UINavigationController *wrapper =
-            [[UINavigationController alloc] initWithRootViewController:controller];
+            target:wrapper action:@selector(fm_close)];
         wrapper.modalPresentationStyle = UIModalPresentationFullScreen;
         [source presentViewController:wrapper animated:YES completion:nil];
     }
-    FilzaDiagnosticsAppend(@"Gestalt", @"presented visible Gestalt loading screen immediately");
+    FilzaDiagnosticsAppend(@"Gestalt",
+        [NSString stringWithFormat:@"presented complete Gestalt Editor directly using %@", path]);
+    return YES;
 }
 
 void FilzaMondPresentFromController(UIViewController *source)
@@ -216,11 +112,41 @@ void FilzaMondPresentFromController(UIViewController *source)
             return;
         }
 
-        FMPresentDeferredHost(presenter);
+        __weak UIViewController *weakPresenter = presenter;
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+            NSString *detail = nil;
+            NSString *path = FilzaGestaltResolvePath(&detail);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                UIViewController *resolvedPresenter = weakPresenter ?: FMActiveController();
+                if (!resolvedPresenter) return;
+                if (!path.length) {
+                    NSString *reason = detail ?:
+                        @"The MobileGestalt property list could not be opened.";
+                    FilzaDiagnosticsAppend(@"Gestalt",
+                        [NSString stringWithFormat:@"MobileGestalt access failed: %@", reason]);
+                    FMShowUnavailable(resolvedPresenter, reason);
+                    return;
+                }
+                FilzaDiagnosticsAppend(@"Gestalt",
+                    [NSString stringWithFormat:@"verified MobileGestalt access: %@", detail ?: path]);
+                FMPresentHost(resolvedPresenter, path);
+            });
+        });
     });
 }
 
 void FilzaMondPresent(void)
 {
     FilzaMondPresentFromController(FMActiveController());
+}
+
+__attribute__((constructor)) static void FilzaMondPrewarm(void)
+{
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        NSString *detail = nil;
+        NSString *path = FilzaGestaltResolvePath(&detail);
+        FilzaDiagnosticsAppend(@"Gestalt", path.length
+            ? @"prewarmed MobileGestalt access for direct presentation"
+            : [NSString stringWithFormat:@"MobileGestalt prewarm unavailable: %@", detail ?: @"unknown"]);
+    });
 }

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ FilzaApplySandboxExt_FILES += XPF/external/ChOma/src/arm64.c XPF/external/ChOma/
 # because its @main owns a standalone UIApplication lifecycle; Filza already
 # owns that lifecycle. ByeTunesEmbeddedHost.swift exposes ContentView() as a
 # child controller that is mounted directly inside Filza's Music Library.
-BYETUNES_SWIFT_FILES := $(shell find $(BYETUNES_ROOT) -type f -name '*.swift' ! -name 'MusicManagerApp.swift' -print)
+BYETUNES_SWIFT_FILES := $(shell find $(BYETUNES_ROOT) -type f -name '*.swift' ! -name 'MusicManagerApp.swift' ! -name 'SplashView.swift' -print)
 FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift MondGestaltView.swift $(BYETUNES_SWIFT_FILES)
 
 # --- Flags ---

--- a/MondGestaltView.swift
+++ b/MondGestaltView.swift
@@ -113,6 +113,52 @@ private struct MondToggle: View {
     }
 }
 
+private struct MondInfoButton: View {
+    let title: String
+    let message: String
+    let warning: Bool
+    @State private var showing = false
+
+    var body: some View {
+        Button {
+            showing = true
+        } label: {
+            Image(systemName: warning ? "exclamationmark.triangle" : "info.circle")
+                .frame(width: 24, height: 22)
+        }
+        .buttonStyle(.plain)
+        .alert(title, isPresented: $showing) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(message)
+        }
+    }
+}
+
+private func mondSupportsDisableDynamicIsland() -> Bool {
+    let supported = [
+        "iPhone15,2", "iPhone15,3", "iPhone15,4", "iPhone15,5",
+        "iPhone16,1", "iPhone16,2", "iPhone17,3", "iPhone17,4",
+        "iPhone17,1", "iPhone17,2", "iPhone18,3", "iPhone18,1",
+        "iPhone18,2", "iPhone17,5"
+    ]
+    return supported.contains(mondMachineName()) && mondSystemVersion() < 19.0
+}
+
+private let mondAppleIntelligenceInstructions = """
+How to use this tweak:
+1. Spoof to the model next to the first one supported by Apple Intelligence.
+2. Spoof back to your model.
+3. Spoof to your final model and you should see the Apple Intelligence icon in Settings.
+4. Connect iPhone to power and leave Settings > Storage open for about one hour.
+
+Do not spoof back afterward.
+"""
+
+private let mondIPadUIWarning = """
+This is a very dangerous tweak. Do not use it with an alphanumeric passcode. Do not turn off “Show Dock In Stage Manager” or the device can bootloop when rotating to landscape. Opening Stage Manager after enabling this can also enter Recovery Mode. Other instability, including app data disappearing, has been reported.
+"""
+
 struct MondGestaltView: View {
     let gestaltPath: String
 
@@ -146,7 +192,7 @@ struct MondGestaltView: View {
     private var selectedSubtypeValue: Int {
         switch selectedSubtype {
         case "og": return originalSubtype
-        case "none": return 0
+        case "no_dynamic_island": return 0
         case "14p": return 2436
         case "14pm": return 2796
         case "15pm": return 2976
@@ -160,19 +206,18 @@ struct MondGestaltView: View {
 
     var body: some View {
         List {
-            if loading {
-                Section {
-                    HStack {
-                        ProgressView()
-                        Text("Loading MobileGestalt…")
-                    }
-                }
-            }
-
             if !valid || empty {
-                Section("Warning") {
-                    if empty { Label("Do not reboot — MobileGestalt.plist is empty.", systemImage: "exclamationmark.triangle.fill") }
-                    if !valid { Label("Do not reboot — MobileGestalt.plist is invalid.", systemImage: "exclamationmark.triangle.fill") }
+                Section {
+                    if empty {
+                        Label("Do not reboot — MobileGestalt.plist is empty.", systemImage: "exclamationmark.triangle.fill")
+                    }
+                    if !valid {
+                        Label("Do not reboot — MobileGestalt.plist is invalid.", systemImage: "exclamationmark.triangle.fill")
+                    }
+                } header: {
+                    Label("Warning", systemImage: "exclamationmark.triangle")
+                } footer: {
+                    Text("Rebooting now may cause a bootloop. Use Revert Tweaks first and confirm the warning disappears.")
                 }
             }
 
@@ -183,79 +228,130 @@ struct MondGestaltView: View {
                 Text("WARNING: These tweaks can break device features or soft-brick the device if misused.")
             }
 
-            Section("Device Artwork") {
+            Section {
                 Picker("Subtype", selection: $selectedSubtype) {
                     Text("Original (\(originalSubtype))").tag("og")
-                    Text("Disable Dynamic Island").tag("none")
+                    if mondSupportsDisableDynamicIsland() {
+                        Text("Disable Dynamic Island").tag("no_dynamic_island")
+                    }
                     Text("iPhone 14 Pro").tag("14p")
                     Text("iPhone 14 Pro Max").tag("14pm")
                     Text("iPhone 15 Pro Max").tag("15pm")
-                    Text("iPhone 16 Pro").tag("16p")
-                    Text("iPhone 16 Pro Max").tag("16pm")
-                    Text("iPhone Air").tag("air")
+                    if mondSystemVersion() >= 18.0 {
+                        Text("iPhone 16 Pro").tag("16p")
+                        Text("iPhone 16 Pro Max").tag("16pm")
+                    }
+                    if mondSystemVersion() >= 26.0 {
+                        Text("iPhone Air").tag("air")
+                    }
                     if mondHasHomeButton() { Text("iPhone X Gestures").tag("x") }
                 }
                 Toggle("Custom Device Name", isOn: $customDeviceName)
                 if customDeviceName { TextField("Device Name", text: $deviceName) }
+            } header: {
+                Label("Device Artwork", systemImage: "paintbrush.pointed")
             }
 
-            Section("Software-Oriented Features") {
+            Section {
                 MondToggle("Dynamic Island", minimum: 19.0, isOn: keyBinding(["YlEtTtHlNesRBMal1CqRaA"]))
                 MondToggle("Always On Display", minimum: 18.0, isOn: keyBinding(["j8/Omm6s1lsmTDFsXjsBfA", "2OOJf1VhaM7NxfRok3HbWQ"]))
                 MondToggle("AOD Vibrancy", minimum: 18.0, isOn: keyBinding(["ykpu7qyhqFweVMKtxNylWA"]))
                 MondToggle("Charge Limit", minimum: 17.0, isOn: keyBinding(["37NVydb//GP/GrhuTN+exg"]))
                 MondToggle("Boot Chime", isOn: keyBinding(["QHxt+hGLaBPbQJbXiUJX3w"]))
                 MondToggle("Liquid Glass LPM", minimum: 19.0, isOn: keyBinding(["SAGvsp6O6kAQ4fEfDJpC4Q"]))
+            } header: {
+                Label("Software-Oriented Features", systemImage: "gearshape")
             }
 
-            Section("Hardware-Oriented Features") {
+            Section {
                 MondToggle("Camera Control", minimum: 18.0, isOn: keyBinding(["CwvKxM2cEogD3p+HYgaW0Q", "oOV1jhJbdV3AddkcCg0AEA"]))
                 MondToggle("Action Button", minimum: 17.0, isOn: keyBinding(["cT44WE1EohiwRzhsZ8xEsw"]))
                 MondToggle("Crash Detection", isOn: keyBinding(["HCzWusHQwZDea6nNhaKndw"]))
                 if mondHasHomeButton() { MondToggle("Enable Tap to Wake", isOn: keyBinding(["yZf3GTRMGTuwSV/lD7Cagw"])) }
                 MondToggle("Pulse Width Modulation", minimum: 19.0, isOn: keyBinding(["6IejgN+1Fmu5/QrZFOIeNw"]))
+            } header: {
+                Label("Hardware-Oriented Features", systemImage: "iphone")
             }
 
-            Section("Eligibility") {
+            Section {
                 MondToggle("Security Research Device UI", minimum: 26.0, isOn: keyBinding(["XYlJKKkj2hztRP1NWWnhlw"]))
-                Toggle("Disable Region Restrictions", isOn: regionBinding())
-                MondToggle("Apple Intelligence", minimum: 18.1, isOn: appleIntelligenceBinding())
-                Picker("Spoofing", selection: $productType) {
-                    Text("Default").tag(mondMachineName())
-                    if UIDevice.current.userInterfaceIdiom == .pad {
-                        Text("iPad Pro 11-inch (M4)").tag("iPad16,3")
-                        Text("iPad Pro 11-inch (M4, Cellular)").tag("iPad16,4")
-                        Text("iPad Pro 11-inch (4th Gen)").tag("iPad14,3")
-                        Text("iPad Pro 11-inch (4th Gen, Cellular)").tag("iPad14,4")
-                    } else {
-                        Text("iPhone 15 Pro").tag("iPhone16,1")
-                        Text("iPhone 15 Pro Max").tag("iPhone16,2")
-                        Text("iPhone 16").tag("iPhone17,3")
-                        Text("iPhone 16 Plus").tag("iPhone17,4")
-                        Text("iPhone 16 Pro").tag("iPhone17,1")
-                        Text("iPhone 16 Pro Max").tag("iPhone17,2")
-                        Text("iPhone 17").tag("iPhone18,3")
-                        Text("iPhone 17 Pro").tag("iPhone18,1")
-                        Text("iPhone 17 Pro Max").tag("iPhone18,2")
-                        Text("iPhone Air").tag("iPhone18,4")
-                    }
+
+                HStack(spacing: 10) {
+                    Toggle("Disable Region Restrictions", isOn: regionBinding())
+                    MondInfoButton(
+                        title: "Region Restrictions",
+                        message: "This tweak may be broken or have no effect on some iOS versions or devices.",
+                        warning: false
+                    )
                 }
+
+                HStack(spacing: 10) {
+                    MondToggle("Apple Intelligence", minimum: 18.1, isOn: appleIntelligenceBinding())
+                    MondInfoButton(
+                        title: "Apple Intelligence",
+                        message: mondAppleIntelligenceInstructions,
+                        warning: false
+                    )
+                }
+
+                HStack(spacing: 10) {
+                    Picker("Spoofing", selection: $productType) {
+                        Text("Default").tag(mondMachineName())
+                        if UIDevice.current.userInterfaceIdiom == .pad {
+                            if mondSystemVersion() >= 17.4 {
+                                Text("iPad Pro 11-inch (M4)").tag("iPad16,3")
+                                Text("iPad Pro 11-inch (M4, Cellular)").tag("iPad16,4")
+                            }
+                            Text("iPad Pro 11-inch (4th Gen)").tag("iPad14,3")
+                            Text("iPad Pro 11-inch (4th Gen, Cellular)").tag("iPad14,4")
+                        } else {
+                            Text("iPhone 15 Pro").tag("iPhone16,1")
+                            Text("iPhone 15 Pro Max").tag("iPhone16,2")
+                            if mondSystemVersion() >= 18.0 {
+                                Text("iPhone 16").tag("iPhone17,3")
+                                Text("iPhone 16 Plus").tag("iPhone17,4")
+                                Text("iPhone 16 Pro").tag("iPhone17,1")
+                                Text("iPhone 16 Pro Max").tag("iPhone17,2")
+                            }
+                            if mondSystemVersion() >= 19.0 {
+                                Text("iPhone 17").tag("iPhone18,3")
+                                Text("iPhone 17 Pro").tag("iPhone18,1")
+                                Text("iPhone 17 Pro Max").tag("iPhone18,2")
+                                Text("iPhone Air").tag("iPhone18,4")
+                            }
+                        }
+                    }
+                    MondInfoButton(
+                        title: "Device Spoofing Info",
+                        message: "Only spoof your device model to download Apple Intelligence. This may break Face ID. If you unspoof and want to keep Apple Intelligence, do not re-enter Apple Intelligence & Siri in Settings.",
+                        warning: false
+                    )
+                }
+            } header: {
+                Label("Eligibility", systemImage: "checklist")
             }
 
-            Section("iPadOS Features") {
+            Section {
                 MondToggle("Allow Installing iPadOS Apps", isOn: arrayBinding("9MZ5AdH43csAUajl/dU+IQ"))
                 MondToggle("Apple Pencil Settings", isOn: keyBinding(["yhHcB0iH0d1XzPO/CFd3ow"]))
                 if UIDevice.current.userInterfaceIdiom == .pad {
                     MondToggle("Stage Manager", isOn: keyBinding(["qeaj75wk3HF4DwQ8qbIi7g"]))
                 }
-                Toggle("iPadOS UI", isOn: trollPadBinding())
-                    .disabled(cacheExtra?["+3Uf0Pm5F8Xy7Onyvko0vA"] as? String != "iPhone")
+                HStack(spacing: 10) {
+                    Toggle("iPadOS UI", isOn: trollPadBinding())
+                    MondInfoButton(title: "iPadOS UI Warning", message: mondIPadUIWarning, warning: true)
+                }
+                .disabled(cacheExtra?["+3Uf0Pm5F8Xy7Onyvko0vA"] as? String != "iPhone")
+            } header: {
+                Label("iPadOS Features", systemImage: "ipad")
             }
 
-            Section("Internal") {
+            Section {
                 MondToggle("Internal Storage", isOn: keyBinding(["LBJfwOEzExRxzlAnSuI7eg"]))
                 Toggle("Internal Features", isOn: internalBinding())
                 MondToggle("Metal HUD in All Apps", isOn: keyBinding(["EqrsVvjcYDdxHBiQmGhAWw"]))
+            } header: {
+                Label("Internal", systemImage: "ant")
             }
 
         }
@@ -291,7 +387,7 @@ struct MondGestaltView: View {
                 let extra = loaded["CacheExtra"] as? NSMutableDictionary ?? NSMutableDictionary()
                 let artwork = extra["oPeik/9e8lQWMszEjbPzng"] as? NSMutableDictionary ?? NSMutableDictionary()
                 let currentSubtype = artwork["ArtworkDeviceSubType"] as? Int ?? subtype
-                let subtypeMap = [0: "none", 2436: "14p", 2796: "14pm", 2976: "15pm", 2622: "16p", 2868: "16pm", 2736: "air"]
+                let subtypeMap = [0: "no_dynamic_island", 2436: "14p", 2796: "14pm", 2976: "15pm", 2622: "16p", 2868: "16pm", 2736: "air"]
                 let currentName = artwork["ArtworkDeviceProductDescription"] as? String ?? originalName
                 let currentProduct = extra["h9jDsbgj7xIVeIQ8S3/X3Q"] as? String ?? mondMachineName()
 
@@ -397,6 +493,7 @@ struct MondGestaltView: View {
         }, set: { enabled in
             guard let extra = cacheExtra else { return }
             if enabled {
+                message = "Do not use this to bypass restrictions required by regional law, including mandatory camera shutter sounds."
                 extra["h63QSdBCiT/z0WU6rdQv6Q"] = "US"
                 extra["zHeENZu+wbg7PUprwNwBWg"] = "LL/A"
             } else {
@@ -409,7 +506,12 @@ struct MondGestaltView: View {
     private func appleIntelligenceBinding() -> Binding<Bool> {
         let key = "A62OafQ85EJAiiqKn4agtg"
         return Binding(get: { (cacheExtra?[key] as? NSNumber)?.intValue == 1 }, set: { enabled in
-            if enabled { cacheExtra?[key] = 1 } else { cacheExtra?.removeObject(forKey: key) }
+            if enabled {
+                cacheExtra?[key] = 1
+                message = mondAppleIntelligenceInstructions
+            } else {
+                cacheExtra?.removeObject(forKey: key)
+            }
         })
     }
 
@@ -442,7 +544,7 @@ struct MondGestaltView: View {
 
     private func internalBinding() -> Binding<Bool> {
         let keys = ["EqrsVvjcYDdxHBiQmGhAWw", "Oji6HRoPi7rH7HPdWVakuw", "LBJfwOEzExRxzlAnSuI7eg"]
-        return Binding(get: { keys.allSatisfy { readCacheInt($0) == 1 } }, set: { enabled in
+        return Binding(get: { readCacheInt(keys[0]) == 1 }, set: { enabled in
             for key in keys { writeCacheInt(key, value: enabled ? 1 : 0) }
         })
     }
@@ -454,9 +556,10 @@ struct MondGestaltView: View {
         ]
         return Binding(get: {
             guard let extra = cacheExtra else { return false }
-            return readCacheInt("mtrAoWJ3gsq+I90ZnQ0vQw") == 3 && values.allSatisfy { (extra[$0] as? NSNumber)?.intValue == 1 }
+            return values.allSatisfy { (extra[$0] as? NSNumber)?.intValue == 1 }
         }, set: { enabled in
             guard let extra = cacheExtra else { return }
+            if enabled { message = mondIPadUIWarning }
             writeCacheInt("mtrAoWJ3gsq+I90ZnQ0vQw", value: enabled ? 3 : 1)
             for key in values {
                 if enabled { extra[key] = 1 } else { extra.removeObject(forKey: key) }

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This fork currently targets the iOS 18 / iOS 26 / early iOS 27 behavior exposed 
 | Gestalt Editor | ✅ Complete editor is linked into the main toolbar route |
 | Gestalt Home Screen quick action | ✅ Static action and runtime handler are both linked |
 | iOS 27 Gestalt key catalog | ✅ Included |
-| ByeTunes resources | ✅ Packaged into the IPA |
-| ByeTunes Music Library integration | ✅ Complete ByeTunes UI mounts directly; on-device validation still required |
+| Music Library resources | ✅ Packaged into the IPA |
+| Music Library integration | ✅ Complete UI opens directly without an intermediate loading or splash screen |
 | WebDAV server | ✅ Redirected to Filza's in-process server for jailed/sideloaded use |
 | Arbitrary `/` / full system filesystem access | ❌ Not established |
 
@@ -38,9 +38,9 @@ Current behavior includes:
 - App disk usage is retried after a real foreign data-container path becomes available instead of permanently showing `0 KB` from the initial inaccessible path.
 - App icon lookup includes a MobileIcons resource-proxy fallback and format `10` before older formats.
 
-### Music Library / ByeTunes
+### Music Library
 
-ByeTunes is compiled into the arm64 target and its runtime resources are copied into the final app bundle.
+The complete upstream music-management implementation is compiled into the arm64 target and its runtime resources are copied into the final app bundle.
 
 The packaged IPA includes:
 
@@ -52,11 +52,10 @@ AppIconImage.png
 ByeTunes-Info.plist
 ```
 
-The Music Library action now intercepts `TGMainView.openMusicLib` and presents the
-complete ByeTunes `ContentView` directly. The Home Screen Music Library action uses the
-same presenter. `TGMusicLibraryViewController` embedding remains only as a fallback.
-A small UIKit shell is attached first, then the complete SwiftUI application is
-constructed on the next main-loop turn so startup boundaries can be recorded.
+The Music Library action intercepts `TGMainView.openMusicLib` and constructs the
+complete SwiftUI `ContentView` immediately. The Home Screen Music Library action uses
+the same presenter. There is no intermediate UIKit loading controller, branded splash,
+or artificial delay. `TGMusicLibraryViewController` remains only as a fallback route.
 
 A runtime stage marker is written to:
 
@@ -82,9 +81,9 @@ Gestalt Editor
 Edit MobileGestalt
 ```
 
-Both the in-app button and Home Screen quick action immediately show the same embedded
-editor shell. MobileGestalt access is resolved from that visible screen; failures are
-shown there with the precise error and a Retry action instead of appearing to do nothing.
+Both the in-app button and Home Screen quick action open the same editor directly with
+no intermediate loading controller. MobileGestalt access is prewarmed after launch;
+an access failure is shown as a normal error alert instead of a fake editor screen.
 The editor attempts to resolve:
 
 ```text
@@ -108,10 +107,12 @@ Write handling includes:
 - post-write plist read-back validation;
 - automatic restoration of the backup if validation fails.
 
-The editor includes the complete device-artwork, software, hardware, eligibility,
-iPadOS, internal-feature, spoofing, Apply, and Revert controls. Writes use the verified
-direct-file-descriptor fallback, property-list read-back validation, and automatic
-backup restoration if validation fails.
+The editor follows `rooootdev/mond` GestaltView at upstream commit
+`50b76a500b34d70119e30e04921dcb138c284855`: complete device-artwork, software,
+hardware, eligibility, iPadOS, internal-feature, spoofing, Apply, and Revert controls;
+the same device/version gating; and the same warning and information dialogs. Filza's
+verified write bridge replaces Mond's standalone exploit lifecycle while preserving
+property-list read-back validation and automatic backup restoration.
 
 ### WebDAV server
 
@@ -120,7 +121,11 @@ and `/usr/libexec/filza/FilzaWebDAVServer` paths. Those paths cannot work from t
 sideloaded MobileHouseArrest app container. FilzaSlop now links a pinned complete
 `GCDWebDAVServer` implementation and forces WebDAV through that in-process server
 while preserving Filza's port, Bonjour, authentication, WebDAV methods, and
-shared-folder settings. It implements OPTIONS, PROPFIND, GET/HEAD, PUT, MKCOL,
+shared-folder settings. The runtime hooks Filza's actual `swithAirBrowserCheckbox`
+action (the selector is misspelled in Filza itself) and the underlying
+`air-browser` preference write/removal, so the visible switch now starts and stops
+the in-process listener instead of only changing its stored value. It implements
+OPTIONS, PROPFIND, GET/HEAD, PUT, MKCOL,
 DELETE, COPY, MOVE, LOCK, and UNLOCK. When Filza authentication is enabled, the
 server validates HTTP Basic credentials against Filza's saved password hash and
 refuses to start if those credentials are incomplete.
@@ -262,7 +267,7 @@ now performs the complete installable build:
 4. stages ByeTunes runtime resources;
 5. downloads and hash-verifies the pinned unsigned Filza base IPA;
 6. injects the current runtime dylib and resources;
-7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.2`;
+7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.3`;
 8. verifies the base executable actually loads `FilzaApplySandboxExt.dylib`;
 9. repacks a real unsigned IPA;
 10. uploads the IPA as a GitHub Actions artifact.
@@ -280,7 +285,7 @@ Open **Actions → Verify Filza installable IPA** to download the latest build a
 ## Current limitations
 
 - A green build proves the current source compiled, linked, packaged, and uploaded successfully. It does **not** prove every private API or sandbox-extension path still works on a specific iOS build.
-- ByeTunes, Gestalt Editor, and WebDAV still need on-device runtime validation after each new IPA build.
+- Music Library, Gestalt Editor, and WebDAV should be revalidated on-device after each new IPA build.
 - The existing container-access primitives do not establish unrestricted `/`, `/System`, `/Library`, `/Applications`, or arbitrary `/private` traversal.
 - No kernel read/write or full jailbreak primitive is claimed by this README.
 

--- a/WebDAVRuntimeFix.m
+++ b/WebDAVRuntimeFix.m
@@ -2,6 +2,7 @@
 @import UIKit;
 
 #import <objc/runtime.h>
+#import <stdint.h>
 #import <string.h>
 #import <CommonCrypto/CommonDigest.h>
 
@@ -27,13 +28,20 @@ static NSString * const FilzaWebDAVSecurityKey = @"air-browser-security";
 
 static void (*FilzaOriginalStartAirBrowser)(id, SEL) = NULL;
 static void (*FilzaOriginalStopAirBrowser)(id, SEL) = NULL;
+static void (*FilzaOriginalSetPreference)(id, SEL, id, id, uintptr_t) = NULL;
+static void (*FilzaOriginalRemovePreference)(id, SEL, id, uintptr_t) = NULL;
+static void (*FilzaOriginalSwitchAirBrowserCheckbox)(id, SEL) = NULL;
 static SEL FilzaStartAirBrowserSelector;
 static SEL FilzaStopAirBrowserSelector;
 static BOOL FilzaWebDAVStartInFlight = NO;
+static BOOL FilzaWebDAVPreferenceHooksInstalled = NO;
 static GCDWebDAVServer *FilzaPinnedWebDAVServer = nil;
 static NSString *FilzaWebDAVAuthenticationUsername = nil;
 static NSString *FilzaWebDAVAuthenticationPasswordMD5 = nil;
 static BOOL FilzaWebDAVAuthenticationRequired = NO;
+
+static void FilzaWebDAVStartAirBrowser(id preferences, SEL selector);
+static void FilzaWebDAVStopAirBrowser(id preferences, SEL selector);
 
 @interface FilzaWebDAVConnection : GCDWebServerConnection
 @end
@@ -380,25 +388,24 @@ static void FilzaWebDAVReport(id preferences, NSString *reason, BOOL permitRetry
 
 static void FilzaWebDAVStopAirBrowser(id preferences, SEL selector)
 {
-    @try {
-        if (FilzaOriginalStopAirBrowser) FilzaOriginalStopAirBrowser(preferences, selector);
-    } @catch (NSException *exception) {
-        FilzaDiagnosticsAppend(@"WebDAV",
-                               [NSString stringWithFormat:@"stop exception: %@ | %@",
-                                exception.name, exception.reason ?: @"no reason"]);
-    }
     [FilzaPinnedWebDAVServer stop];
     FilzaPinnedWebDAVServer = nil;
+    FilzaWebDAVAssignServer(preferences, nil);
+    SEL enableIdleTimer = NSSelectorFromString(@"enableIdleTimer");
+    if ([preferences respondsToSelector:enableIdleTimer]) {
+        IMP implementation = [preferences methodForSelector:enableIdleTimer];
+        if (implementation) ((void (*)(id, SEL))implementation)(preferences, enableIdleTimer);
+    }
     FilzaWebDAVAuthenticationUsername = nil;
     FilzaWebDAVAuthenticationPasswordMD5 = nil;
     FilzaWebDAVAuthenticationRequired = NO;
     FilzaWebDAVWriteStatus(@"WebDAV server stopped");
     FilzaDiagnosticsAppend(@"WebDAV", @"in-process WebDAV server stopped");
+    [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged" object:preferences];
 }
 
 static void FilzaWebDAVStartAirBrowser(id preferences, __unused SEL selector)
 {
-    if (!FilzaOriginalStartAirBrowser) return;
     if (FilzaWebDAVStartInFlight) {
         return;
     }
@@ -427,6 +434,95 @@ static void FilzaWebDAVStartAirBrowser(id preferences, __unused SEL selector)
                    dispatch_get_main_queue(), ^{
         FilzaWebDAVReport(preferences, @"after start", YES);
     });
+}
+
+static void FilzaWebDAVPreferenceChanged(id preferences, SEL selector,
+                                         id value, id key, uintptr_t notification)
+{
+    if (FilzaOriginalSetPreference)
+        FilzaOriginalSetPreference(preferences, selector, value, key, notification);
+    if (![key isKindOfClass:NSString.class] ||
+        ![(NSString *)key isEqualToString:FilzaWebDAVEnabledKey]) return;
+
+    BOOL enabled = [value respondsToSelector:@selector(boolValue)] && [value boolValue];
+    FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:
+        @"WebDAV toggle preference observed enabled=%@", enabled ? @"YES" : @"NO"]);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (enabled)
+            FilzaWebDAVStartAirBrowser(preferences, FilzaStartAirBrowserSelector);
+        else
+            FilzaWebDAVStopAirBrowser(preferences, FilzaStopAirBrowserSelector);
+    });
+}
+
+static void FilzaWebDAVPreferenceRemoved(id preferences, SEL selector,
+                                         id key, uintptr_t notification)
+{
+    if (FilzaOriginalRemovePreference)
+        FilzaOriginalRemovePreference(preferences, selector, key, notification);
+    if (![key isKindOfClass:NSString.class] ||
+        ![(NSString *)key isEqualToString:FilzaWebDAVEnabledKey]) return;
+
+    FilzaDiagnosticsAppend(@"WebDAV", @"WebDAV toggle preference removed; stopping listener");
+    dispatch_async(dispatch_get_main_queue(), ^{
+        FilzaWebDAVStopAirBrowser(preferences, FilzaStopAirBrowserSelector);
+    });
+}
+
+static void FilzaWebDAVSwitchAirBrowserCheckbox(id controller, SEL selector)
+{
+    if (FilzaOriginalSwitchAirBrowserCheckbox)
+        FilzaOriginalSwitchAirBrowserCheckbox(controller, selector);
+
+    // Filza updates its preference during this action. Read it on the next run
+    // loop so this also covers builds that bypass setObject:forPreferenceKey:.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        id preferences = FilzaWebDAVSharedPreferences();
+        BOOL enabled = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVEnabledKey);
+        FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:
+            @"WebDAV checkbox action completed enabled=%@", enabled ? @"YES" : @"NO"]);
+        if (enabled)
+            FilzaWebDAVStartAirBrowser(preferences, FilzaStartAirBrowserSelector);
+        else
+            FilzaWebDAVStopAirBrowser(preferences, FilzaStopAirBrowserSelector);
+    });
+}
+
+static void FilzaWebDAVInstallPreferenceHooks(Class preferencesClass)
+{
+    if (FilzaWebDAVPreferenceHooksInstalled || !preferencesClass) return;
+
+    SEL setSelector = NSSelectorFromString(@"setObject:forPreferenceKey:notification:");
+    Method setMethod = class_getInstanceMethod(preferencesClass, setSelector);
+    if (setMethod) {
+        FilzaOriginalSetPreference = (void (*)(id, SEL, id, id, uintptr_t))
+            method_getImplementation(setMethod);
+        method_setImplementation(setMethod, (IMP)FilzaWebDAVPreferenceChanged);
+    }
+
+    SEL removeSelector = NSSelectorFromString(@"removeObjectForPreferenceKey:notification:");
+    Method removeMethod = class_getInstanceMethod(preferencesClass, removeSelector);
+    if (removeMethod) {
+        FilzaOriginalRemovePreference = (void (*)(id, SEL, id, uintptr_t))
+            method_getImplementation(removeMethod);
+        method_setImplementation(removeMethod, (IMP)FilzaWebDAVPreferenceRemoved);
+    }
+
+    Class controllerClass = NSClassFromString(@"TGPreferencesTableViewController");
+    SEL checkboxSelector = NSSelectorFromString(@"swithAirBrowserCheckbox");
+    Method checkboxMethod = controllerClass
+        ? class_getInstanceMethod(controllerClass, checkboxSelector) : NULL;
+    if (checkboxMethod) {
+        FilzaOriginalSwitchAirBrowserCheckbox = (void (*)(id, SEL))
+            method_getImplementation(checkboxMethod);
+        method_setImplementation(checkboxMethod, (IMP)FilzaWebDAVSwitchAirBrowserCheckbox);
+    }
+
+    FilzaWebDAVPreferenceHooksInstalled = setMethod || removeMethod || checkboxMethod;
+    FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:
+        @"WebDAV toggle hooks installed preference-write=%@ preference-remove=%@ checkbox=%@",
+        setMethod ? @"YES" : @"NO", removeMethod ? @"YES" : @"NO",
+        checkboxMethod ? @"YES" : @"NO"]);
 }
 
 static void FilzaWebDAVResumeIfNeeded(NSString *reason)
@@ -468,6 +564,7 @@ static void FilzaWebDAVInstall(void)
         FilzaOriginalStopAirBrowser = (void (*)(id, SEL))method_getImplementation(stopMethod);
         method_setImplementation(stopMethod, (IMP)FilzaWebDAVStopAirBrowser);
     }
+    FilzaWebDAVInstallPreferenceHooks(preferencesClass);
     FilzaDiagnosticsAppend(@"WebDAV", @"jailed in-process WebDAV lifecycle hook installed");
 
     NSNotificationCenter *center = NSNotificationCenter.defaultCenter;

--- a/scripts/patch-byetunes-embedded.sh
+++ b/scripts/patch-byetunes-embedded.sh
@@ -8,6 +8,7 @@ test -f "$CONTENT"
 
 python3 - "$DEVICE" "$CONTENT" <<'PY'
 from pathlib import Path
+import re
 import sys
 
 device = Path(sys.argv[1])
@@ -41,50 +42,80 @@ ds = ds[:init_start] + safe_init + ds[init_end:]
 device.write_text(ds)
 
 cs = content.read_text()
-old_appear = '''        .onAppear {
-            cleanupLegacyImportedAudioFiles()
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                withAnimation(.easeOut(duration: 0.5)) {
-                    showSplash = false
-                }
+cs = re.sub(r'^[ \t]+$', '', cs, flags=re.MULTILINE)
+cs = cs.replace('    @State private var showSplash = true\n', '')
+cs = cs.replace('''            if showSplash {
+                SplashView()
+                    .transition(.opacity)
+                    .zIndex(1)
             }
-            manager.refreshExpectedPairingFileState()
-            hasCompletedOnboarding = manager.hasValidExpectedPairingFile || manager.needsRPPairingFileUpgrade
-            if manager.hasValidExpectedPairingFile {
-                manager.startHeartbeat()
+
+            if !showSplash {
+                Group {
+''', '''            Group {
+''')
+cs = cs.replace('''                }
             }
-            
-            
-            checkPendingInjections()
-            checkForAppUpdate()
-        }
-'''
+
+            if !showSplash && manager.needsRPPairingFileUpgrade {
+''', '''            }
+
+            if manager.needsRPPairingFileUpgrade {
+''')
+cs = cs.replace('''            if !showSplash,
+               let availableUpdate,
+''', '''            if let availableUpdate,
+''')
 new_appear = '''        .onAppear {
             // Filza embed: rendering this view must be side-effect free. In the
             // standalone app these startup helpers touch app-group storage,
             // pairing parsers, network transport and update state. None of that
             // is required to draw the UI, and a failure in any one subsystem
             // previously took down Filza with it.
-            Logger.shared.log("[ContentView] Filza embed: safe onAppear entered")
+            Logger.shared.log("[ContentView] Filza embed: immediate safe onAppear entered")
             hasCompletedOnboarding = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                withAnimation(.easeOut(duration: 0.5)) {
-                    showSplash = false
-                }
-                Logger.shared.log("[ContentView] Filza embed: splash completed; waiting for explicit pairing import")
-            }
+            Logger.shared.log("[ContentView] Filza embed: showing Music Library immediately; waiting for explicit pairing import")
         }
 '''
-if old_appear not in cs:
+appear_start = cs.find('        .onAppear {')
+appear_end = cs.find('        .onOpenURL', appear_start)
+if appear_start < 0 or appear_end < 0:
     raise SystemExit('embedded ContentView onAppear anchor not found')
-cs = cs.replace(old_appear, new_appear, 1)
+cs = cs[:appear_start] + new_appear + cs[appear_end:]
+if 'showSplash' in cs or 'SplashView()' in cs:
+    raise SystemExit('embedded splash route was not fully removed')
 content.write_text(cs)
+
+visible_replacements = {
+    Path("ByeTunes/MusicManager/OnboardingView.swift"): [
+        ('Text("ByeTunes")', 'Text("Music Library")'),
+    ],
+    Path("ByeTunes/MusicManager/ContentView.swift"): [
+        ('before ByeTunes can connect', 'before Music Library can connect'),
+        ('Text("ByeTunes \\(update.version) is available.', 'Text("Music Library \\(update.version) is available.'),
+    ],
+    Path("ByeTunes/MusicManager/SettingsView.swift"): [
+        ('Text("Add ByeTunes Shortcut")', 'Text("Add Music Library Shortcut")'),
+        ('title: "ByeTunes \\(update.version) is available"', 'title: "Music Library \\(update.version) is available"'),
+        ('title: "ByeTunes is up to date"', 'title: "Music Library is up to date"'),
+    ],
+}
+for path, replacements in visible_replacements.items():
+    text = path.read_text()
+    for old, new in replacements:
+        if old not in text and new not in text:
+            raise SystemExit(f'visible branding anchor not found in {path}: {old}')
+        text = text.replace(old, new)
+    path.write_text(text)
 PY
 
 grep -Fq 'Filza embed: inert startup initialized' "$DEVICE"
 grep -Fq 'all pairing/transport/storage work deferred until explicit import' "$DEVICE"
-grep -Fq 'Filza embed: safe onAppear entered' "$CONTENT"
+grep -Fq 'Filza embed: immediate safe onAppear entered' "$CONTENT"
+! grep -Fq 'SplashView()' "$CONTENT"
+! grep -Fq 'showSplash' "$CONTENT"
+grep -Fq 'Text("Music Library")' ByeTunes/MusicManager/OnboardingView.swift
+! grep -Fq 'Text("ByeTunes")' ByeTunes/MusicManager/OnboardingView.swift
 ! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'idevice_init_logger('
 ! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'regularPairingFile'
 ! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'refreshExpectedPairingFileState()'


### PR DESCRIPTION
## What changed
- remove the visible ByeTunes splash/loading controller and replace visible branding with Music Library
- open the complete Music Library ContentView directly
- open the Gestalt editor directly with no loading screen, and match rooootdev/mond's controls, device/version gating, warnings, and information dialogs
- hook Filza's actual `swithAirBrowserCheckbox` selector plus the `air-browser` preference write/removal so the WebDAV switch starts and stops the in-process listener
- package as version 4.3 and add binary assertions for all routes

## Validation
- patch script tested against a clean ByeTunes submodule archive
- workflow YAML parsed and local diffs passed static checks
- Apple SDK arm64 build/IPA verification runs in GitHub Actions

## Summary by Sourcery

Open the full Music Library and Gestalt editor directly, align Gestalt controls and warnings with upstream Mond behavior, and make the WebDAV toggle drive Filza’s in-process server while bumping the app to version 4.3.

New Features:
- Add inline info and warning dialogs to Gestalt controls for region restrictions, Apple Intelligence, device spoofing, and iPadOS UI.
- Gate Gestalt artwork and spoofing options based on device type and OS version, including Dynamic Island disable support.

Bug Fixes:
- Wire the WebDAV toggle to Filza’s actual checkbox action and air-browser preference changes so the visible switch starts and stops the in-process listener.
- Ensure Gestalt editor failures are surfaced as alerts instead of hanging on a loading screen.

Enhancements:
- Remove intermediate ByeTunes splash/loading controllers and rebrand embedded music features as Music Library, opening ContentView immediately.
- Update Mond Gestalt UI sections with clearer warnings, structured headers, and refined internal toggling behavior.
- Prewarm MobileGestalt access at launch to speed direct Gestalt editor presentation and log availability.

Build:
- Exclude SplashView.swift from the embedded ByeTunes Swift file set and extend the patch script to strip splash behavior and visible ByeTunes branding.
- Update README and CI workflow assertions to reflect direct Music Library and Gestalt editor presentation, WebDAV toggle hooks, and version 4.3 metadata.
- Bump CFBundleShortVersionString and related checks from 4.2 to 4.3 and adjust quick action subtitles to reference Music Library.
- Tighten CI verification of Gestalt and Music Library routes by asserting new log messages and ensuring legacy loading/splash strings are absent.

Documentation:
- Revise README to describe direct Music Library integration, Mond-aligned Gestalt editor behavior, and the corrected WebDAV toggle wiring, along with updated validation guidance.

Tests:
- Extend CI workflow content-assertions to cover new Gestalt info strings, Music Library branding, WebDAV hook logs, and removal of old loading and splash markers.

Chores:
- Normalize and harden patch script behavior around ContentView onAppear replacement and branding updates to enforce a fully splash-free embedded route.