### PR TITLE
Package embedded ByeTunes 2.4 AppIntents metadata

### DIFF
--- a/.github/workflows/probe-appintents-tool.yml
+++ b/.github/workflows/probe-appintents-tool.yml
@@ -34,7 +34,7 @@ jobs:
           test "$(git -C ByeTunes rev-parse HEAD)" = "$BYETUNES_COMMIT"
           test "$(xcrun --sdk iphoneos --show-sdk-version)" = "26.2"
           xcrun --find appintentsmetadataprocessor
-          grep -q 'emit-const-values-path' Makefile
+          grep -q -- '-emit-const-values -emit-const-values-path' Makefile
           test -f scripts/generate-appintents-metadata.sh
 
       - name: Install Procursus build tools

--- a/.github/workflows/probe-appintents-tool.yml
+++ b/.github/workflows/probe-appintents-tool.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - '.github/workflows/probe-appintents-tool.yml'
+      - 'scripts/emit-byetunes-appintents-const-values.sh'
+      - 'scripts/generate-appintents-metadata.sh'
   workflow_dispatch:
 
 concurrency:
@@ -74,6 +76,9 @@ jobs:
           META=.theos/byetunes-appintents/Metadata.appintents
           test -d "$META"
           test -s .theos/byetunes-appintents/FilzaApplySandboxExt.swiftconstvalues
+          test -s .theos/byetunes-appintents/FilzaApplySandboxExt_const_extract_protocols.json
+          grep -Fq 'AppIntents.AppIntent' .theos/byetunes-appintents/FilzaApplySandboxExt_const_extract_protocols.json
+          grep -Fq 'AppIntents.AppShortcutsProvider' .theos/byetunes-appintents/FilzaApplySandboxExt_const_extract_protocols.json
           find "$META" -type f -print
           test "$(find "$META" -type f | wc -l | tr -d ' ')" -gt 0
           grep -aR -q 'InjectMusicIntent' "$META"

--- a/.github/workflows/probe-appintents-tool.yml
+++ b/.github/workflows/probe-appintents-tool.yml
@@ -34,7 +34,7 @@ jobs:
           test "$(git -C ByeTunes rev-parse HEAD)" = "$BYETUNES_COMMIT"
           test "$(xcrun --sdk iphoneos --show-sdk-version)" = "26.2"
           xcrun --find appintentsmetadataprocessor
-          grep -q -- '-emit-const-values -emit-const-values-path' Makefile
+          test -f scripts/emit-byetunes-appintents-const-values.sh
           test -f scripts/generate-appintents-metadata.sh
 
       - name: Install Procursus build tools
@@ -66,8 +66,6 @@ jobs:
           test -f "$DYLIB"
           test "$(lipo -archs "$DYLIB")" = "arm64"
           grep -aFq 'MusicManagerShortcuts' "$DYLIB"
-          find .theos -type f -name '*.swiftconstvalues' -print -exec test -s {} \;
-          test -n "$(find .theos -type f -name '*.swiftconstvalues' -print -quit)"
 
       - name: Extract AppIntents metadata from actual module
         run: |
@@ -75,6 +73,7 @@ jobs:
           bash scripts/generate-appintents-metadata.sh .theos/byetunes-appintents
           META=.theos/byetunes-appintents/Metadata.appintents
           test -d "$META"
+          test -s .theos/byetunes-appintents/FilzaApplySandboxExt.swiftconstvalues
           find "$META" -type f -print
           test "$(find "$META" -type f | wc -l | tr -d ' ')" -gt 0
           grep -aR -q 'InjectMusicIntent' "$META"

--- a/.github/workflows/probe-appintents-tool.yml
+++ b/.github/workflows/probe-appintents-tool.yml
@@ -77,8 +77,8 @@ jobs:
           test -d "$META"
           test -s .theos/byetunes-appintents/FilzaApplySandboxExt.swiftconstvalues
           test -s .theos/byetunes-appintents/FilzaApplySandboxExt_const_extract_protocols.json
-          grep -Fq 'AppIntents.AppIntent' .theos/byetunes-appintents/FilzaApplySandboxExt_const_extract_protocols.json
-          grep -Fq 'AppIntents.AppShortcutsProvider' .theos/byetunes-appintents/FilzaApplySandboxExt_const_extract_protocols.json
+          grep -Fq '"AppIntent"' .theos/byetunes-appintents/FilzaApplySandboxExt_const_extract_protocols.json
+          grep -Fq '"AppShortcutsProvider"' .theos/byetunes-appintents/FilzaApplySandboxExt_const_extract_protocols.json
           find "$META" -type f -print
           test "$(find "$META" -type f | wc -l | tr -d ' ')" -gt 0
           grep -aR -q 'InjectMusicIntent' "$META"

--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -116,6 +116,7 @@ jobs:
 
           makefile = Path("Makefile").read_text()
           assert "Filza3105AppLauncher.m" not in makefile
+          assert "-emit-const-values -emit-const-values-path" in makefile
 
           browser = Path("ThirdParty/3105/Sources/FileBrowserView.swift").read_text()
           for required in (

--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -116,7 +116,8 @@ jobs:
 
           makefile = Path("Makefile").read_text()
           assert "Filza3105AppLauncher.m" not in makefile
-          assert "-emit-const-values -emit-const-values-path" in makefile
+          assert "-default-isolation MainActor" in makefile
+          assert Path("scripts/emit-byetunes-appintents-const-values.sh").is_file()
 
           browser = Path("ThirdParty/3105/Sources/FileBrowserView.swift").read_text()
           for required in (
@@ -343,7 +344,6 @@ jobs:
           shasum -a 256 "$DYLIB"
 
       - name: Generate ByeTunes AppIntents metadata
-        continue-on-error: true
         run: |
           set -euxo pipefail
           bash scripts/generate-appintents-metadata.sh .theos/byetunes-appintents

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ FilzaApplySandboxExt_OBJCCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
 # output. Xcode emits this automatically for app targets; Theos does not, so
 # preserve the equivalent module-level file for the post-link processor.
 FilzaApplySandboxExt_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xcc -I$(IDEVICE_VENDOR)/include
-FilzaApplySandboxExt_SWIFTFLAGS += -emit-const-values-path $(THEOS_OBJ_DIR)/FilzaApplySandboxExt.swiftconstvalues
+FilzaApplySandboxExt_SWIFTFLAGS += -emit-const-values -emit-const-values-path $(THEOS_OBJ_DIR)/FilzaApplySandboxExt.swiftconstvalues
 FilzaApplySandboxExt_LDFLAGS += $(IDEVICE_STATIC)
 
 # Framework coverage matches the complete ByeTunes source tree rather than the

--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,7 @@ FilzaApplySandboxExt_CFLAGS += -Wno-arc-performSelector-leaks
 FilzaApplySandboxExt_CCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
 FilzaApplySandboxExt_OBJCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
 FilzaApplySandboxExt_OBJCCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
-# AppIntents metadata extraction consumes Swift's supplementary constant-value
-# output. Xcode emits this automatically for app targets; Theos does not, so
-# preserve the equivalent module-level file for the post-link processor.
 FilzaApplySandboxExt_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xcc -I$(IDEVICE_VENDOR)/include
-FilzaApplySandboxExt_SWIFTFLAGS += -emit-const-values -emit-const-values-path $(THEOS_OBJ_DIR)/FilzaApplySandboxExt.swiftconstvalues
 FilzaApplySandboxExt_LDFLAGS += $(IDEVICE_STATIC)
 
 # Framework coverage matches the complete ByeTunes source tree rather than the

--- a/scripts/emit-byetunes-appintents-const-values.sh
+++ b/scripts/emit-byetunes-appintents-const-values.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euxo pipefail
+
+OUTPUT_ROOT="${1:-.theos/byetunes-appintents}"
+SOURCE_LIST="$OUTPUT_ROOT/source-files.txt"
+CONST_VALUES="$OUTPUT_ROOT/FilzaApplySandboxExt.swiftconstvalues"
+MODULE_OUT="$OUTPUT_ROOT/FilzaApplySandboxExt.swiftmodule"
+MODULE_CACHE="$OUTPUT_ROOT/module-cache"
+ROOT="$(pwd)"
+
+mkdir -p "$OUTPUT_ROOT" "$MODULE_CACHE"
+
+# Match the Swift source graph in Makefile exactly. The standalone @main and
+# splash owners are intentionally excluded because Filza owns the lifecycle.
+{
+  for file in ByeTunesEmbeddedHost.swift MondGestaltView.swift Filza3105Host.swift; do
+    python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$file"
+  done
+  find ThirdParty/3105/Sources -type f -name '*.swift' -print | sort | while IFS= read -r file; do
+    python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$file"
+  done
+  find ByeTunes/MusicManager -type f -name '*.swift' \
+    ! -name 'MusicManagerApp.swift' ! -name 'SplashView.swift' -print | sort | while IFS= read -r file; do
+    python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$file"
+  done
+  python3 -c 'import os; print(os.path.realpath("ByeTunes/MusicManagerActivityShared/DownloadLiveActivityAttributes.swift"))'
+} > "$SOURCE_LIST"
+
+test -s "$SOURCE_LIST"
+grep -Fq '/MusicManagerIntents.swift' "$SOURCE_LIST"
+grep -Fq '/DownloadLiveActivityAttributes.swift' "$SOURCE_LIST"
+! grep -Fq '/MusicManagerApp.swift' "$SOURCE_LIST"
+! grep -Fq '/SplashView.swift' "$SOURCE_LIST"
+
+SOURCES=()
+while IFS= read -r file; do
+  test -s "$file"
+  SOURCES+=("$file")
+done < "$SOURCE_LIST"
+
+DEVELOPER_DIR="${DEVELOPER_DIR:-$(xcode-select -p)}"
+SDK_ROOT="$(xcrun --sdk iphoneos --show-sdk-path)"
+
+# Theos compiles the real module successfully but does not retain Xcode's
+# supplementary constant-value output. Re-run the same source graph as a
+# module-only compile so appintentsmetadataprocessor receives a real sidecar.
+xcrun --sdk iphoneos swiftc \
+  -emit-module \
+  -emit-module-path "$MODULE_OUT" \
+  -emit-const-values \
+  -emit-const-values-path "$CONST_VALUES" \
+  -module-name FilzaApplySandboxExt \
+  -parse-as-library \
+  -swift-version 5 \
+  -default-isolation MainActor \
+  -target arm64-apple-ios16.0 \
+  -sdk "$SDK_ROOT" \
+  -module-cache-path "$MODULE_CACHE" \
+  -import-objc-header "$ROOT/FilzaApplySandboxExt-Bridging-Header.h" \
+  -Xcc -fmodules \
+  -Xcc -fblocks \
+  -Xcc -fobjc-arc \
+  -Xcc -I"$ROOT/compat" \
+  -Xcc -I"$ROOT" \
+  -Xcc -I"$ROOT/XPF/src" \
+  -Xcc -I"$ROOT/XPF/external/ChOma/include" \
+  -Xcc -I"$ROOT/Vendor/idevice/include" \
+  -Xcc -I"$ROOT/ThirdParty/bad_query/bad_query" \
+  -Xcc -I"$ROOT/ThirdParty/3105/Sources" \
+  -Xcc -I"$SDK_ROOT/usr/include/libxml2" \
+  "${SOURCES[@]}"
+
+test -s "$MODULE_OUT"
+test -s "$CONST_VALUES"
+echo "Emitted $CONST_VALUES from ${#SOURCES[@]} embedded Swift sources"

--- a/scripts/emit-byetunes-appintents-const-values.sh
+++ b/scripts/emit-byetunes-appintents-const-values.sh
@@ -6,6 +6,7 @@ SOURCE_LIST="$OUTPUT_ROOT/source-files.txt"
 CONST_VALUES="$OUTPUT_ROOT/FilzaApplySandboxExt.swiftconstvalues"
 MODULE_OUT="$OUTPUT_ROOT/FilzaApplySandboxExt.swiftmodule"
 MODULE_CACHE="$OUTPUT_ROOT/module-cache"
+PROTOCOL_LIST="$OUTPUT_ROOT/FilzaApplySandboxExt_const_extract_protocols.json"
 ROOT="$(pwd)"
 
 mkdir -p "$OUTPUT_ROOT" "$MODULE_CACHE"
@@ -32,6 +33,14 @@ grep -Fq '/DownloadLiveActivityAttributes.swift' "$SOURCE_LIST"
 ! grep -Fq '/MusicManagerApp.swift' "$SOURCE_LIST"
 ! grep -Fq '/SplashView.swift' "$SOURCE_LIST"
 
+# Swift only emits the supplementary constant-value sidecar for conformances
+# named in this JSON array. These are the two AppIntents protocols implemented
+# by the complete ByeTunes 2.4 source graph in MusicManagerIntents.swift.
+printf '%s\n' '["AppIntents.AppIntent", "AppIntents.AppShortcutsProvider"]' > "$PROTOCOL_LIST"
+test -s "$PROTOCOL_LIST"
+grep -Fq 'AppIntents.AppIntent' "$PROTOCOL_LIST"
+grep -Fq 'AppIntents.AppShortcutsProvider' "$PROTOCOL_LIST"
+
 SOURCES=()
 while IFS= read -r file; do
   test -s "$file"
@@ -49,6 +58,8 @@ xcrun --sdk iphoneos swiftc \
   -emit-module-path "$MODULE_OUT" \
   -emit-const-values \
   -emit-const-values-path "$CONST_VALUES" \
+  -Xfrontend -const-gather-protocols-file \
+  -Xfrontend "$PROTOCOL_LIST" \
   -module-name FilzaApplySandboxExt \
   -parse-as-library \
   -swift-version 5 \
@@ -72,4 +83,4 @@ xcrun --sdk iphoneos swiftc \
 
 test -s "$MODULE_OUT"
 test -s "$CONST_VALUES"
-echo "Emitted $CONST_VALUES from ${#SOURCES[@]} embedded Swift sources"
+echo "Emitted $CONST_VALUES from ${#SOURCES[@]} embedded Swift sources using $PROTOCOL_LIST"

--- a/scripts/emit-byetunes-appintents-const-values.sh
+++ b/scripts/emit-byetunes-appintents-const-values.sh
@@ -34,12 +34,12 @@ grep -Fq '/DownloadLiveActivityAttributes.swift' "$SOURCE_LIST"
 ! grep -Fq '/SplashView.swift' "$SOURCE_LIST"
 
 # Swift only emits the supplementary constant-value sidecar for conformances
-# named in this JSON array. These are the two AppIntents protocols implemented
-# by the complete ByeTunes 2.4 source graph in MusicManagerIntents.swift.
-printf '%s\n' '["AppIntents.AppIntent", "AppIntents.AppShortcutsProvider"]' > "$PROTOCOL_LIST"
+# whose unqualified declaration names appear in this JSON array. These are the
+# two protocols implemented by the complete ByeTunes 2.4 intents source.
+printf '%s\n' '["AppIntent", "AppShortcutsProvider"]' > "$PROTOCOL_LIST"
 test -s "$PROTOCOL_LIST"
-grep -Fq 'AppIntents.AppIntent' "$PROTOCOL_LIST"
-grep -Fq 'AppIntents.AppShortcutsProvider' "$PROTOCOL_LIST"
+grep -Fq '"AppIntent"' "$PROTOCOL_LIST"
+grep -Fq '"AppShortcutsProvider"' "$PROTOCOL_LIST"
 
 SOURCES=()
 while IFS= read -r file; do

--- a/scripts/emit-byetunes-appintents-const-values.sh
+++ b/scripts/emit-byetunes-appintents-const-values.sh
@@ -4,10 +4,11 @@ set -euxo pipefail
 OUTPUT_ROOT="${1:-.theos/byetunes-appintents}"
 SOURCE_LIST="$OUTPUT_ROOT/source-files.txt"
 CONST_VALUES="$OUTPUT_ROOT/FilzaApplySandboxExt.swiftconstvalues"
-MODULE_OUT="$OUTPUT_ROOT/FilzaApplySandboxExt.swiftmodule"
+OBJECT_OUT="$OUTPUT_ROOT/MusicManagerIntents.o"
 MODULE_CACHE="$OUTPUT_ROOT/module-cache"
 PROTOCOL_LIST="$OUTPUT_ROOT/FilzaApplySandboxExt_const_extract_protocols.json"
 ROOT="$(pwd)"
+INTENTS_SOURCE="$(python3 -c 'import os; print(os.path.realpath("ByeTunes/MusicManager/MusicManagerIntents.swift"))')"
 
 mkdir -p "$OUTPUT_ROOT" "$MODULE_CACHE"
 
@@ -42,24 +43,31 @@ grep -Fq '"AppIntent"' "$PROTOCOL_LIST"
 grep -Fq '"AppShortcutsProvider"' "$PROTOCOL_LIST"
 
 SOURCES=()
+FRONTEND_SOURCES=()
 while IFS= read -r file; do
   test -s "$file"
   SOURCES+=("$file")
+  if test "$file" = "$INTENTS_SOURCE"; then
+    FRONTEND_SOURCES+=(-primary-file "$file")
+  else
+    FRONTEND_SOURCES+=("$file")
+  fi
 done < "$SOURCE_LIST"
+test "$(printf '%s\n' "${FRONTEND_SOURCES[@]}" | grep -Fc -- '-primary-file')" = 1
 
 DEVELOPER_DIR="${DEVELOPER_DIR:-$(xcode-select -p)}"
 SDK_ROOT="$(xcrun --sdk iphoneos --show-sdk-path)"
 
-# Theos compiles the real module successfully but does not retain Xcode's
-# supplementary constant-value output. Re-run the same source graph as a
-# module-only compile so appintentsmetadataprocessor receives a real sidecar.
-xcrun --sdk iphoneos swiftc \
-  -emit-module \
-  -emit-module-path "$MODULE_OUT" \
-  -emit-const-values \
+# Match Xcode's per-primary Swift frontend job: compile the intents source as
+# the primary file while making the complete embedded module graph visible.
+# Calling swift-frontend directly prevents swiftc's module-only driver action
+# from discarding the supplementary constant-values output.
+xcrun --sdk iphoneos swift-frontend \
+  -frontend \
+  -c \
+  "${FRONTEND_SOURCES[@]}" \
   -emit-const-values-path "$CONST_VALUES" \
-  -Xfrontend -const-gather-protocols-file \
-  -Xfrontend "$PROTOCOL_LIST" \
+  -const-gather-protocols-file "$PROTOCOL_LIST" \
   -module-name FilzaApplySandboxExt \
   -parse-as-library \
   -swift-version 5 \
@@ -79,8 +87,8 @@ xcrun --sdk iphoneos swiftc \
   -Xcc -I"$ROOT/ThirdParty/bad_query/bad_query" \
   -Xcc -I"$ROOT/ThirdParty/3105/Sources" \
   -Xcc -I"$SDK_ROOT/usr/include/libxml2" \
-  "${SOURCES[@]}"
+  -o "$OBJECT_OUT"
 
-test -s "$MODULE_OUT"
+test -s "$OBJECT_OUT"
 test -s "$CONST_VALUES"
 echo "Emitted $CONST_VALUES from ${#SOURCES[@]} embedded Swift sources using $PROTOCOL_LIST"

--- a/scripts/generate-appintents-metadata.sh
+++ b/scripts/generate-appintents-metadata.sh
@@ -4,8 +4,8 @@ set -euxo pipefail
 OUTPUT_ROOT="${1:-.theos/byetunes-appintents}"
 SOURCE_LIST="$OUTPUT_ROOT/source-files.txt"
 CONST_LIST="$OUTPUT_ROOT/swift-const-values.txt"
+CONST_VALUES="$OUTPUT_ROOT/FilzaApplySandboxExt.swiftconstvalues"
 METADATA_OUT="$OUTPUT_ROOT/Metadata.appintents"
-BYETUNES_ROOT="ByeTunes/MusicManager"
 MODULE_NAME="FilzaApplySandboxExt"
 DEPLOYMENT_TARGET="16.0"
 TARGET_TRIPLE="arm64-apple-ios16.0"
@@ -13,25 +13,13 @@ TARGET_TRIPLE="arm64-apple-ios16.0"
 rm -rf "$OUTPUT_ROOT"
 mkdir -p "$OUTPUT_ROOT"
 
-# The metadata must describe the embedded module, not the standalone
-# MusicManager @main target. Use the exact Swift source set compiled by Theos.
-{
-  python3 -c 'import os; print(os.path.realpath("ByeTunesEmbeddedHost.swift"))'
-  find "$BYETUNES_ROOT" -type f -name '*.swift' ! -name 'MusicManagerApp.swift' -print | sort | while IFS= read -r file; do
-    python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$file"
-  done
-} > "$SOURCE_LIST"
-
-test "$(wc -l < "$SOURCE_LIST" | tr -d ' ')" = "48"
-
-# Xcode's AppIntents metadata processor consumes supplementary constant-value
-# output emitted by swiftc. Find the module-level file produced by the Theos
-# build; fail rather than silently shipping undiscoverable shortcuts.
-find .theos -type f -name '*.swiftconstvalues' -print | sort > "$CONST_LIST"
+# Generate the supplementary constant-value sidecar from the exact Swift graph
+# compiled into FilzaApplySandboxExt. Do not substitute standalone ByeTunes.
+bash scripts/emit-byetunes-appintents-const-values.sh "$OUTPUT_ROOT"
+printf '%s\n' "$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$CONST_VALUES")" > "$CONST_LIST"
+test -s "$SOURCE_LIST"
 test -s "$CONST_LIST"
-while IFS= read -r file; do
-  test -s "$file"
-done < "$CONST_LIST"
+test -s "$CONST_VALUES"
 
 DEVELOPER_DIR="${DEVELOPER_DIR:-$(xcode-select -p)}"
 TOOLCHAIN_DIR="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain"


### PR DESCRIPTION
The embedded ByeTunes 2.4 module compiles and links, but Theos does not retain Xcode’s supplementary `.swiftconstvalues` sidecar. Generate that sidecar from the exact Swift source graph compiled into `FilzaApplySandboxExt`, feed Swift the exact ByeTunes protocol declaration names (`AppIntent` and `AppShortcutsProvider`), then run `appintentsmetadataprocessor` and package the resulting `Metadata.appintents` in the IPA.

CI is intentionally strict: both the dedicated metadata workflow and the full installable IPA workflow fail if constant extraction, intent discovery, or metadata packaging is missing. The metadata proof checks for `InjectMusicIntent`, `InjectRingtoneIntent`, and `MusicManagerShortcuts`.

## Summary by Sourcery

Generate and package AppIntents metadata for the embedded ByeTunes FilzaApplySandboxExt module using a dedicated Swift frontend helper script instead of relying on Theos-emitted sidecars, and tighten CI to require successful metadata extraction in installable builds.

New Features:
- Add a helper script to emit Swift constant-value sidecar data and protocol lists for the ByeTunes AppIntents source graph.
- Produce and bundle Metadata.appintents for the FilzaApplySandboxExt embedded module using the generated sidecar and protocol information.

Enhancements:
- Simplify Swift compiler flags in the Makefile by removing direct const-values emission from the main build and delegating it to the helper script.
- Strengthen CI workflows to verify presence and correctness of AppIntents-related artifacts, including constant values, protocol JSON, and specific intents in the generated metadata.

CI:
- Extend probe and safe-fixes workflows to depend on the new constant-emission script and to assert that AppIntents metadata generation cannot silently fail.