### PR TITLE
Add iOS 27 Gestalt key editor

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -57,6 +57,33 @@ jobs:
           test -f ThirdParty/GCDWebServer/GCDWebDAVServer/GCDWebDAVServer.m
           test -f ThirdParty/GCDWebServer/GCDWebServer/Core/GCDWebServer.m
           test -f ThirdParty/GCDWebServer/LICENSE
+          python3 - <<'PY'
+          from pathlib import Path
+          source = Path("MondGestaltView.swift").read_text()
+          mappings = {
+              "7brdL5xrEUWnlF9C0kdg5A": "DeviceSupportsHighLuminanceAlwaysOnDisplay",
+              "A/74xUbqJwBsaWTjSDd0fQ": "ChassisSlotFunctionNumber",
+              "a3n5T9sFtlyQ74NEp9ESxg": "SiriMode",
+              "HBG+hj/Oz89PjVgn93Jd8A": "Image4SecureBootKeyScheme",
+              "ikn/KMyeztXJhAj/dqBjBg": "LowPowerRendererCapability",
+              "J2+oJRiGdbAzTi6U5nhqdQ": "PostQuantumCryptographyEnforced",
+              "Kpfa0nb8nn8EVzI/UgcMfQ": "CoalescedSubTargetID",
+              "lyJZrSDc8J8eQ5b7A1Rvw": "DeviceSupportsTouchSensitiveCameraControl",
+              "m4xs4mhvxnAopYrApoLDMw": "DeviceSupportsInstructionFollowingPruningModels",
+              "mnPU37/y4i0TJFnJc+r4lA": "DeviceSupportsLowPowerWake",
+              "odI0U9Etrx7hObzvJ9xJ8Q": "DeviceSupportsSandcat",
+              "P4ZJVy/zYuLy4ejRKP+0DA": "DeviceSupportsRegionalCameraShutterRelaxation",
+              "qqrspu7CpuPdZwSDxNY+Fg": "MaximumFlipbookCount",
+              "s1ZXqZtUSpr+BjUgZXZ/2g": "ChassisSlotInstanceNumber",
+              "TusANsf9Lfe3P/9fIXXSrQ": "DeviceSupportsAlwaysListeningHeySiri",
+              "VXc3L66nqQ6bn4z60ChX+A": "ResponsiveAirPlayAudioCapability",
+              "ym8C/Ut5YcBnqAdm4NEDLQ": "Image4SecureBootCertificateFormat",
+          }
+          assert len(mappings) == 17
+          for key, name in mappings.items():
+              assert f'key: "{key}", name: "{name}"' in source, (key, name)
+          print("Verified all 17 exact iOS 27 Gestalt key mappings")
+          PY
 
       - name: Syntax-check runtime integrations
         run: |
@@ -159,6 +186,10 @@ jobs:
           grep -aFq 'Device Spoofing Info' "$DYLIB"
           grep -aFq 'iPadOS UI Warning' "$DYLIB"
           grep -aFq 'Disable Dynamic Island' "$DYLIB"
+          grep -aFq 'iOS 27 Gestalt Keys' "$DYLIB"
+          grep -aFq 'DeviceSupportsHighLuminanceAlwaysOnDisplay' "$DYLIB"
+          grep -aFq 'DeviceSupportsSandcat' "$DYLIB"
+          grep -aFq 'Image4SecureBootCertificateFormat' "$DYLIB"
           grep -aFq 'presenting complete Mond Settings' "$DYLIB"
           grep -aFq 'Run Exploit' "$DYLIB"
           grep -aFq 'Generate Token' "$DYLIB"
@@ -248,7 +279,7 @@ jobs:
           fi
 
           plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemSubtitle":"Browse installed apps","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemSubtitle":"Open Music Library","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemSubtitle":"Edit MobileGestalt","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"}]' "$APP/Info.plist"
-          plutil -replace CFBundleShortVersionString -string "4.5" "$APP/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "4.6" "$APP/Info.plist"
           plutil -replace CFBundleVersion -string "${GITHUB_RUN_NUMBER}" "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
@@ -271,7 +302,7 @@ jobs:
           assert info.get('LSSupportsOpeningDocumentsInPlace') is True
           assert info.get('NSLocalNetworkUsageDescription')
           assert info.get('NSBonjourServices') == ['_http._tcp']
-          assert info.get('CFBundleShortVersionString') == '4.5'
+          assert info.get('CFBundleShortVersionString') == '4.6'
           assert str(info.get('CFBundleVersion', '')).isdigit()
           print('Verified exactly three quick actions and Files/Documents exposure flags')
           PY

--- a/MondGestaltView.swift
+++ b/MondGestaltView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 import AVFoundation
 import WebKit
+import CoreFoundation
 import Darwin
 import MachO
 
@@ -422,6 +423,238 @@ private struct MondSettingsView: View {
     }
 }
 
+private enum MondGestaltScalarKind: String, CaseIterable, Identifiable {
+    case boolean = "Boolean"
+    case integer = "Integer"
+    case decimal = "Decimal"
+    case string = "String"
+
+    var id: String { rawValue }
+}
+
+private struct MondGestaltKeyDefinition: Identifiable {
+    let key: String
+    let name: String
+    let preferredKind: MondGestaltScalarKind
+
+    var id: String { key }
+}
+
+private let mondIOS27GestaltKeys: [MondGestaltKeyDefinition] = [
+    .init(key: "7brdL5xrEUWnlF9C0kdg5A", name: "DeviceSupportsHighLuminanceAlwaysOnDisplay", preferredKind: .boolean),
+    .init(key: "A/74xUbqJwBsaWTjSDd0fQ", name: "ChassisSlotFunctionNumber", preferredKind: .integer),
+    .init(key: "a3n5T9sFtlyQ74NEp9ESxg", name: "SiriMode", preferredKind: .integer),
+    .init(key: "HBG+hj/Oz89PjVgn93Jd8A", name: "Image4SecureBootKeyScheme", preferredKind: .string),
+    .init(key: "ikn/KMyeztXJhAj/dqBjBg", name: "LowPowerRendererCapability", preferredKind: .integer),
+    .init(key: "J2+oJRiGdbAzTi6U5nhqdQ", name: "PostQuantumCryptographyEnforced", preferredKind: .boolean),
+    .init(key: "Kpfa0nb8nn8EVzI/UgcMfQ", name: "CoalescedSubTargetID", preferredKind: .integer),
+    .init(key: "lyJZrSDc8J8eQ5b7A1Rvw", name: "DeviceSupportsTouchSensitiveCameraControl", preferredKind: .boolean),
+    .init(key: "m4xs4mhvxnAopYrApoLDMw", name: "DeviceSupportsInstructionFollowingPruningModels", preferredKind: .boolean),
+    .init(key: "mnPU37/y4i0TJFnJc+r4lA", name: "DeviceSupportsLowPowerWake", preferredKind: .boolean),
+    .init(key: "odI0U9Etrx7hObzvJ9xJ8Q", name: "DeviceSupportsSandcat", preferredKind: .boolean),
+    .init(key: "P4ZJVy/zYuLy4ejRKP+0DA", name: "DeviceSupportsRegionalCameraShutterRelaxation", preferredKind: .boolean),
+    .init(key: "qqrspu7CpuPdZwSDxNY+Fg", name: "MaximumFlipbookCount", preferredKind: .integer),
+    .init(key: "s1ZXqZtUSpr+BjUgZXZ/2g", name: "ChassisSlotInstanceNumber", preferredKind: .integer),
+    .init(key: "TusANsf9Lfe3P/9fIXXSrQ", name: "DeviceSupportsAlwaysListeningHeySiri", preferredKind: .boolean),
+    .init(key: "VXc3L66nqQ6bn4z60ChX+A", name: "ResponsiveAirPlayAudioCapability", preferredKind: .integer),
+    .init(key: "ym8C/Ut5YcBnqAdm4NEDLQ", name: "Image4SecureBootCertificateFormat", preferredKind: .string),
+]
+
+private func mondGestaltScalarKind(
+    for value: Any?,
+    fallback: MondGestaltScalarKind
+) -> MondGestaltScalarKind {
+    guard let value else { return fallback }
+    if let number = value as? NSNumber {
+        if CFGetTypeID(number) == CFBooleanGetTypeID() { return .boolean }
+        let type = String(cString: number.objCType)
+        return ["f", "d"].contains(type) ? .decimal : .integer
+    }
+    if value is NSString || value is String { return .string }
+    return fallback
+}
+
+private func mondGestaltScalarText(_ value: Any?) -> String {
+    guard let value else { return "" }
+    if let number = value as? NSNumber {
+        if CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return number.boolValue ? "true" : "false"
+        }
+        return number.stringValue
+    }
+    if let string = value as? String { return string }
+    if let string = value as? NSString { return String(string) }
+    return String(describing: value)
+}
+
+private struct MondGestaltKeyToggle: View {
+    let definition: MondGestaltKeyDefinition
+    @Binding var isOn: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Toggle(definition.name, isOn: $isOn)
+            Text(definition.key)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+private struct MondRawGestaltKeyEditor: View {
+    let definition: MondGestaltKeyDefinition
+    let onSave: (Any?) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var kind: MondGestaltScalarKind
+    @State private var text: String
+    @State private var booleanValue: Bool
+    @State private var errorMessage: String?
+
+    init(
+        definition: MondGestaltKeyDefinition,
+        value: Any?,
+        onSave: @escaping (Any?) -> Void
+    ) {
+        self.definition = definition
+        self.onSave = onSave
+        let detectedKind = mondGestaltScalarKind(for: value, fallback: definition.preferredKind)
+        _kind = State(initialValue: detectedKind)
+        _text = State(initialValue: mondGestaltScalarText(value))
+        _booleanValue = State(initialValue: (value as? NSNumber)?.boolValue ?? false)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text(definition.name)
+                    Text(definition.key)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                } header: {
+                    Label("Gestalt Key", systemImage: "key")
+                }
+
+                Section {
+                    Picker("Value Type", selection: $kind) {
+                        ForEach(MondGestaltScalarKind.allCases) { kind in
+                            Text(kind.rawValue).tag(kind)
+                        }
+                    }
+
+                    if kind == .boolean {
+                        Toggle("Value", isOn: $booleanValue)
+                    } else {
+                        TextField("Value", text: $text)
+                            .keyboardType(kind == .string ? .default : .numbersAndPunctuation)
+                    }
+                } header: {
+                    Label("Value", systemImage: "slider.horizontal.3")
+                } footer: {
+                    Text("The existing MobileGestalt scalar type is detected automatically. A missing key starts with its suggested type.")
+                }
+
+                Section {
+                    Button("Remove Key", role: .destructive) {
+                        onSave(nil)
+                        dismiss()
+                    }
+                }
+            }
+            .navigationTitle("Edit iOS 27 Key")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save", action: save)
+                }
+            }
+            .alert("Invalid Value", isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK", role: .cancel) { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+    }
+
+    private func save() {
+        switch kind {
+        case .boolean:
+            onSave(NSNumber(value: booleanValue))
+        case .integer:
+            guard let value = Int64(text.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+                errorMessage = "Enter a valid signed integer."
+                return
+            }
+            onSave(NSNumber(value: value))
+        case .decimal:
+            guard let value = Double(text.trimmingCharacters(in: .whitespacesAndNewlines)),
+                  value.isFinite else {
+                errorMessage = "Enter a valid finite decimal value."
+                return
+            }
+            onSave(NSNumber(value: value))
+        case .string:
+            onSave(text)
+        }
+        dismiss()
+    }
+}
+
+private struct MondRawGestaltKeyRow: View {
+    let definition: MondGestaltKeyDefinition
+    let onSave: (Any?) -> Void
+
+    @State private var currentValue: Any?
+    @State private var showingEditor = false
+
+    init(
+        definition: MondGestaltKeyDefinition,
+        value: Any?,
+        onSave: @escaping (Any?) -> Void
+    ) {
+        self.definition = definition
+        self.onSave = onSave
+        _currentValue = State(initialValue: value)
+    }
+
+    var body: some View {
+        Button {
+            showingEditor = true
+        } label: {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(definition.name)
+                    Text(definition.key)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Text(currentValue == nil ? "Not set" : mondGestaltScalarText(currentValue))
+                    .font(.subheadline.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showingEditor) {
+            MondRawGestaltKeyEditor(definition: definition, value: currentValue) { value in
+                currentValue = value
+                onSave(value)
+            }
+        }
+    }
+}
+
 struct MondGestaltView: View {
     let gestaltPath: String
 
@@ -524,6 +757,36 @@ struct MondGestaltView: View {
                 MondToggle("Liquid Glass LPM", minimum: 19.0, isOn: keyBinding(["SAGvsp6O6kAQ4fEfDJpC4Q"]))
             } header: {
                 Label("Software-Oriented Features", systemImage: "gearshape")
+            }
+
+            if mondSystemVersion() >= 27.0 {
+                Section {
+                    ForEach(mondIOS27GestaltKeys) { definition in
+                        if definition.preferredKind == .boolean {
+                            MondGestaltKeyToggle(
+                                definition: definition,
+                                isOn: keyBinding([definition.key])
+                            )
+                        } else {
+                            MondRawGestaltKeyRow(
+                                definition: definition,
+                                value: cacheExtra?[definition.key]
+                            ) { value in
+                                guard let extra = cacheExtra else { return }
+                                if let value {
+                                    extra[definition.key] = value
+                                } else {
+                                    extra.removeObject(forKey: definition.key)
+                                }
+                            }
+                            .id("\(definition.key):\(mondGestaltScalarText(cacheExtra?[definition.key]))")
+                        }
+                    }
+                } header: {
+                    Label("iOS 27 Gestalt Keys", systemImage: "cpu")
+                } footer: {
+                    Text("Exact iOS 27 beta 1–5 key mappings. Apply Tweaks writes the changes; Revert Tweaks restores the saved original plist.")
+                }
             }
 
             Section {

--- a/README.md
+++ b/README.md
@@ -121,6 +121,30 @@ or `cmg` access, Run Exploit, sandbox-token generation and validation, Keep Aliv
 and confirmed Respring. Filza's bridge runs the selected access method in-process and
 preserves property-list read-back validation and automatic backup restoration.
 
+On iOS 27, the editor also exposes these beta key mappings. Boolean capabilities use
+toggles; the remaining scalar values open a type-aware editor that detects the current
+plist type and supports Boolean, integer, decimal, and string values.
+
+| MobileGestalt key | Name |
+|---|---|
+| `7brdL5xrEUWnlF9C0kdg5A` | `DeviceSupportsHighLuminanceAlwaysOnDisplay` |
+| `A/74xUbqJwBsaWTjSDd0fQ` | `ChassisSlotFunctionNumber` |
+| `a3n5T9sFtlyQ74NEp9ESxg` | `SiriMode` |
+| `HBG+hj/Oz89PjVgn93Jd8A` | `Image4SecureBootKeyScheme` |
+| `ikn/KMyeztXJhAj/dqBjBg` | `LowPowerRendererCapability` |
+| `J2+oJRiGdbAzTi6U5nhqdQ` | `PostQuantumCryptographyEnforced` |
+| `Kpfa0nb8nn8EVzI/UgcMfQ` | `CoalescedSubTargetID` |
+| `lyJZrSDc8J8eQ5b7A1Rvw` | `DeviceSupportsTouchSensitiveCameraControl` |
+| `m4xs4mhvxnAopYrApoLDMw` | `DeviceSupportsInstructionFollowingPruningModels` |
+| `mnPU37/y4i0TJFnJc+r4lA` | `DeviceSupportsLowPowerWake` |
+| `odI0U9Etrx7hObzvJ9xJ8Q` | `DeviceSupportsSandcat` |
+| `P4ZJVy/zYuLy4ejRKP+0DA` | `DeviceSupportsRegionalCameraShutterRelaxation` |
+| `qqrspu7CpuPdZwSDxNY+Fg` | `MaximumFlipbookCount` |
+| `s1ZXqZtUSpr+BjUgZXZ/2g` | `ChassisSlotInstanceNumber` |
+| `TusANsf9Lfe3P/9fIXXSrQ` | `DeviceSupportsAlwaysListeningHeySiri` |
+| `VXc3L66nqQ6bn4z60ChX+A` | `ResponsiveAirPlayAudioCapability` |
+| `ym8C/Ut5YcBnqAdm4NEDLQ` | `Image4SecureBootCertificateFormat` |
+
 ### WebDAV server
 
 Filza's original **Run as system service** option targets jailbreak-only `launchctl`
@@ -274,7 +298,7 @@ now performs the complete installable build:
 4. stages ByeTunes runtime resources;
 5. downloads and hash-verifies the pinned unsigned Filza base IPA;
 6. injects the current runtime dylib and resources;
-7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.5`;
+7. writes exactly three Home Screen shortcuts plus Local Network/Bonjour declarations into `Info.plist` and assigns build version `4.6`;
 8. verifies the base executable actually loads `FilzaApplySandboxExt.dylib`;
 9. repacks a real unsigned IPA;
 10. uploads the IPA as a GitHub Actions artifact.


### PR DESCRIPTION
## What changed
- add all 17 supplied iOS 27 beta 1–5 MobileGestalt key/name mappings to the embedded Mond editor
- expose Boolean capability keys as toggles with the exact opaque key visible
- expose non-Boolean keys through a scalar editor that detects the existing plist type and supports Boolean, integer, decimal, and string values
- gate the section to iOS 27 and keep Apply/Revert on Mond’s validated backup/write path
- document all mappings and bump the installable IPA to version 4.6
- add CI source assertions for every exact pair plus linked-binary UI markers

## Validation
- mapping uniqueness/count check: 17/17
- workflow YAML parse passed
- diff and shell checks passed
- full Xcode 26.2 arm64 IPA workflow must pass before merge

## Summary by Sourcery

Add an iOS 27–specific MobileGestalt key editor to Mond and update the IPA versioning and CI checks to cover the new mappings.

New Features:
- Expose 17 iOS 27 beta MobileGestalt key/name mappings in the Mond Gestalt editor with Boolean toggles and a scalar value editor for non-Boolean keys.

Enhancements:
- Restrict the new Gestalt key section to iOS 27 while keeping it on the existing validated Apply/Revert path.
- Improve scalar value handling by detecting the underlying plist type and supporting Boolean, integer, decimal, and string values in the editor.

Build:
- Bump the installable IPA bundle short version from 4.5 to 4.6 and update build-time verification accordingly.

CI:
- Add CI assertions to verify all 17 exact iOS 27 MobileGestalt key/name mappings are present in source and surfaced in the linked binary UI.

Documentation:
- Document the new iOS 27 MobileGestalt key mappings and editor behavior in the README.