### PR TITLE
Report readable versus writable bad_query roots

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -131,7 +131,22 @@ jobs:
           patches = Path("ThirdParty/3105/Sources/PatchProjectsView.swift").read_text()
           assert ".sheet(item: $draftCoordinator.request)" in patches
           assert "initialDraft: request.draft" in patches
-          print("Verified the complete connected 3105 root instead of standalone partial hosts")
+
+          system_probe = Path("BadQuerySystemProbe.m").read_text()
+          for required in (
+              "WritePermissionCheck",
+              "FilesystemReadOnly",
+              "EffectiveWritable",
+              "readable-read-only-filesystem",
+              "Access Status.txt",
+              "MNT_RDONLY",
+          ):
+              assert required in system_probe, required
+
+          paste_fix = Path("Tweak.m").read_text()
+          assert "code == EROFS" in paste_fix
+          assert "cannot remount a filesystem read-write" in paste_fix
+          print("Verified connected 3105 root and system-root write-boundary diagnostics")
           PY
           test -f ByeTunesFilzaLibraryEmbed.m
           test -f ByeTunesFullAppLauncher.m
@@ -386,7 +401,7 @@ jobs:
           fi
 
           plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.patches","UIApplicationShortcutItemTitle":"Patches","UIApplicationShortcutItemIconSymbolName":"shippingbox"}]' "$APP/Info.plist"
-          plutil -replace CFBundleShortVersionString -string "4.10" "$APP/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "4.11" "$APP/Info.plist"
           plutil -replace CFBundleVersion -string "${GITHUB_RUN_NUMBER}" "$APP/Info.plist"
           plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
@@ -413,7 +428,7 @@ jobs:
           assert info.get('LSSupportsOpeningDocumentsInPlace') is True
           assert info.get('NSLocalNetworkUsageDescription')
           assert info.get('NSBonjourServices') == ['_http._tcp']
-          assert info.get('CFBundleShortVersionString') == '4.10'
+          assert info.get('CFBundleShortVersionString') == '4.11'
           assert info.get('NSSupportsLiveActivities') is True
           assert info.get('NSSupportsLiveActivitiesFrequentUpdates') is True
           assert str(info.get('CFBundleVersion', '')).isdigit()

--- a/BadQuerySystemProbe.m
+++ b/BadQuerySystemProbe.m
@@ -4,6 +4,7 @@
 #import <errno.h>
 #import <limits.h>
 #import <string.h>
+#import <sys/mount.h>
 #import <sys/stat.h>
 #import <unistd.h>
 
@@ -40,6 +41,60 @@ static NSString *BQErrorString(int error)
     if (error == 0) return @"none";
     const char *text = strerror(error);
     return text ? [NSString stringWithUTF8String:text] : @"unknown";
+}
+
+static NSDictionary *BQAccessDiagnostics(NSString *path)
+{
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+
+    errno = 0;
+    BOOL permissionWritable = access(path.fileSystemRepresentation, W_OK) == 0;
+    int permissionErrno = permissionWritable ? 0 : errno;
+    result[@"WritePermissionCheck"] = @(permissionWritable);
+    result[@"WritePermissionErrno"] = @(permissionErrno);
+    result[@"WritePermissionError"] = BQErrorString(permissionErrno);
+
+    struct statfs filesystem = {0};
+    errno = 0;
+    BOOL mountInspected = statfs(path.fileSystemRepresentation, &filesystem) == 0;
+    int mountErrno = mountInspected ? 0 : errno;
+    BOOL readOnlyFilesystem = mountInspected &&
+        (filesystem.f_flags & MNT_RDONLY) != 0;
+    result[@"MountInspectionSucceeded"] = @(mountInspected);
+    result[@"MountInspectionErrno"] = @(mountErrno);
+    result[@"MountInspectionError"] = BQErrorString(mountErrno);
+    result[@"FilesystemReadOnly"] = @(readOnlyFilesystem);
+    if (mountInspected) {
+        result[@"FilesystemType"] = [NSString stringWithUTF8String:
+            filesystem.f_fstypename] ?: @"unknown";
+        result[@"MountPoint"] = [NSString stringWithUTF8String:
+            filesystem.f_mntonname] ?: @"unknown";
+        result[@"MountedFrom"] = [NSString stringWithUTF8String:
+            filesystem.f_mntfromname] ?: @"unknown";
+        result[@"MountFlags"] = @((unsigned long long)filesystem.f_flags);
+    }
+
+    BOOL effectiveWritable = permissionWritable && mountInspected &&
+        !readOnlyFilesystem;
+    result[@"EffectiveWritable"] = @(effectiveWritable);
+    if (readOnlyFilesystem) {
+        result[@"AccessMode"] = @"readable-read-only-filesystem";
+        result[@"WriteBoundary"] =
+            @"The filesystem is mounted read-only. A sandbox extension can grant traversal/read access but cannot change the mount policy.";
+    } else if (effectiveWritable) {
+        result[@"AccessMode"] = @"readable-write-permission-present";
+        result[@"WriteBoundary"] =
+            @"The current process passes the directory write-permission check; individual descendants can still enforce stricter policy.";
+    } else if (mountInspected) {
+        result[@"AccessMode"] = @"readable-no-write-permission";
+        result[@"WriteBoundary"] =
+            @"Enumeration succeeded, but the current process has no verified write authority for this directory.";
+    } else {
+        result[@"AccessMode"] = @"readable-write-status-unknown";
+        result[@"WriteBoundary"] =
+            @"Enumeration succeeded, but the filesystem mount could not be inspected.";
+    }
+    return result;
 }
 
 static BOOL BQInstallLink(NSString *directory, NSString *name, NSString *target,
@@ -119,14 +174,17 @@ static NSDictionary *BQProbe(NSString *directory, NSDictionary *candidate)
         result[@"HandleRetained"] = @NO;
     }
 
+    [result addEntriesFromDictionary:BQAccessDiagnostics(path)];
+
     NSString *linkError = nil;
     BOOL linked = BQInstallLink(directory, name, path, &linkError);
     result[@"Status"] = linked ? @"verified" : @"verified-link-failed";
     result[@"LinkCreated"] = @(linked);
     if (linkError.length) result[@"LinkError"] = linkError;
 
-    NSLog(@"[BadQuerySystemProbe] VERIFIED scope=%@ path=%@ handle=%lld link=%d",
-          scope, path, handle, linked);
+    NSLog(@"[BadQuerySystemProbe] VERIFIED scope=%@ path=%@ handle=%lld link=%d access=%@ readonly=%@ writable=%@",
+          scope, path, handle, linked, result[@"AccessMode"],
+          result[@"FilesystemReadOnly"], result[@"EffectiveWritable"]);
     return result;
 }
 
@@ -138,8 +196,32 @@ static void BQWriteReadme(NSString *directory)
          "A bad_query return value alone is not treated as access. Every link requires a successful opendir/readdir check.\n\n"
          "Upstream-documented iOS 27 roots are tested first. Broader roots requested for full filesystem research are experimental and may remain denied.\n"
          "Denied candidates are recorded in Probe Results.plist and are intentionally not linked.\n"
-         "Read-only system-volume policy, Data Protection, POSIX permissions, and sandbox policy can still restrict descendants even when a parent root is visible.\n";
+         "Read-only system-volume policy, Data Protection, POSIX permissions, and sandbox policy can still restrict descendants even when a parent root is visible.\n\n"
+         "Important: /System/Library is part of the signed system volume on current iOS and is expected to report readable-read-only-filesystem. The bad_query token can expose directory contents, but it cannot remount that filesystem or turn read access into write access. App Groups live on the separate Data volume and can therefore be writable when the returned extension includes write authority.\n"
+         "See Access Status.txt for the observed mode of every visible root. Broad read access is not a jailbreak and does not imply kernel read/write, AMFI bypass, trust-cache control, root execution, or a writable system volume.\n";
     [text writeToFile:[directory stringByAppendingPathComponent:@"README.txt"]
+              atomically:YES encoding:NSUTF8StringEncoding error:nil];
+}
+
+static void BQWriteAccessStatus(NSString *directory, NSArray<NSDictionary *> *results)
+{
+    NSMutableString *text = [NSMutableString stringWithString:
+        @"bad_query observed access status\n\n"
+         "This report distinguishes directory enumeration from write authority. No files are created in the probed roots.\n\n"];
+    for (NSDictionary *result in results) {
+        if (![result[@"EnumerateAfter"] boolValue]) continue;
+        [text appendFormat:@"%@\n  Path: %@\n  Access: %@\n  Mount: %@ (%@)\n  Write check: %@ (errno=%@ %@)\n  Boundary: %@\n\n",
+            result[@"Name"] ?: @"Unnamed root",
+            result[@"Path"] ?: @"unknown",
+            result[@"AccessMode"] ?: @"unknown",
+            result[@"MountPoint"] ?: @"unknown",
+            [result[@"FilesystemReadOnly"] boolValue] ? @"read-only" : @"not reported read-only",
+            [result[@"WritePermissionCheck"] boolValue] ? @"passed" : @"failed",
+            result[@"WritePermissionErrno"] ?: @0,
+            result[@"WritePermissionError"] ?: @"unknown",
+            result[@"WriteBoundary"] ?: @"unknown"];
+    }
+    [text writeToFile:[directory stringByAppendingPathComponent:@"Access Status.txt"]
               atomically:YES encoding:NSUTF8StringEncoding error:nil];
 }
 
@@ -193,6 +275,7 @@ static void BQRunSystemProbe(void)
 
     [results writeToFile:[directory stringByAppendingPathComponent:@"Probe Results.plist"]
               atomically:YES];
+    BQWriteAccessStatus(directory, results);
     BQWriteReadme(directory);
 }
 

--- a/CVE43724RieCompatibility.m
+++ b/CVE43724RieCompatibility.m
@@ -1,0 +1,123 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#include <dlfcn.h>
+#include <sys/sysctl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static NSString *RCSysctlString(const char *name) {
+    size_t size = 0;
+    if (sysctlbyname(name, NULL, &size, NULL, 0) != 0 || size == 0) return @"unknown";
+    char *buffer = calloc(1, size + 1);
+    if (!buffer) return @"unknown";
+    NSString *value = @"unknown";
+    if (sysctlbyname(name, buffer, &size, NULL, 0) == 0 && buffer[0])
+        value = [NSString stringWithUTF8String:buffer] ?: @"unknown";
+    free(buffer);
+    return value;
+}
+
+static NSDictionary *RCPathStatus(NSString *path) {
+    struct stat st = {0};
+    BOOL exists = path.length && lstat(path.fileSystemRepresentation, &st) == 0;
+    return @{
+        @"path": path ?: @"",
+        @"exists": @(exists),
+        @"readable": @(exists && access(path.fileSystemRepresentation, R_OK) == 0),
+        @"directory": @(exists && S_ISDIR(st.st_mode)),
+    };
+}
+
+static NSDictionary *RCSymbolStatus(const char *symbol) {
+    dlerror();
+    void *address = dlsym(RTLD_DEFAULT, symbol);
+    const char *error = dlerror();
+    return @{
+        @"symbol": [NSString stringWithUTF8String:symbol] ?: @"",
+        @"present": @(address != NULL),
+        @"address": address ? [NSString stringWithFormat:@"%p", address] : @"0x0",
+        @"error": error ? ([NSString stringWithUTF8String:error] ?: @"") : @"",
+    };
+}
+
+static void RCWriteReport(void) {
+    NSString *documents = NSSearchPathForDirectoriesInDomains(
+        NSDocumentDirectory, NSUserDomainMask, YES).firstObject ?: NSTemporaryDirectory();
+    NSString *directory = [documents stringByAppendingPathComponent:@"Device Storage/Diagnostics"];
+    [NSFileManager.defaultManager createDirectoryAtPath:directory
+                             withIntermediateDirectories:YES
+                                              attributes:nil
+                                                   error:nil];
+
+    NSString *build = RCSysctlString("kern.osversion");
+    NSString *machine = RCSysctlString("hw.machine");
+    BOOL exactResearchBuild = [build isEqualToString:@"24A5380h"] &&
+                              [machine isEqualToString:@"iPhone17,3"];
+
+    NSArray *symbols = @[
+        RCSymbolStatus("shared_region_check_np"),
+        RCSymbolStatus("shared_region_map_and_slide_2_np"),
+        RCSymbolStatus("_shared_region_check_np"),
+        RCSymbolStatus("_shared_region_map_and_slide_2_np"),
+    ];
+
+    NSArray *cachePaths = @[
+        RCPathStatus(@"/System/Library/dyld/dyld_shared_cache_arm64e"),
+        RCPathStatus(@"/System/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e"),
+        RCPathStatus(@"/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e"),
+    ];
+
+    NSDictionary *report = @{
+        @"generatedAt": NSDate.date,
+        @"cve": @"CVE-2026-43724",
+        @"upstream": @"impost0r/Rie",
+        @"upstreamValidatedTarget": @"macOS 26.5 (25F71), Apple M1 arm64e",
+        @"device": @{
+            @"systemVersion": UIDevice.currentDevice.systemVersion ?: @"unknown",
+            @"build": build,
+            @"machine": machine,
+            @"exactResearchBuild": @(exactResearchBuild),
+        },
+        @"sharedRegionSymbols": symbols,
+        @"dyldCachePaths": cachePaths,
+        @"status": @"probe-only",
+        @"triggerAttempted": @NO,
+        @"kernelWriteClaimed": @NO,
+        @"notes": @[
+            @"Rie upstream is validated for macOS, not iOS.",
+            @"This probe does not invoke shared_region_map_and_slide_2_np or syscall 536.",
+            @"Presence of symbols or cache files does not prove CVE-2026-43724 is reachable on this iOS build.",
+        ],
+    };
+
+    NSString *plistPath = [directory stringByAppendingPathComponent:@"CVE-2026-43724-Rie-Compatibility.plist"];
+    NSString *textPath = [directory stringByAppendingPathComponent:@"CVE-2026-43724-Rie-Compatibility.txt"];
+    [report writeToURL:[NSURL fileURLWithPath:plistPath] error:nil];
+
+    NSMutableString *text = [NSMutableString string];
+    [text appendString:@"CVE-2026-43724 / Rie iOS compatibility probe\n"];
+    [text appendFormat:@"Generated: %@\n", report[@"generatedAt"]];
+    [text appendFormat:@"Device: %@\n", machine];
+    [text appendFormat:@"iOS: %@ (%@)\n", UIDevice.currentDevice.systemVersion, build];
+    [text appendFormat:@"Exact research target: %@\n\n", exactResearchBuild ? @"YES" : @"NO"];
+    [text appendString:@"Upstream validated target: macOS 26.5 (25F71), Apple M1 arm64e\n"];
+    [text appendString:@"Trigger attempted: NO\nKernel write claimed: NO\n\n"];
+    [text appendFormat:@"Shared-region symbols:\n%@\n\n", symbols];
+    [text appendFormat:@"dyld cache paths:\n%@\n", cachePaths];
+    [text writeToFile:textPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+
+    NSLog(@"[CVE43724RieCompatibility] report written to %@", textPath);
+}
+
+__attribute__((constructor)) static void CVE43724RieCompatibilityInit(void) {
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:UIApplicationDidFinishLaunchingNotification
+                    object:nil
+                     queue:nil
+                usingBlock:^(__unused NSNotification *note) {
+                    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+                        RCWriteReport();
+                    });
+                }];
+}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ THREEONE_ROOT := ThirdParty/3105
 # real tweak target. The direct launcher intercepts TGMainView.openMusicLib and
 # presents the full ByeTunes SwiftUI root; the legacy controller embed remains
 # linked only as a compatibility fallback.
-FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m FilzaMondBridge.m FilzaMainToolbarGestalt.m Filza3105Bridge.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ByeTunesFullAppLauncher.m FilzaDiagnostics.m FilzaQuickActions.m WebDAVRuntimeFix.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
+FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m FilzaMondBridge.m FilzaMainToolbarGestalt.m Filza3105Bridge.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ByeTunesFullAppLauncher.m FilzaDiagnostics.m FilzaQuickActions.m WebDAVRuntimeFix.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m CVE43724RieCompatibility.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 FilzaApplySandboxExt_FILES += $(THREEONE_ROOT)/Sources/AppIconHelper.m
 FilzaApplySandboxExt_FILES += $(THREEONE_ROOT)/Sources/wallpaper_zip.c
 
@@ -92,6 +92,7 @@ before-FilzaApplySandboxExt-all::
 	@test -f "VirtualBackendFix.m" || (echo "Missing VirtualBackendFix.m" >&2; exit 1)
 	@test -f "SystemPathDiagnostics.m" || (echo "Missing SystemPathDiagnostics.m" >&2; exit 1)
 	@test -f "BadQuerySystemProbe.m" || (echo "Missing BadQuerySystemProbe.m" >&2; exit 1)
+	@test -f "CVE43724RieCompatibility.m" || (echo "Missing CVE43724RieCompatibility.m" >&2; exit 1)
 	@test -f "GestaltManager.m" || (echo "Missing GestaltManager.m" >&2; exit 1)
 	@test -f "FilzaMondBridge.m" || (echo "Missing FilzaMondBridge.m" >&2; exit 1)
 	@test -f "FilzaMainToolbarGestalt.m" || (echo "Missing FilzaMainToolbarGestalt.m" >&2; exit 1)

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ now performs the complete installable build:
 4. stages ByeTunes runtime resources;
 5. downloads and hash-verifies the pinned unsigned Filza base IPA;
 6. injects the current runtime dylib and resources;
-7. writes exactly four Home Screen shortcuts plus Local Network/Bonjour and Live Activity declarations into `Info.plist` and assigns build version `4.10`;
+7. writes exactly four Home Screen shortcuts plus Local Network/Bonjour and Live Activity declarations into `Info.plist` and assigns build version `4.11`;
 8. verifies the base executable actually loads `FilzaApplySandboxExt.dylib`;
 9. repacks a real unsigned IPA;
 10. uploads the IPA as a GitHub Actions artifact.
@@ -357,6 +357,11 @@ Open **Actions → Verify Filza installable IPA** to download the latest build a
 - Apps Manager, Patches, Music Library, Gestalt Editor, and WebDAV should be revalidated on-device after each new IPA build.
 - The existing container-access primitives do not establish unrestricted `/`, `/System`, `/Library`, `/Applications`, or arbitrary `/private` traversal.
 - No kernel read/write or full jailbreak primitive is claimed by this README.
+- A verified `bad_query` root proves only the access recorded in its generated
+  `Probe Results.plist` and `Access Status.txt`. In particular,
+  `/System/Library` can be enumerated while remaining on iOS's read-only signed
+  system volume; the sandbox extension does not remount it or grant system-volume
+  writes. App Groups are on the separate Data volume and may be writable.
 
 ## PoCs / upstream research
 

--- a/Tweak.m
+++ b/Tweak.m
@@ -614,10 +614,31 @@ static void hook_activationViewDidLoad(id self, SEL _cmd) {
 static void setPastePOSIXError(NSError **error, int code,
                                NSString *operation, NSString *path) {
     if (!error) return;
-    NSString *description = [NSString stringWithFormat:@"%@ failed for %@: %s",
-        operation, path, strerror(code)];
+    NSString *resolvedPath = [path stringByResolvingSymlinksInPath];
+    BOOL systemLibrary = [resolvedPath isEqualToString:@"/System/Library"] ||
+        [resolvedPath hasPrefix:@"/System/Library/"];
+    NSString *description = nil;
+    NSString *recovery = nil;
+    if (code == EROFS) {
+        description = [NSString stringWithFormat:
+            @"%@ failed for %@: the destination filesystem is mounted read-only.",
+            operation, path];
+        recovery = @"A retained sandbox extension can expose a directory for browsing, but it cannot remount a filesystem read-write. Use a writable Data-volume path such as an authorized App Group.";
+    } else if (systemLibrary && (code == EACCES || code == EPERM)) {
+        description = [NSString stringWithFormat:
+            @"%@ failed for %@: System Library is readable, but this process has no write authority.",
+            operation, path];
+        recovery = @"/System/Library is on the signed system volume. bad_query directory access does not make that volume writable.";
+    } else {
+        description = [NSString stringWithFormat:@"%@ failed for %@: %s",
+            operation, path, strerror(code)];
+    }
+    NSMutableDictionary *userInfo = [@{
+        NSLocalizedDescriptionKey: description
+    } mutableCopy];
+    if (recovery.length) userInfo[NSLocalizedRecoverySuggestionErrorKey] = recovery;
     *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:code
-        userInfo:@{NSLocalizedDescriptionKey: description}];
+        userInfo:userInfo];
 }
 
 static BOOL directCopyItem(NSString *source, NSString *destination, NSError **error);


### PR DESCRIPTION
The existing verified-root probe only proved `opendir/readdir`, so `/System/Library` looked equivalent to writable Data-volume roots even though it is on the signed, read-only system volume.

This change records the mount point, filesystem type/flags, `W_OK` errno, and an effective access mode for every enumerated root. It writes a human-readable `Access Status.txt`, explains why a sandbox extension cannot remount `/System/Library`, improves Filza paste errors for `EROFS` and protected System Library paths, and bumps the installable IPA to 4.11.

The probe remains non-destructive: it does not create test files in system roots and does not claim jailbreak, kernel, AMFI, trust-cache, root, or system-volume write capabilities.

## Summary by Sourcery

Distinguish readable versus writable bad_query roots, adding system-root access diagnostics and updating user-facing messaging around read-only system volumes and the installable build version.

New Features:
- Generate an Access Status.txt report that records access mode and mount characteristics for each verified bad_query root.
- Expose improved paste error messages explaining read-only filesystem and System Library write boundaries in Filza.
- Document bad_query root access semantics in the README, including the distinction between system-volume and Data-volume writability.

Enhancements:
- Augment the system probe with per-root write-permission checks, filesystem mount inspection, and an effective writable classification without performing destructive writes.
- Log verified roots with additional access-mode metadata for clearer runtime diagnostics.

Build:
- Bump the installable Filza IPA version from 4.10 to 4.11 in the build workflow and Info.plist generation.

Tests:
- Extend the verify-safe-fixes CI workflow to assert the presence of system-root access diagnostics and paste error improvements in the codebase.
- Update CI assertions to expect the bumped installable IPA version.