### PR TITLE
Persist Music Library pairing file across launches

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -174,6 +174,10 @@ jobs:
           grep -aFq 'complete ByeTunes host attached directly to Music Library' "$DYLIB"
           grep -aFq 'before direct Music Library ContentView construction' "$DYLIB"
           grep -aFq 'direct Music Library SwiftUI host ready' "$DYLIB"
+          grep -aFq 'persistent pairing state restored=' "$DYLIB"
+          grep -aFq 'imported pairing file persisted at' "$DYLIB"
+          grep -aFq 'restored persisted pairing file; reconnecting automatically' "$DYLIB"
+          grep -aFq 'no persisted pairing file; showing import flow' "$DYLIB"
           ! grep -aFq 'Starting ByeTunes' "$DYLIB"
           ! grep -aFq 'before ByeTunes can connect' "$DYLIB"
           ! grep -aFq 'Add ByeTunes Shortcut' "$DYLIB"
@@ -236,7 +240,7 @@ jobs:
           fi
 
           plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open Music Library","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
-          plutil -replace CFBundleShortVersionString -string "4.3" "$APP/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "4.4" "$APP/Info.plist"
           plutil -replace CFBundleVersion -string "${GITHUB_RUN_NUMBER}" "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
@@ -259,7 +263,7 @@ jobs:
           assert info.get('LSSupportsOpeningDocumentsInPlace') is True
           assert info.get('NSLocalNetworkUsageDescription')
           assert info.get('NSBonjourServices') == ['_http._tcp']
-          assert info.get('CFBundleShortVersionString') == '4.3'
+          assert info.get('CFBundleShortVersionString') == '4.4'
           assert str(info.get('CFBundleVersion', '')).isdigit()
           print('Verified exactly three quick actions and Files/Documents exposure flags')
           PY

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The Music Library action intercepts `TGMainView.openMusicLib` and constructs the
 complete SwiftUI `ContentView` immediately. The Home Screen Music Library action uses
 the same presenter. There is no intermediate UIKit loading controller, branded splash,
 or artificial delay. `TGMusicLibraryViewController` remains only as a fallback route.
+Imported pairing files are copied into FilzaSlop's persistent Documents container. On
+later launches the embedded manager validates that saved copy, skips the import screen,
+and reconnects automatically; the document picker is shown only when no valid saved
+pairing file exists.
 
 A runtime stage marker is written to:
 
@@ -267,7 +271,7 @@ now performs the complete installable build:
 4. stages ByeTunes runtime resources;
 5. downloads and hash-verifies the pinned unsigned Filza base IPA;
 6. injects the current runtime dylib and resources;
-7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.3`;
+7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.4`;
 8. verifies the base executable actually loads `FilzaApplySandboxExt.dylib`;
 9. repacks a real unsigned IPA;
 10. uploads the IPA as a GitHub Actions artifact.

--- a/scripts/patch-byetunes-embedded.sh
+++ b/scripts/patch-byetunes-embedded.sh
@@ -15,6 +15,22 @@ device = Path(sys.argv[1])
 content = Path(sys.argv[2])
 
 ds = device.read_text()
+
+# Filza does not own ByeTunes' application-group entitlement. Keep the embedded
+# pairing copy in Filza's persistent Documents container so it survives process
+# relaunches and can be reused without reopening the document picker.
+pairing_property_start = ds.find("    var regularPairingFile: URL {")
+pairing_property_end = ds.find("\n    var rpPairingFile: URL {", pairing_property_start)
+if pairing_property_start < 0 or pairing_property_end < 0:
+    raise SystemExit('DeviceManager regularPairingFile property not found')
+persistent_pairing_property = '''    var regularPairingFile: URL {
+        URL.documentsDirectory
+            .appendingPathComponent("pairing file", isDirectory: true)
+            .appendingPathComponent("pairingFile.plist")
+    }
+'''
+ds = ds[:pairing_property_start] + persistent_pairing_property + ds[pairing_property_end:]
+
 init_start = ds.find("    private init() {")
 if init_start < 0:
     raise SystemExit('DeviceManager private init not found')
@@ -24,9 +40,8 @@ if init_end < 0:
 
 # Filza owns the process. DeviceManager.shared is created while SwiftUI builds
 # ContentView, so its embedded initializer must not touch process-global FFI,
-# app-group storage, pairing files, sockets, or tunnel state. Those operations
-# stay in the existing explicit import/connect methods and begin only after the
-# user presses the pairing-file import action.
+# process-global FFI, sockets, or tunnel state. Restoring the saved pairing
+# file's local state is intentionally safe and required across app launches.
 safe_init = '''    private init() {
         Logger.shared.log("===========================================")
         Logger.shared.log("[DeviceManager] BUILD VERSION: \\(BUILD_VERSION)")
@@ -35,10 +50,41 @@ safe_init = '''    private init() {
         hasValidExpectedPairingFile = false
         heartbeatReady = false
         connectionStatus = "Disconnected"
-        Logger.shared.log("[DeviceManager] Filza embed: all pairing/transport/storage work deferred until explicit import")
+        let folderPath = regularPairingFile.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(
+                at: folderPath,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            Logger.shared.log("[DeviceManager] Filza embed: pairing directory error: \\(error.localizedDescription)")
+        }
+        refreshExpectedPairingFileState()
+        Logger.shared.log("[DeviceManager] Filza embed: persistent pairing state restored=\\(hasValidExpectedPairingFile) path=\\(expectedPairingFile.path)")
+        Logger.shared.log("[DeviceManager] Filza embed: transport work deferred until ContentView appears or an explicit import completes")
     }
 '''
 ds = ds[:init_start] + safe_init + ds[init_end:]
+
+# Read the security-scoped selection before replacing the saved copy. Atomic
+# data writes also handle selecting the already-saved file and avoid leaving a
+# missing/partial pairing file if the process is interrupted during import.
+old_import_write = '''        if FileManager.default.fileExists(atPath: expectedPairingFile.path) {
+            try FileManager.default.removeItem(at: expectedPairingFile)
+        }
+        try FileManager.default.copyItem(at: url, to: expectedPairingFile)
+
+        refreshExpectedPairingFileState()
+'''
+new_import_write = '''        let importedPairingData = try Data(contentsOf: url)
+        try importedPairingData.write(to: expectedPairingFile, options: .atomic)
+        Logger.shared.log("[DeviceManager] Filza embed: imported pairing file persisted at \\(expectedPairingFile.path)")
+
+        refreshExpectedPairingFileState()
+'''
+if old_import_write not in ds:
+    raise SystemExit('DeviceManager pairing import write anchor not found')
+ds = ds.replace(old_import_write, new_import_write, 1)
 device.write_text(ds)
 
 cs = content.read_text()
@@ -73,8 +119,14 @@ new_appear = '''        .onAppear {
             // is required to draw the UI, and a failure in any one subsystem
             // previously took down Filza with it.
             Logger.shared.log("[ContentView] Filza embed: immediate safe onAppear entered")
-            hasCompletedOnboarding = false
-            Logger.shared.log("[ContentView] Filza embed: showing Music Library immediately; waiting for explicit pairing import")
+            manager.refreshExpectedPairingFileState()
+            hasCompletedOnboarding = manager.hasValidExpectedPairingFile
+            if manager.hasValidExpectedPairingFile {
+                Logger.shared.log("[ContentView] Filza embed: restored persisted pairing file; reconnecting automatically")
+                manager.startHeartbeat()
+            } else {
+                Logger.shared.log("[ContentView] Filza embed: no persisted pairing file; showing import flow")
+            }
         }
 '''
 appear_start = cs.find('        .onAppear {')
@@ -110,15 +162,16 @@ for path, replacements in visible_replacements.items():
 PY
 
 grep -Fq 'Filza embed: inert startup initialized' "$DEVICE"
-grep -Fq 'all pairing/transport/storage work deferred until explicit import' "$DEVICE"
+grep -Fq 'URL.documentsDirectory' "$DEVICE"
+grep -Fq 'persistent pairing state restored=' "$DEVICE"
+grep -Fq 'imported pairing file persisted at' "$DEVICE"
 grep -Fq 'Filza embed: immediate safe onAppear entered' "$CONTENT"
+grep -Fq 'restored persisted pairing file; reconnecting automatically' "$CONTENT"
 ! grep -Fq 'SplashView()' "$CONTENT"
 ! grep -Fq 'showSplash' "$CONTENT"
 grep -Fq 'Text("Music Library")' ByeTunes/MusicManager/OnboardingView.swift
 ! grep -Fq 'Text("ByeTunes")' ByeTunes/MusicManager/OnboardingView.swift
 ! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'idevice_init_logger('
-! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'regularPairingFile'
-! grep -A14 -F 'private init() {' "$DEVICE" | grep -Fq 'refreshExpectedPairingFileState()'
 # The explicit import/connect paths must remain present; this patch only removes
 # automatic startup work.
 grep -Fq 'func importPairingFile(from url: URL) throws' "$DEVICE"


### PR DESCRIPTION
## What changed
- store the embedded Music Library pairing file in FilzaSlop's persistent Documents container
- restore and validate that saved file during `DeviceManager` initialization
- skip the import screen and reconnect automatically on later app launches
- make imports atomic so selecting the saved file cannot delete it before copying
- add arm64 binary assertions and package the fix as version 4.4

## Root cause
The prior embedded patch deliberately reset `hasCompletedOnboarding` to `false` on every `ContentView.onAppear` and removed the launch-time pairing-state refresh, so a valid copied pairing file was ignored after restart.

## Validation
The patch was applied to a clean ByeTunes submodule archive; the generated Swift sources passed structural assertions and delimiter checks. GitHub Actions performs the Apple SDK arm64 build and IPA verification.

## Summary by Sourcery

Persist the embedded Music Library pairing file across FilzaSlop launches and package the change as a new 4.4 build.

New Features:
- Reuse a previously imported Music Library pairing file to skip re-onboarding and reconnect automatically on later app launches.

Bug Fixes:
- Ensure the embedded DeviceManager restores and validates a saved pairing file instead of discarding it on each ContentView appearance.
- Make pairing file imports atomic to avoid losing or partially writing the saved copy when reselecting it or on interrupted imports.

Enhancements:
- Store the embedded Music Library pairing file in FilzaSlop's persistent Documents container so it survives process relaunches.
- Extend logging around pairing state restoration and imports to support automated verification of the embedded runtime behavior.

Build:
- Bump the FilzaSlop app version from 4.3 to 4.4 in Info.plist and the build verification script.

CI:
- Update the GitHub Actions verification workflow to assert the new pairing persistence log markers in the embedded dylib output.

Documentation:
- Document Music Library pairing file persistence, automatic reconnection behavior, and the updated build version in the README.