### PR TITLE
Fix ByeTunes downloads and add Mond settings

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -186,7 +186,6 @@ jobs:
           grep -aFq 'restored persisted pairing file; reconnecting automatically' "$DYLIB"
           grep -aFq 'no persisted pairing file; showing import flow' "$DYLIB"
           grep -aFq 'Current Apple Music JWT token selected' "$DYLIB"
-          grep -aFq 'AMPWebPlay' "$DYLIB"
           ! grep -aFq 'Starting ByeTunes' "$DYLIB"
           ! grep -aFq 'before ByeTunes can connect' "$DYLIB"
           ! grep -aFq 'Add ByeTunes Shortcut' "$DYLIB"

--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -159,6 +159,13 @@ jobs:
           grep -aFq 'Device Spoofing Info' "$DYLIB"
           grep -aFq 'iPadOS UI Warning' "$DYLIB"
           grep -aFq 'Disable Dynamic Island' "$DYLIB"
+          grep -aFq 'presenting complete Mond Settings' "$DYLIB"
+          grep -aFq 'Run Exploit' "$DYLIB"
+          grep -aFq 'Generate Token' "$DYLIB"
+          grep -aFq 'Keep Alive' "$DYLIB"
+          grep -aFq 'Mond Respring confirmed' "$DYLIB"
+          grep -aFq 'bad_query' "$DYLIB"
+          grep -aFq 'cmg' "$DYLIB"
           ! grep -aFq 'Loading MobileGestalt' "$DYLIB"
           ! grep -aFq 'Opening the complete Gestalt Editor' "$DYLIB"
           grep -aFq 'inserted in-app Gestalt Editor row beside Apps/Music' "$DYLIB"
@@ -178,6 +185,8 @@ jobs:
           grep -aFq 'imported pairing file persisted at' "$DYLIB"
           grep -aFq 'restored persisted pairing file; reconnecting automatically' "$DYLIB"
           grep -aFq 'no persisted pairing file; showing import flow' "$DYLIB"
+          grep -aFq 'Current Apple Music JWT token selected' "$DYLIB"
+          grep -aFq 'AMPWebPlay' "$DYLIB"
           ! grep -aFq 'Starting ByeTunes' "$DYLIB"
           ! grep -aFq 'before ByeTunes can connect' "$DYLIB"
           ! grep -aFq 'Add ByeTunes Shortcut' "$DYLIB"
@@ -240,7 +249,7 @@ jobs:
           fi
 
           plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open Music Library","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
-          plutil -replace CFBundleShortVersionString -string "4.4" "$APP/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "4.5" "$APP/Info.plist"
           plutil -replace CFBundleVersion -string "${GITHUB_RUN_NUMBER}" "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
@@ -263,7 +272,7 @@ jobs:
           assert info.get('LSSupportsOpeningDocumentsInPlace') is True
           assert info.get('NSLocalNetworkUsageDescription')
           assert info.get('NSBonjourServices') == ['_http._tcp']
-          assert info.get('CFBundleShortVersionString') == '4.4'
+          assert info.get('CFBundleShortVersionString') == '4.5'
           assert str(info.get('CFBundleVersion', '')).isdigit()
           print('Verified exactly three quick actions and Files/Documents exposure flags')
           PY

--- a/GestaltManager.h
+++ b/GestaltManager.h
@@ -6,6 +6,9 @@ FOUNDATION_EXPORT void FilzaGestaltManagerInstall(void);
 FOUNDATION_EXPORT void FilzaGestaltManagerPresent(void);
 FOUNDATION_EXPORT void FilzaGestaltManagerPresentFromController(UIViewController * _Nullable controller);
 FOUNDATION_EXPORT NSString * _Nullable FilzaGestaltResolvePath(NSString * _Nullable * _Nullable detail);
+FOUNDATION_EXPORT NSString *FilzaGestaltPreferredMethod(void);
+FOUNDATION_EXPORT void FilzaGestaltSetPreferredMethod(NSString *method);
+FOUNDATION_EXPORT NSString * _Nullable FilzaGestaltRefreshAccess(NSString * _Nullable * _Nullable detail);
 FOUNDATION_EXPORT NSError * _Nullable FilzaGestaltWritePlist(NSString *path, NSDictionary *plist);
 FOUNDATION_EXPORT NSError * _Nullable FilzaGestaltRestoreBackup(NSString *path);
 

--- a/GestaltManager.m
+++ b/GestaltManager.m
@@ -23,8 +23,10 @@ static NSString *const GMSystemGroupIdentifier = @"systemgroup.com.apple.mobileg
 static NSString *const GMFallbackDirectory = @"/private/var/containers/Shared/SystemGroup/systemgroup.com.apple.mobilegestaltcache/Library/Caches";
 static NSString *const GMPlistName = @"com.apple.MobileGestalt.plist";
 static NSString *const GMShortcutType = @"com.nightvibes33.filzaslop.gestalt-manager";
+static NSString *const GMMethodDefaultsKey = @"method";
 
 static NSString *gGMResolvedPath;
+static NSString *gGMResolvedMethod;
 static int64_t gGMBadQueryHandle = -1;
 static BOOL gGMMenuHooksInstalled = NO;
 static BOOL gGMMenuScanScheduled = NO;
@@ -163,11 +165,6 @@ static NSString *GMTryContainerManagerAccess(NSString **detail)
 static NSString *GMTryBadQueryAccess(NSString **detail)
 {
     NSString *file = [GMFallbackDirectory stringByAppendingPathComponent:GMPlistName];
-    if (GMFileReadable(file)) {
-        if (detail) *detail = @"MobileGestalt cache already readable";
-        return file;
-    }
-
     int64_t handle = bad_query((char *)GMFallbackDirectory.fileSystemRepresentation,
                                false, NULL, false);
     if (handle < 0) {
@@ -191,27 +188,50 @@ static NSString *GMTryBadQueryAccess(NSString **detail)
     return file;
 }
 
+NSString *FilzaGestaltPreferredMethod(void)
+{
+    NSString *method = [NSUserDefaults.standardUserDefaults stringForKey:GMMethodDefaultsKey];
+    return [method isEqualToString:@"cmg"] ? @"cmg" : @"bad_query";
+}
+
+void FilzaGestaltSetPreferredMethod(NSString *method)
+{
+    NSString *normalized = [method isEqualToString:@"cmg"] ? @"cmg" : @"bad_query";
+    NSString *previous = FilzaGestaltPreferredMethod();
+    [NSUserDefaults.standardUserDefaults setObject:normalized forKey:GMMethodDefaultsKey];
+    if (![previous isEqualToString:normalized]) {
+        if ([normalized isEqualToString:@"cmg"] && gGMBadQueryHandle >= 0) {
+            bad_query_release(gGMBadQueryHandle);
+            gGMBadQueryHandle = -1;
+        }
+        gGMResolvedPath = nil;
+        gGMResolvedMethod = nil;
+        FilzaDiagnosticsAppend(@"Gestalt", [NSString stringWithFormat:
+            @"access method changed from %@ to %@", previous, normalized]);
+    }
+}
+
 static NSString *GMEnsureAccess(NSString **detail)
 {
-    if (gGMResolvedPath.length && GMFileReadable(gGMResolvedPath)) {
+    NSString *method = FilzaGestaltPreferredMethod();
+    if (gGMResolvedPath.length && [gGMResolvedMethod isEqualToString:method] &&
+        GMFileReadable(gGMResolvedPath)) {
         if (detail) *detail = GMFileWritable(gGMResolvedPath)
-            ? @"MobileGestalt cache read/write access active"
-            : @"MobileGestalt cache read-only access active";
+            ? [NSString stringWithFormat:@"%@ MobileGestalt read/write access active", method]
+            : [NSString stringWithFormat:@"%@ MobileGestalt read-only access active", method];
         return gGMResolvedPath;
     }
 
-    NSString *cmgDetail = nil;
-    NSString *path = GMTryContainerManagerAccess(&cmgDetail);
-    if (!path.length) {
-        NSString *bqDetail = nil;
-        path = GMTryBadQueryAccess(&bqDetail);
-        if (detail) *detail = [NSString stringWithFormat:@"%@; %@",
-            cmgDetail ?: @"ContainerManager path unavailable",
-            bqDetail ?: @"fallback unavailable"];
-    } else if (detail) {
-        *detail = cmgDetail;
+    NSString *methodDetail = nil;
+    NSString *path = [method isEqualToString:@"cmg"]
+        ? GMTryContainerManagerAccess(&methodDetail)
+        : GMTryBadQueryAccess(&methodDetail);
+    if (detail) *detail = [NSString stringWithFormat:@"%@ — %@", method,
+        methodDetail ?: @"access unavailable"];
+    if (path.length) {
+        gGMResolvedPath = path;
+        gGMResolvedMethod = method;
     }
-    if (path.length) gGMResolvedPath = path;
     return path;
 }
 
@@ -432,6 +452,19 @@ NSString *FilzaGestaltResolvePath(NSString **detail)
 {
     NSString *path = GMEnsureAccess(detail);
     if (path.length) (void)GMEnsureBackup(path, nil);
+    return path;
+}
+
+NSString *FilzaGestaltRefreshAccess(NSString **detail)
+{
+    gGMResolvedPath = nil;
+    gGMResolvedMethod = nil;
+    NSString *path = GMEnsureAccess(detail);
+    if (path.length) (void)GMEnsureBackup(path, nil);
+    FilzaDiagnosticsAppend(@"Gestalt", path.length
+        ? [NSString stringWithFormat:@"Run Exploit completed using %@", FilzaGestaltPreferredMethod()]
+        : [NSString stringWithFormat:@"Run Exploit failed using %@: %@",
+            FilzaGestaltPreferredMethod(), detail && *detail ? *detail : @"unknown"]);
     return path;
 }
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ FilzaApplySandboxExt_LDFLAGS += $(IDEVICE_STATIC)
 
 # Framework coverage matches the complete ByeTunes source tree rather than the
 # old reduced music-library bridge.
-FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents CFNetwork MobileCoreServices
+FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents CFNetwork MobileCoreServices WebKit
 FilzaApplySandboxExt_PRIVATE_FRAMEWORKS = IOSurface
 FilzaApplySandboxExt_LIBRARIES = z xml2 sandbox sqlite3
 

--- a/MondGestaltView.swift
+++ b/MondGestaltView.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import UIKit
+import AVFoundation
+import WebKit
 import Darwin
 import MachO
 
@@ -158,6 +160,267 @@ Do not spoof back afterward.
 private let mondIPadUIWarning = """
 This is a very dangerous tweak. Do not use it with an alphanumeric passcode. Do not turn off “Show Dock In Stage Manager” or the device can bootloop when rotating to landscape. Opening Stage Manager after enabling this can also enter Recovery Mode. Other instability, including app data disappearing, has been reported.
 """
+
+// Mond's settings are part of the embedded editor, including its original
+// silent-audio keep-alive behavior and WebKit respring tool. They live in this
+// process instead of launching a separate branded app.
+private var mondKeepAlivePlayer: AVAudioPlayer?
+private var mondKeepAliveTimer: Timer?
+
+private func mondKeepAlive() {
+    guard mondKeepAlivePlayer == nil else { return }
+    try? AVAudioSession.sharedInstance().setCategory(.playback, options: .mixWithOthers)
+    try? AVAudioSession.sharedInstance().setActive(true)
+
+    let sampleRate = 8000
+    let samples = Int(Double(sampleRate) * 0.5)
+    var wave = Data("RIFF".utf8)
+    wave.append(withUnsafeBytes(of: UInt32(36 + samples * 2).littleEndian) { Data($0) })
+    wave.append(Data("WAVEfmt ".utf8))
+    wave.append(withUnsafeBytes(of: UInt32(16).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt16(1).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt16(1).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt32(sampleRate).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt32(sampleRate * 2).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt16(2).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt16(16).littleEndian) { Data($0) })
+    wave.append(Data("data".utf8))
+    wave.append(withUnsafeBytes(of: UInt32(samples * 2).littleEndian) { Data($0) })
+    wave.append(Data(count: samples * 2))
+
+    mondKeepAlivePlayer = try? AVAudioPlayer(data: wave)
+    mondKeepAlivePlayer?.volume = 0
+    mondKeepAlivePlayer?.numberOfLoops = -1
+    mondKeepAlivePlayer?.play()
+    mondKeepAliveTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+        mondKeepAlivePlayer?.play()
+    }
+    FilzaDiagnosticsAppend("Gestalt", "Mond Keep Alive started")
+}
+
+private func mondLetDie() {
+    mondKeepAliveTimer?.invalidate()
+    mondKeepAliveTimer = nil
+    mondKeepAlivePlayer?.stop()
+    mondKeepAlivePlayer = nil
+    try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    FilzaDiagnosticsAppend("Gestalt", "Mond Keep Alive stopped")
+}
+
+private func mondIssueSandboxToken(path: String) -> String? {
+    typealias IssueFunction = @convention(c) (
+        UnsafePointer<CChar>?, UnsafePointer<CChar>?, Int32, Int32
+    ) -> UnsafeMutablePointer<CChar>?
+    guard let library = dlopen("/usr/lib/system/libsystem_sandbox.dylib", RTLD_NOW) else { return nil }
+    defer { dlclose(library) }
+    guard let symbol = dlsym(library, "sandbox_extension_issue_file") else { return nil }
+    let issue = unsafeBitCast(symbol, to: IssueFunction.self)
+    let pointer = path.withCString {
+        issue("com.apple.app-sandbox.read-write", $0, 0, 0)
+    }
+    guard let pointer else { return nil }
+    defer { free(pointer) }
+    return String(cString: pointer)
+}
+
+private func mondConsumeSandboxToken(_ token: String) -> Int64? {
+    typealias ConsumeFunction = @convention(c) (UnsafePointer<CChar>?) -> Int64
+    guard !token.isEmpty,
+          let library = dlopen("/usr/lib/system/libsystem_sandbox.dylib", RTLD_NOW) else { return nil }
+    defer { dlclose(library) }
+    guard let symbol = dlsym(library, "sandbox_extension_consume") else { return nil }
+    let consume = unsafeBitCast(symbol, to: ConsumeFunction.self)
+    return token.withCString { consume($0) }
+}
+
+private let mondRespringDocument = """
+<!DOCTYPE html>
+<html>
+<body>
+<iframe id="frame" srcdoc="" sandbox="allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts"></iframe>
+<script>
+const frame = document.getElementById('frame');
+const respringScript = `
+<html><body><script>
+const container = document.createElement('div');
+container.style.cssText = 'perspective:1px;perspective-origin:9999999% 9999999%;';
+document.body.appendChild(container);
+for (let i = 0; i < 500; i++) {
+  const d = document.createElement('div');
+  d.style.cssText = 'position:absolute;width:100vw;height:100vh;backdrop-filter:blur(100px);-webkit-backdrop-filter:blur(100px);transform:translate3d(100000px,100000px,' + i + 'px) rotateY(90deg);';
+  container.appendChild(d);
+}
+setInterval(() => {
+  navigator.share({title:'R', text:'R'.repeat(100000)}).catch(() => {});
+  const x = new Uint8Array(1024 * 1024 * 10);
+  crypto.getRandomValues(x);
+}, 0);
+<\\/script></body></html>`;
+frame.srcdoc = respringScript;
+</script>
+</body>
+</html>
+"""
+
+private struct MondRespringView: UIViewRepresentable {
+    func makeUIView(context: Context) -> WKWebView { WKWebView() }
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        webView.loadHTMLString(mondRespringDocument, baseURL: nil)
+    }
+}
+
+private struct MondSettingsView: View {
+    let gestaltPath: String
+
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("method") private var method = "bad_query"
+    @AppStorage("ka_on") private var keepAlive = true
+    @AppStorage("token") private var token = ""
+    @State private var accessStatus = "Access has not been refreshed from Settings yet."
+    @State private var runningExploit = false
+    @State private var showRespringConfirmation = false
+    @State private var showRespring = false
+
+    private var gestaltDirectory: String {
+        (gestaltPath as NSString).deletingLastPathComponent
+    }
+
+    private var tokenValid: Bool {
+        guard !token.isEmpty else { return false }
+        return (mondConsumeSandboxToken(token) ?? -1) >= 0
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Picker("Method", selection: $method) {
+                        Text("bad_query").tag("bad_query")
+                        Text("cmg").tag("cmg")
+                    }
+                    .pickerStyle(.segmented)
+
+                    Button(runningExploit ? "Running…" : "Run Exploit", action: runExploit)
+                        .disabled(runningExploit)
+                } header: {
+                    Label("Exploit", systemImage: "wrench.and.screwdriver")
+                } footer: {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(method == "cmg"
+                            ? "CMG supports iOS 27.0 beta 1–4. Use it when bad_query is not working."
+                            : "bad_query supports iOS 27.0 beta 1–4.")
+                        Text(accessStatus)
+                    }
+                }
+
+                Section {
+                    HStack {
+                        TextField("Sandbox Extension Token", text: $token)
+                            .lineLimit(1)
+                        Button {
+                            UIPasteboard.general.string = token
+                        } label: {
+                            Image(systemName: "document.on.document")
+                        }
+                        .disabled(token.isEmpty)
+                    }
+
+                    Button("Generate Token", action: generateToken)
+                } header: {
+                    Label("Token", systemImage: "key")
+                } footer: {
+                    if !token.isEmpty {
+                        Text(tokenValid ? "Your sandbox token is valid." : "Your sandbox token is invalid.")
+                    }
+                }
+
+                Section {
+                    Toggle("Keep Alive", isOn: $keepAlive)
+                } header: {
+                    Label("Settings", systemImage: "gear")
+                }
+
+                Section {
+                    Button("Respring") { showRespringConfirmation = true }
+                } header: {
+                    Label("Tools", systemImage: "wrench.and.screwdriver")
+                }
+
+                Section {
+                    Link("roooot — Main developer", destination: URL(string: "https://github.com/rooootdev")!)
+                    Link("forcequit — bad_query", destination: URL(string: "https://github.com/forcequitOS")!)
+                    Link("jailbreak.party — Gestalt and respring work", destination: URL(string: "https://github.com/jailbreakdotparty")!)
+                } header: {
+                    Label("Credits", systemImage: "person.3.fill")
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .onAppear {
+                method = FilzaGestaltPreferredMethod()
+                if keepAlive { mondKeepAlive() }
+            }
+            .onChange(of: method) { newMethod in
+                FilzaGestaltSetPreferredMethod(newMethod)
+                accessStatus = "Method changed to \(newMethod). Tap Run Exploit to refresh access."
+            }
+            .onChange(of: keepAlive) { enabled in
+                if enabled { mondKeepAlive() } else { mondLetDie() }
+            }
+            .alert("Are you sure?", isPresented: $showRespringConfirmation) {
+                Button("Cancel", role: .cancel) {}
+                Button("Confirm") {
+                    FilzaDiagnosticsAppend("Gestalt", "Mond Respring confirmed")
+                    showRespring = true
+                }
+            } message: {
+                Text("Confirm that you want to respring.")
+            }
+            .overlay {
+                if showRespring {
+                    MondRespringView()
+                        .brightness(-1.0)
+                        .ignoresSafeArea()
+                }
+            }
+        }
+    }
+
+    private func runExploit() {
+        FilzaGestaltSetPreferredMethod(method)
+        runningExploit = true
+        accessStatus = "Running \(method)…"
+        DispatchQueue.global(qos: .userInitiated).async {
+            var detail: NSString?
+            let path = FilzaGestaltRefreshAccess(&detail)
+            DispatchQueue.main.async {
+                runningExploit = false
+                let detailText = detail.map { String($0) }
+                if let path, !path.isEmpty {
+                    accessStatus = "\(detailText ?? "Access active")\n\(path)"
+                } else {
+                    accessStatus = detailText ?? "Access failed"
+                }
+            }
+        }
+    }
+
+    private func generateToken() {
+        guard let generated = mondIssueSandboxToken(path: gestaltDirectory) else {
+            token = ""
+            accessStatus = "Failed to issue a sandbox extension token. Run Exploit first."
+            FilzaDiagnosticsAppend("Gestalt", "Generate Token failed")
+            return
+        }
+        token = generated
+        accessStatus = "Sandbox extension token generated for \(gestaltDirectory)."
+        FilzaDiagnosticsAppend("Gestalt", "Generate Token completed")
+    }
+}
 
 struct MondGestaltView: View {
     let gestaltPath: String
@@ -576,6 +839,16 @@ public final class MondGestaltHostFactory: NSObject {
         let controller = UIHostingController(rootView: MondGestaltView(gestaltPath: path))
         controller.title = "Gestalt Editor"
         controller.view.backgroundColor = .systemGroupedBackground
+        let settingsAction = UIAction { [weak controller] _ in
+            FilzaDiagnosticsAppend("Gestalt", "presenting complete Mond Settings")
+            let settings = UIHostingController(rootView: MondSettingsView(gestaltPath: path))
+            settings.modalPresentationStyle = .pageSheet
+            controller?.present(settings, animated: true)
+        }
+        controller.navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "gear"),
+            primaryAction: settingsAction
+        )
         return controller
     }
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ or artificial delay. `TGMusicLibraryViewController` remains only as a fallback r
 Imported pairing files are copied into FilzaSlop's persistent Documents container. On
 later launches the embedded manager validates that saved copy, skips the import screen,
 and reconnects automatically; the document picker is shown only when no valid saved
-pairing file exists.
+pairing file exists. Apple Music search extracts the current unexpired JWT from Apple's
+live web-player bundle and prefers its `AMPWebPlay` token, so token header-field order
+changes do not silently empty the Download tab.
 
 A runtime stage marker is written to:
 
@@ -96,11 +98,10 @@ The editor attempts to resolve:
 
 Access flow:
 
-1. Query the MobileGestalt system-group container through ContainerManager.
-2. Activate the returned sandbox extension when available.
-3. Fall back to the bundled directory-access primitive when required.
-4. Verify the actual MobileGestalt plist is readable before exposing it.
-5. Detect whether the file is read-only or read/write.
+1. Run the access method selected in Settings (`bad_query` by default or `cmg`).
+2. Activate the returned sandbox extension when the selected method provides one.
+3. Verify the actual MobileGestalt plist is readable before exposing it.
+4. Detect whether the file is read-only or read/write.
 
 Write handling includes:
 
@@ -114,9 +115,11 @@ Write handling includes:
 The editor follows `rooootdev/mond` GestaltView at upstream commit
 `50b76a500b34d70119e30e04921dcb138c284855`: complete device-artwork, software,
 hardware, eligibility, iPadOS, internal-feature, spoofing, Apply, and Revert controls;
-the same device/version gating; and the same warning and information dialogs. Filza's
-verified write bridge replaces Mond's standalone exploit lifecycle while preserving
-property-list read-back validation and automatic backup restoration.
+the same device/version gating; and the same warning and information dialogs. Its
+navigation-bar gear opens Mond's functional Settings surface: selectable `bad_query`
+or `cmg` access, Run Exploit, sandbox-token generation and validation, Keep Alive,
+and confirmed Respring. Filza's bridge runs the selected access method in-process and
+preserves property-list read-back validation and automatic backup restoration.
 
 ### WebDAV server
 
@@ -271,7 +274,7 @@ now performs the complete installable build:
 4. stages ByeTunes runtime resources;
 5. downloads and hash-verifies the pinned unsigned Filza base IPA;
 6. injects the current runtime dylib and resources;
-7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.4`;
+7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.5`;
 8. verifies the base executable actually loads `FilzaApplySandboxExt.dylib`;
 9. repacks a real unsigned IPA;
 10. uploads the IPA as a GitHub Actions artifact.

--- a/scripts/patch-byetunes-embedded.sh
+++ b/scripts/patch-byetunes-embedded.sh
@@ -3,16 +3,19 @@ set -euo pipefail
 
 DEVICE="ByeTunes/MusicManager/iDeviceManager.swift"
 CONTENT="ByeTunes/MusicManager/ContentView.swift"
+SONG_METADATA="ByeTunes/MusicManager/SongMetadata.swift"
 test -f "$DEVICE"
 test -f "$CONTENT"
+test -f "$SONG_METADATA"
 
-python3 - "$DEVICE" "$CONTENT" <<'PY'
+python3 - "$DEVICE" "$CONTENT" "$SONG_METADATA" <<'PY'
 from pathlib import Path
 import re
 import sys
 
 device = Path(sys.argv[1])
 content = Path(sys.argv[2])
+song_metadata = Path(sys.argv[3])
 
 ds = device.read_text()
 
@@ -82,9 +85,10 @@ new_import_write = '''        let importedPairingData = try Data(contentsOf: url
 
         refreshExpectedPairingFileState()
 '''
-if old_import_write not in ds:
+if old_import_write in ds:
+    ds = ds.replace(old_import_write, new_import_write, 1)
+elif 'Filza embed: imported pairing file persisted at' not in ds:
     raise SystemExit('DeviceManager pairing import write anchor not found')
-ds = ds.replace(old_import_write, new_import_write, 1)
 device.write_text(ds)
 
 cs = content.read_text()
@@ -138,6 +142,68 @@ if 'showSplash' in cs or 'SplashView()' in cs:
     raise SystemExit('embedded splash route was not fully removed')
 content.write_text(cs)
 
+# Apple changed the ordering of fields in the web-player JWT header. The
+# standalone ByeTunes matcher required the token to begin with {"alg":...},
+# which now rejects the valid current {"typ":...,"alg":...} token and leaves
+# the Download tab with no search results. Match complete JWTs, decode their
+# payloads, reject expired candidates and prefer Apple's AMPWebPlay token.
+sms = song_metadata.read_text()
+new_token_block = '''            let tokenPattern = #"eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{20,}"#
+            guard let tokenRegex = try? NSRegularExpression(pattern: tokenPattern) else {
+                await Logger.shared.log("[AppleMusicAPI] ⚠️ Failed to construct JWT matcher")
+                return nil
+            }
+
+            let tokenMatches = tokenRegex.matches(
+                in: jsContent,
+                range: NSRange(jsContent.startIndex..<jsContent.endIndex, in: jsContent)
+            )
+
+            func payload(for token: String) -> [String: Any]? {
+                let pieces = token.split(separator: ".", omittingEmptySubsequences: false)
+                guard pieces.count == 3 else { return nil }
+                var encoded = String(pieces[1])
+                    .replacingOccurrences(of: "-", with: "+")
+                    .replacingOccurrences(of: "_", with: "/")
+                let padding = (4 - encoded.count % 4) % 4
+                encoded += String(repeating: "=", count: padding)
+                guard let data = Data(base64Encoded: encoded),
+                      let object = try? JSONSerialization.jsonObject(with: data),
+                      let dictionary = object as? [String: Any] else { return nil }
+                return dictionary
+            }
+
+            let now = Date().timeIntervalSince1970
+            let candidates: [(token: String, payload: [String: Any])] = tokenMatches.compactMap { match in
+                guard let range = Range(match.range, in: jsContent) else { return nil }
+                let token = String(jsContent[range])
+                guard let decoded = payload(for: token) else { return nil }
+                if let expiry = (decoded["exp"] as? NSNumber)?.doubleValue, expiry <= now + 60 {
+                    return nil
+                }
+                return (token, decoded)
+            }
+
+            guard let selected = candidates.first(where: { $0.payload["iss"] as? String == "AMPWebPlay" })
+                    ?? candidates.first else {
+                await Logger.shared.log("[AppleMusicAPI] ⚠️ No current unexpired JWT found in JS bundle")
+                return nil
+            }
+
+            self.cachedToken = selected.token
+            let issuer = selected.payload["iss"] as? String ?? "unknown"
+            await Logger.shared.log("[AppleMusicAPI] ✅ Current Apple Music JWT token selected issuer=\\(issuer) candidates=\\(candidates.count)")
+            return selected.token
+'''
+if 'Current Apple Music JWT token selected' not in sms:
+    token_start = sms.find('            let tokenPattern = #"eyJhbGciOi')
+    token_return = sms.find('            return token\n', token_start)
+    if token_start < 0 or token_return < 0:
+        raise SystemExit('Apple Music token matcher anchor not found')
+    token_end = token_return + len('            return token\n')
+    sms = sms[:token_start] + new_token_block + sms[token_end:]
+song_metadata.write_text(sms)
+
 visible_replacements = {
     Path("ByeTunes/MusicManager/OnboardingView.swift"): [
         ('Text("ByeTunes")', 'Text("Music Library")'),
@@ -167,6 +233,9 @@ grep -Fq 'persistent pairing state restored=' "$DEVICE"
 grep -Fq 'imported pairing file persisted at' "$DEVICE"
 grep -Fq 'Filza embed: immediate safe onAppear entered' "$CONTENT"
 grep -Fq 'restored persisted pairing file; reconnecting automatically' "$CONTENT"
+grep -Fq 'Current Apple Music JWT token selected' "$SONG_METADATA"
+grep -Fq 'AMPWebPlay' "$SONG_METADATA"
+! grep -Fq 'eyJhbGciOi[A-Za-z0-9_-]' "$SONG_METADATA"
 ! grep -Fq 'SplashView()' "$CONTENT"
 ! grep -Fq 'showSplash' "$CONTENT"
 grep -Fq 'Text("Music Library")' ByeTunes/MusicManager/OnboardingView.swift


### PR DESCRIPTION
## What changed
- update the embedded ByeTunes Apple Music JWT discovery for Apple's current `{typ, alg}` token header ordering
- decode candidate payloads, reject expired JWTs, and prefer the confirmed `AMPWebPlay` token
- add Mond's navigation-bar Settings gear and integrate Method (`bad_query` / `cmg`), Run Exploit, Token generation/validation, Keep Alive, Respring, and credits
- make the selected Mond access method drive the actual in-process access bridge
- bump the installable IPA version to 4.5 and add linked-binary proof gates

## Verification
- embedded ByeTunes patch applied successfully twice on a clean pinned submodule checkout
- shell syntax, YAML parse, and diff checks pass locally
- full arm64/Xcode 26.2 IPA workflow must pass before merge

## Summary by Sourcery

Update ByeTunes JWT handling and Mond Gestalt access to restore Apple Music downloads and expose Mond settings in-app, while bumping the IPA version and tightening verification gates.

New Features:
- Embed Mond Settings UI within the Gestalt editor, including method selection, exploit triggering, sandbox token tooling, keep-alive control, and respring capability.

Bug Fixes:
- Adjust embedded ByeTunes Apple Music JWT discovery to accept current header field ordering, decode and validate candidate tokens, and prefer the AMPWebPlay issuer so Download tab search results work again.

Enhancements:
- Make the selected Mond access method drive the in-process Gestalt access bridge and diagnostics.
- Add Mond keep-alive audio behavior and WebKit-based respring surface to the Gestalt editor.
- Document the updated access flow and Mond Settings behavior in the README.

Build:
- Extend FilzaApplySandboxExt framework coverage to include WebKit.
- Bump the installable IPA bundle version from 4.4 to 4.5.

CI:
- Strengthen safe-fix verification by asserting presence of Mond Settings and updated ByeTunes JWT messages in the built dylib and enforcing the new bundle version.