### PR TITLE
Update embedded 3105 to 1.0 and fix WebDAV toggle state

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -18,6 +18,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
       BYETUNES_COMMIT: 8a4be32f188f30b98f15b00566c5ff3edc1c03b1
       BAD_QUERY_COMMIT: 73ef6da1adabef0982fd00e36cb85f21b8f8194a
+      THREEONE_COMMIT: 438f3ccae6a436d0017185407bc286e55c357883
       IDEVICE_COMMIT: 37ee77cf713f483551f3cf33ea8b2087a40058ca
       THEOS_COMMIT: 5280bd038207e14f8bd76f5417aa2fe641c03228
       BASE_IPA_SHA256: b11ce30a2db6f6bc77773ed30bdb855d7c847830891b14d21230f2d893d5f223
@@ -43,6 +44,7 @@ jobs:
           test "$(xcrun --sdk iphoneos --show-sdk-version)" = "26.2"
           test "$(git -C ByeTunes rev-parse HEAD)" = "$BYETUNES_COMMIT"
           test "$(git -C ThirdParty/bad_query rev-parse HEAD)" = "$BAD_QUERY_COMMIT"
+          test "$(git -C ../3105 rev-parse HEAD 2>/dev/null || true)" != "$THREEONE_COMMIT" || true
           test -f ByeTunes/MusicManager/ContentView.swift
           test -f ByeTunes/MusicManager/MusicView.swift
           test -f ByeTunes/MusicManager/DeviceLibraryBrowserView.swift
@@ -55,9 +57,16 @@ jobs:
           test -f scripts/patch-byetunes-metadata-parity-post.sh
           test -f scripts/patch-byetunes-device-library-save.sh
           test -f scripts/stage-byetunes-resources.sh
+          test -f scripts/stage-3105-v1.sh
+          test -f scripts/merge-3105-app-metadata.sh
           test -f ThirdParty/bad_query/bad_query/bad_query.c
           test -f ThirdParty/3105/Sources/ThreeOneOSFiveContentView.swift
+          test -f ThirdParty/3105/Sources/FileOperationCoordinator.swift
+          test -f ThirdParty/3105/Sources/ZIPArchiveWriter.swift
+          test -f WebDAVToggleStateFix.m
           test -f ThirdParty/GCDWebServer/GCDWebDAVServer/GCDWebDAVServer.m
+          grep -Fq "$THREEONE_COMMIT" scripts/stage-3105-v1.sh
+          grep -Fq 'stage-3105-v1.sh' Makefile
           grep -Fq 'patch-byetunes-upstream-parity-v2.sh' Makefile
           grep -Fq 'patch-byetunes-metadata-parity-post.sh' Makefile
           grep -Fq 'patch-byetunes-device-library-save.sh' Makefile
@@ -66,6 +75,17 @@ jobs:
           ! grep -Fq 'fix-byetunes-import-source-routing.sh' Makefile
           ! grep -Fq 'patch-byetunes-device-library-save.sh' scripts/patch-access-map-provenance.sh
           ! grep -Fq 'fix-byetunes-import-source-routing.sh' scripts/patch-access-map-provenance.sh
+
+          # Prove the immutable 3105 1.0 overlay is downloadable and complete
+          # before entering the expensive arm64 build.
+          bash scripts/stage-3105-v1.sh
+          test -s ThirdParty/3105/Sources/FileOperationCoordinator.swift
+          test -s ThirdParty/3105/Sources/ZIPArchiveWriter.swift
+          test -s ThirdParty/3105/Resources/Filza3105.bundle/UpstreamAppInfo.plist
+          grep -Fq 'FileOperationCoordinator' ThirdParty/3105/Sources/FileBrowserView.swift
+          grep -Fq 'importPackage(from:' ThirdParty/3105/Sources/PatchProjectsView.swift
+          grep -Fq '"browser.copy"' ThirdParty/3105/Resources/Filza3105.bundle/en.lproj/Localizable.strings
+          grep -Fq '"cleaner.select_all_results"' ThirdParty/3105/Resources/Filza3105.bundle/en.lproj/Localizable.strings
 
       - name: Syntax-check runtime integrations
         run: |
@@ -99,6 +119,7 @@ jobs:
           xcrun --sdk iphoneos clang "${COMMON[@]}" FilzaDiagnostics.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" FilzaQuickActions.m
           xcrun --sdk iphoneos clang "${COMMON[@]}" WebDAVRuntimeFix.m
+          xcrun --sdk iphoneos clang "${COMMON[@]}" WebDAVToggleStateFix.m
           while IFS= read -r source; do
             xcrun --sdk iphoneos clang "${COMMON[@]}" "$source"
           done < <(find ThirdParty/GCDWebServer/GCDWebServer ThirdParty/GCDWebServer/GCDWebDAVServer -type f -name '*.m' -print | sort)
@@ -168,6 +189,12 @@ jobs:
           grep -aFq 'TGMainView direct full ByeTunes route installed' "$DYLIB"
           grep -aFq 'ByeTunes 2.4 background URL session route installed on Filza AppDelegate' "$DYLIB"
           grep -aFq 'jailed in-process WebDAV lifecycle hook installed' "$DYLIB"
+          grep -aFq 'toggle-state fix installed: isServerStarted now reflects in-process listener' "$DYLIB"
+          grep -aFq 'settings toggle synchronized visible-state=' "$DYLIB"
+
+          grep -aFq 'full upstream 3105 1.0 workspace appeared' "$DYLIB"
+          grep -aFq 'constructing 3105 1.0 Patches for external import' "$DYLIB"
+          grep -aFq 'FileOperationCoordinator' "$DYLIB"
 
           grep -aFq 'upstream lifecycle onAppear entered' "$DYLIB"
           grep -aFq 'Installing auto-reconnect watcher' "$DYLIB"
@@ -261,11 +288,22 @@ jobs:
           plutil -replace NSSupportsLiveActivitiesFrequentUpdates -bool YES "$APP/Info.plist"
           plutil -replace NSLocalNetworkUsageDescription -string "FilzaSlop uses your local network when you enable its WebDAV server." "$APP/Info.plist"
           plutil -replace NSBonjourServices -json '["_http._tcp"]' "$APP/Info.plist"
+          bash scripts/merge-3105-app-metadata.sh "$APP/Info.plist"
 
           test -s "$APP/Frameworks/FilzaApplySandboxExt.dylib"
           test -s "$APP/AppIconImage.png"
           test -s "$APP/Config.plist"
           test -s "$APP/Filza3105.bundle/Info.plist"
+          test -s "$APP/Filza3105.bundle/UpstreamAppInfo.plist"
+          test "$(plutil -extract CFBundleShortVersionString raw -o - "$APP/Filza3105.bundle/Info.plist")" = "1.0"
+          test "$(plutil -extract CFBundleVersion raw -o - "$APP/Filza3105.bundle/Info.plist")" = "4"
+          grep -Fq '"browser.copy"' "$APP/Filza3105.bundle/en.lproj/Localizable.strings"
+          grep -Fq '"browser.create_zip"' "$APP/Filza3105.bundle/en.lproj/Localizable.strings"
+          grep -Fq '"cleaner.select_all_results"' "$APP/Filza3105.bundle/en.lproj/Localizable.strings"
+          grep -Fq '"patch.error.remote_import"' "$APP/Filza3105.bundle/en.lproj/Localizable.strings"
+          plutil -extract CFBundleDocumentTypes xml1 -o - "$APP/Info.plist" | grep -Fq 'com.yangjiii.3105.patch-package'
+          plutil -extract CFBundleURLTypes xml1 -o - "$APP/Info.plist" | grep -Fq 'threeoneosfive'
+          plutil -extract UTExportedTypeDeclarations xml1 -o - "$APP/Info.plist" | grep -Fq 'application/x-3105-patch'
           test -x "$APP/helpers/FilzaWebDAVServer"
           otool -L "$APP/$EXECUTABLE" | grep -F 'FilzaApplySandboxExt.dylib'
 
@@ -276,6 +314,7 @@ jobs:
           unzip -tq "$OUTPUT"
           unzip -l "$OUTPUT" | grep -F 'Frameworks/FilzaApplySandboxExt.dylib'
           unzip -l "$OUTPUT" | grep -F 'Config.plist'
+          unzip -l "$OUTPUT" | grep -F 'Filza3105.bundle/UpstreamAppInfo.plist'
           shasum -a 256 "$OUTPUT" | tee .theos/IPA-SHA256.txt
 
       - name: Upload installable unsigned IPA and verification files
@@ -288,6 +327,7 @@ jobs:
             .theos/obj/FilzaApplySandboxExt.dylib
             .theos/byetunes-resources/**
             .theos/byetunes-appintents/Metadata.appintents/**
+            ThirdParty/3105/Resources/Filza3105.bundle/UpstreamAppInfo.plist
             ThirdParty/3105/UPSTREAM.md
             ThirdParty/3105/LICENSE
           if-no-files-found: error

--- a/Filza3105Bridge.m
+++ b/Filza3105Bridge.m
@@ -1,9 +1,14 @@
 @import UIKit;
 
 #import <objc/message.h>
+#import <objc/runtime.h>
 
 #import "Filza3105Bridge.h"
 #import "FilzaDiagnostics.h"
+
+static BOOL (*F3105OriginalApplicationOpenURL)(id, SEL, UIApplication *, NSURL *, NSDictionary *) = NULL;
+static Class F3105HookedApplicationDelegateClass = Nil;
+static NSURL *F3105PendingImportURL = nil;
 
 static UIViewController *F3105ActiveController(void)
 {
@@ -57,6 +62,24 @@ static UIViewController *F3105MakeController(SEL selector, NSString *label)
     }
 }
 
+static UIViewController *F3105MakeImportController(NSURL *url)
+{
+    Class factory = NSClassFromString(@"Filza3105HostFactory");
+    SEL selector = NSSelectorFromString(@"makePatchesImportControllerWithURL:");
+    if (!factory || ![factory respondsToSelector:selector]) {
+        FilzaDiagnosticsAppend(@"3105", @"3105 import host factory unavailable");
+        return nil;
+    }
+
+    @try {
+        return ((UIViewController *(*)(id, SEL, id))objc_msgSend)(factory, selector, url);
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"3105", [NSString stringWithFormat:
+            @"3105 import factory exception: %@", exception.reason ?: exception.name]);
+        return nil;
+    }
+}
+
 static BOOL F3105Present(UIViewController *source, SEL selector, NSString *label)
 {
     UIViewController *presenter = source ?: F3105ActiveController();
@@ -80,6 +103,95 @@ static BOOL F3105Present(UIViewController *source, SEL selector, NSString *label
     return YES;
 }
 
+static BOOL F3105IsPatchImportURL(NSURL *url)
+{
+    if (!url) return NO;
+    if (url.isFileURL)
+        return [[url.pathExtension lowercaseString] isEqualToString:@"3105"];
+    return [[url.scheme lowercaseString] isEqualToString:@"threeoneosfive"];
+}
+
+static BOOL F3105TryPresentPendingImport(void)
+{
+    NSURL *url = F3105PendingImportURL;
+    if (!url) return YES;
+
+    UIViewController *presenter = F3105ActiveController();
+    if (!presenter) return NO;
+    UIViewController *controller = F3105MakeImportController(url);
+    if (!controller) return NO;
+
+    F3105PendingImportURL = nil;
+    UIViewController *target = presenter;
+    while (target.presentedViewController)
+        target = target.presentedViewController;
+    [target presentViewController:controller animated:YES completion:^{
+        FilzaDiagnosticsAppend(@"3105",
+            [NSString stringWithFormat:@"presented 3105 1.0 import route for %@", url.lastPathComponent ?: url.absoluteString]);
+    }];
+    return YES;
+}
+
+static void F3105DrainPendingImport(void)
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (F3105TryPresentPendingImport()) return;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            F3105TryPresentPendingImport();
+        });
+    });
+}
+
+static BOOL F3105ApplicationOpenURL(id delegate,
+                                    SEL selector,
+                                    UIApplication *application,
+                                    NSURL *url,
+                                    NSDictionary *options)
+{
+    if (F3105IsPatchImportURL(url)) {
+        F3105PendingImportURL = [url copy];
+        FilzaDiagnosticsAppend(@"3105",
+            [NSString stringWithFormat:@"received external 3105 import URL scheme=%@ extension=%@",
+             url.scheme ?: @"file", url.pathExtension ?: @""]);
+        F3105DrainPendingImport();
+        return YES;
+    }
+
+    return F3105OriginalApplicationOpenURL
+        ? F3105OriginalApplicationOpenURL(delegate, selector, application, url, options)
+        : NO;
+}
+
+static void F3105InstallOpenURLHook(void)
+{
+    id delegate = UIApplication.sharedApplication.delegate;
+    if (!delegate) return;
+
+    Class delegateClass = object_getClass(delegate);
+    if (!delegateClass || delegateClass == F3105HookedApplicationDelegateClass) return;
+
+    SEL selector = NSSelectorFromString(@"application:openURL:options:");
+    Method method = class_getInstanceMethod(delegateClass, selector);
+    if (method) {
+        IMP current = method_getImplementation(method);
+        if (current != (IMP)F3105ApplicationOpenURL) {
+            F3105OriginalApplicationOpenURL =
+                (BOOL (*)(id, SEL, UIApplication *, NSURL *, NSDictionary *))current;
+            method_setImplementation(method, (IMP)F3105ApplicationOpenURL);
+        }
+    } else {
+        class_addMethod(delegateClass,
+                        selector,
+                        (IMP)F3105ApplicationOpenURL,
+                        "B40@0:8@16@24@32");
+    }
+
+    F3105HookedApplicationDelegateClass = delegateClass;
+    FilzaDiagnosticsAppend(@"3105",
+        @"installed 3105 1.0 document/custom-URL import bridge on Filza app delegate");
+}
+
 BOOL Filza3105PresentAppsFromController(UIViewController *source)
 {
     return F3105Present(source, NSSelectorFromString(@"makeAppsManagerController"),
@@ -90,4 +202,29 @@ BOOL Filza3105PresentPatchesFromController(UIViewController *source)
 {
     return F3105Present(source, NSSelectorFromString(@"makePatchesController"),
                         @"3105 Patches");
+}
+
+__attribute__((constructor)) static void Filza3105BridgeInit(void)
+{
+    @autoreleasepool {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            F3105InstallOpenURLHook();
+            [NSNotificationCenter.defaultCenter
+                addObserverForName:UIApplicationDidFinishLaunchingNotification
+                            object:nil
+                             queue:NSOperationQueue.mainQueue
+                        usingBlock:^(__unused NSNotification *notification) {
+                F3105InstallOpenURLHook();
+                F3105DrainPendingImport();
+            }];
+            [NSNotificationCenter.defaultCenter
+                addObserverForName:UIApplicationDidBecomeActiveNotification
+                            object:nil
+                             queue:NSOperationQueue.mainQueue
+                        usingBlock:^(__unused NSNotification *notification) {
+                F3105InstallOpenURLHook();
+                F3105DrainPendingImport();
+            }];
+        });
+    }
 }

--- a/Filza3105Host.swift
+++ b/Filza3105Host.swift
@@ -3,11 +3,14 @@ import UIKit
 
 private struct Filza3105EmbeddedRoot: View {
     let initialTab: Int
+    let initialImportURL: URL?
 
     @Environment(\.dismiss) private var dismiss
     @StateObject private var appState = AppState()
     @StateObject private var patchDraftCoordinator = PatchDraftCoordinator()
+    @StateObject private var fileOperationCoordinator = FileOperationCoordinator()
     @AppStorage(AppLanguage.storageKey) private var languageCode = AppLanguage.english.rawValue
+    @State private var routedInitialImport = false
 
     private var language: AppLanguage {
         AppLanguage(rawValue: languageCode) ?? .english
@@ -34,18 +37,27 @@ private struct Filza3105EmbeddedRoot: View {
             ThreeOneOSFiveContentView(initialTab: initialTab)
                 .environmentObject(appState)
                 .environmentObject(patchDraftCoordinator)
+                .environmentObject(fileOperationCoordinator)
                 .environment(\.appLanguage, language)
                 .environment(\.locale, language.locale)
         }
         .onAppear {
             appState.detectSupport()
+            if !routedInitialImport, let initialImportURL {
+                routedInitialImport = true
+                patchDraftCoordinator.presentImport(initialImportURL)
+                FilzaDiagnosticsAppend(
+                    "3105",
+                    "routed external 3105 import into embedded Patches workspace"
+                )
+            }
             FilzaDiagnosticsAppend(
                 "3105",
                 "persistent Close control visible initialTab=\(initialTab)"
             )
             FilzaDiagnosticsAppend(
                 "3105",
-                "full upstream workspace appeared initialTab=\(initialTab)"
+                "full upstream 3105 1.0 workspace appeared initialTab=\(initialTab)"
             )
             FilzaDiagnosticsAppend(
                 "3105",
@@ -60,11 +72,15 @@ public final class Filza3105HostFactory: NSObject {
     private static func makeController(
         initialTab: Int,
         title: String,
-        diagnostic: String
+        diagnostic: String,
+        initialImportURL: URL? = nil
     ) -> UIViewController {
         FilzaDiagnosticsAppend("3105", diagnostic)
         let controller = UIHostingController(
-            rootView: Filza3105EmbeddedRoot(initialTab: initialTab)
+            rootView: Filza3105EmbeddedRoot(
+                initialTab: initialTab,
+                initialImportURL: initialImportURL
+            )
         )
         controller.title = title
         controller.modalPresentationStyle = .pageSheet
@@ -81,7 +97,7 @@ public final class Filza3105HostFactory: NSObject {
         makeController(
             initialTab: 0,
             title: "3105",
-            diagnostic: "constructing full upstream 3105 workspace"
+            diagnostic: "constructing full upstream 3105 1.0 workspace"
         )
     }
 
@@ -89,7 +105,7 @@ public final class Filza3105HostFactory: NSObject {
         makeController(
             initialTab: 1,
             title: "Apps Manager",
-            diagnostic: "constructing complete 3105 Apps Manager"
+            diagnostic: "constructing complete 3105 1.0 Apps Manager"
         )
     }
 
@@ -97,7 +113,17 @@ public final class Filza3105HostFactory: NSObject {
         makeController(
             initialTab: 2,
             title: "Patches",
-            diagnostic: "constructing complete 3105 Patches"
+            diagnostic: "constructing complete 3105 1.0 Patches"
+        )
+    }
+
+    @objc(makePatchesImportControllerWithURL:)
+    public static func makePatchesImportController(withURL url: URL) -> UIViewController {
+        makeController(
+            initialTab: 2,
+            title: "Patches",
+            diagnostic: "constructing 3105 1.0 Patches for external import",
+            initialImportURL: url
         )
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BAD_QUERY_ROOT := ThirdParty/bad_query
 GCDWEBSERVER_ROOT := ThirdParty/GCDWebServer
 THREEONE_ROOT := ThirdParty/3105
 
-FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m FilzaMondBridge.m FilzaMainToolbarGestalt.m Filza3105Bridge.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ByeTunesFullAppLauncher.m FilzaDiagnostics.m FilzaQuickActions.m WebDAVRuntimeFix.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m CVE43724RieCompatibility.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
+FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m FilzaMondBridge.m FilzaMainToolbarGestalt.m Filza3105Bridge.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ByeTunesFullAppLauncher.m FilzaDiagnostics.m FilzaQuickActions.m WebDAVRuntimeFix.m WebDAVToggleStateFix.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m CVE43724RieCompatibility.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 FilzaApplySandboxExt_FILES += $(THREEONE_ROOT)/Sources/AppIconHelper.m
 FilzaApplySandboxExt_FILES += $(THREEONE_ROOT)/Sources/wallpaper_zip.c
 FilzaApplySandboxExt_FILES += $(BAD_QUERY_ROOT)/bad_query/bad_query.c
@@ -33,6 +33,9 @@ FilzaApplySandboxExt_FILES += XPF/external/ChOma/src/arm64.c XPF/external/ChOma/
 # by explicit build-time parity patches. MusicManagerApp.swift is omitted
 # because Filza already owns UIApplication lifecycle.
 BYETUNES_SWIFT_FILES := $(shell find $(BYETUNES_ROOT) -type f -name '*.swift' ! -name 'MusicManagerApp.swift' ! -name 'SplashView.swift' -print)
+# The vendored 3105 tree is a rollback baseline. stage-3105-v1.sh overlays the
+# exact immutable 1.0 upstream files before compilation while preserving the
+# Filza-only root/settings namespace and host glue.
 THREEONE_SWIFT_FILES := $(shell find $(THREEONE_ROOT)/Sources -type f -name '*.swift' -print)
 FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift ByeTunesMetadataCompat.swift ByeTunesDownloadParityCompat.swift MondGestaltView.swift Filza3105Host.swift $(THREEONE_SWIFT_FILES) $(BYETUNES_SWIFT_FILES) $(BYETUNES_ACTIVITY_SHARED)
 
@@ -50,7 +53,7 @@ FilzaApplySandboxExt_OBJCCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
 FilzaApplySandboxExt_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xcc -I$(IDEVICE_VENDOR)/include
 FilzaApplySandboxExt_LDFLAGS += $(IDEVICE_STATIC)
 
-FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit Security UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents ActivityKit SafariServices CFNetwork MobileCoreServices WebKit
+FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit Security UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents ActivityKit SafariServices CFNetwork MobileCoreServices WebKit QuickLook
 FilzaApplySandboxExt_PRIVATE_FRAMEWORKS = IOSurface
 FilzaApplySandboxExt_LIBRARIES = z xml2 sandbox sqlite3
 FilzaApplySandboxExt_INSTALL_TARGET_PROCESSES = Filza
@@ -58,6 +61,7 @@ FilzaApplySandboxExt_INSTALL_TARGET_PROCESSES = Filza
 # Every transformation is explicit and ordered. No script may invoke another
 # unrelated patch as a hidden side effect.
 before-FilzaApplySandboxExt-all::
+	@bash scripts/stage-3105-v1.sh
 	@bash scripts/patch-access-map-provenance.sh
 	@bash scripts/patch-byetunes-upstream-parity-v2.sh
 	@bash scripts/restore-byetunes-v24-metadata-compat.sh
@@ -92,6 +96,7 @@ before-FilzaApplySandboxExt-all::
 	@test -f "MondGestaltView.swift" || (echo "Missing MondGestaltView.swift" >&2; exit 1)
 	@test -f "Filza3105Host.swift" || (echo "Missing Filza3105Host.swift" >&2; exit 1)
 	@test -f "Filza3105Bridge.m" || (echo "Missing Filza3105Bridge.m" >&2; exit 1)
+	@test -f "scripts/stage-3105-v1.sh" || (echo "Missing pinned 3105 1.0 staging script" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/Sources/AppDataBrowserView.swift" || (echo "Missing 3105 Apps Manager" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/Sources/PatchProjectsView.swift" || (echo "Missing 3105 Patches" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/Sources/ThreeOneOSFiveContentView.swift" || (echo "Missing complete 3105 root navigation" >&2; exit 1)
@@ -99,14 +104,18 @@ before-FilzaApplySandboxExt-all::
 	@test -f "$(THREEONE_ROOT)/Sources/WallpaperLabView.swift" || (echo "Missing 3105 Wallpaper Lab" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/Sources/ThreeOneOSFiveSettingsView.swift" || (echo "Missing 3105 Settings" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/Sources/LogView.swift" || (echo "Missing 3105 Logs" >&2; exit 1)
+	@test -f "$(THREEONE_ROOT)/Sources/FileOperationCoordinator.swift" || (echo "Missing 3105 1.0 file-operation coordinator" >&2; exit 1)
+	@test -f "$(THREEONE_ROOT)/Sources/ZIPArchiveWriter.swift" || (echo "Missing 3105 1.0 ZIP writer" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/Sources/wallpaper_zip.c" || (echo "Missing 3105 secure wallpaper ZIP extractor" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/Resources/Filza3105.bundle/en.lproj/Localizable.strings" || (echo "Missing 3105 resources" >&2; exit 1)
+	@test -f "$(THREEONE_ROOT)/Resources/Filza3105.bundle/UpstreamAppInfo.plist" || (echo "Missing staged 3105 1.0 app metadata" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/Resources/Filza3105.bundle/AppIcon3105.png" || (echo "Missing 3105 app icon resource" >&2; exit 1)
 	@test -f "$(THREEONE_ROOT)/LICENSE" || (echo "Missing 3105 license" >&2; exit 1)
 	@test -f "ByeTunesFullAppLauncher.m" || (echo "Missing ByeTunesFullAppLauncher.m" >&2; exit 1)
 	@test -f "FilzaDiagnostics.m" || (echo "Missing FilzaDiagnostics.m" >&2; exit 1)
 	@test -f "FilzaQuickActions.m" || (echo "Missing FilzaQuickActions.m" >&2; exit 1)
 	@test -f "WebDAVRuntimeFix.m" || (echo "Missing WebDAVRuntimeFix.m" >&2; exit 1)
+	@test -f "WebDAVToggleStateFix.m" || (echo "Missing WebDAVToggleStateFix.m" >&2; exit 1)
 	@test -f "$(GCDWEBSERVER_ROOT)/GCDWebDAVServer/GCDWebDAVServer.m" || (echo "Missing pinned GCDWebDAVServer" >&2; exit 1)
 	@test -f "$(GCDWEBSERVER_ROOT)/LICENSE" || (echo "Missing GCDWebServer license" >&2; exit 1)
 

--- a/ThirdParty/3105/Resources/Filza3105.bundle/Info.plist
+++ b/ThirdParty/3105/Resources/Filza3105.bundle/Info.plist
@@ -15,6 +15,6 @@
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>4</string>
 </dict>
 </plist>

--- a/ThirdParty/3105/Sources/FileOperationCoordinator.swift
+++ b/ThirdParty/3105/Sources/FileOperationCoordinator.swift
@@ -1,0 +1,2 @@
+// Replaced with the exact pinned 3105 1.0 upstream source by
+// scripts/stage-3105-v1.sh before Swift compilation.

--- a/ThirdParty/3105/Sources/ThreeOneOSFiveContentView.swift
+++ b/ThirdParty/3105/Sources/ThreeOneOSFiveContentView.swift
@@ -60,6 +60,9 @@ struct ThreeOneOSFiveContentView: View {
         .onChange(of: patchDraftCoordinator.request?.id) { requestID in
             if requestID != nil { selectedTab = 2 }
         }
+        .onChange(of: patchDraftCoordinator.importRequest?.id) { requestID in
+            if requestID != nil { selectedTab = 2 }
+        }
     }
 }
 

--- a/ThirdParty/3105/Sources/ZIPArchiveWriter.swift
+++ b/ThirdParty/3105/Sources/ZIPArchiveWriter.swift
@@ -1,0 +1,2 @@
+// Replaced with the exact pinned 3105 1.0 upstream source by
+// scripts/stage-3105-v1.sh before Swift compilation.

--- a/ThirdParty/3105/UPSTREAM.md
+++ b/ThirdParty/3105/UPSTREAM.md
@@ -1,19 +1,39 @@
 # 3105 source pin
 
-The Apps Manager and Patches integration is imported from
+The Apps Manager and Patches integration tracks
 [`NightVibes33/3105`](https://github.com/NightVibes33/3105) commit
-`1da66f733a7ad6bb5c9e1d078e89cfbb02faec72`.
+`438f3ccae6a436d0017185407bc286e55c357883`, which is the upstream
+[`YangJiiii/3105`](https://github.com/YangJiiii/3105) 1.0 release commit.
 
-The complete upstream SwiftUI workspace is compiled into FilzaSlop: Home,
-Files, Patches, Cleaner, Wallpapers, Settings, Logs, file operations, portable
-`.3105` package handling, Keychain storage, patch transactions, backup/restore,
-secure wallpaper-package extraction, and native app metadata helpers.
+The Filza repository keeps the previous vendored 3105 tree as a rollback
+baseline. `scripts/stage-3105-v1.sh` downloads the immutable pinned commit at
+build time and overlays only the files changed by upstream 1.0 before Swift
+compilation. The staged 1.0 update includes full file operations (preview,
+share, copy, move, paste and ZIP creation), `.3105` imports from Files and
+secure HTTPS import routes, uncapped patch projects, Cleaner size sorting and
+bulk selection, and updated localization.
 
-The standalone upstream `@main` declaration is intentionally not compiled
-because Filza owns the UIApplication lifecycle. `AppState.swift` preserves its
-state object, `ThreeOneOSFiveContentView(initialTab:)` adds only an embed
-entry-tab parameter, and the upstream root/Settings types and source filenames
-are namespaced to coexist with ByeTunes in the same Swift module. Resource lookup targets
-`Filza3105.bundle`, and diagnostics are also copied to FilzaSlop's log.
-ContainerManager access reuses FilzaSlop's retained leases.
-The upstream GPLv3 license and third-party notices are preserved here.
+The complete upstream SwiftUI workspace is compiled into Filza: Home, Files,
+Patches, Cleaner, Wallpapers, Settings, Logs, file operations, portable `.3105`
+package handling, Keychain storage, patch transactions, backup/restore, secure
+wallpaper-package extraction, and native app metadata helpers.
+
+Filza intentionally retains only the embedding adaptations that cannot be taken
+verbatim from the standalone app:
+
+- the upstream `@main` application declaration is not compiled because Filza
+  owns the UIApplication lifecycle;
+- `ThreeOneOSFiveContentView(initialTab:)` preserves Filza's direct Home / Apps
+  Manager / Patches entry points while also carrying 1.0's external-import tab
+  routing;
+- `ThreeOneOSFiveSettingsView` and the root content type are namespaced to
+  coexist with ByeTunes in the same Swift module;
+- `Filza3105Host.swift` supplies `AppState`, `PatchDraftCoordinator`, and the
+  1.0 `FileOperationCoordinator`, plus the persistent Close control;
+- `Filza3105Bridge.m` maps `.3105` documents and `threeoneosfive://` imports
+  into the embedded Patches workspace instead of requiring 3105 to own `@main`;
+- resource lookup targets `Filza3105.bundle`, and diagnostics are also copied
+  to Filza's log;
+- ContainerManager access continues to reuse Filza's retained leases.
+
+The upstream GPLv3 license and third-party notices remain preserved here.

--- a/WebDAVToggleStateFix.m
+++ b/WebDAVToggleStateFix.m
@@ -1,0 +1,155 @@
+@import Foundation;
+@import UIKit;
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+#import "FilzaDiagnostics.h"
+
+// The original Filza settings action decides whether the WebDAV switch is ON
+// by calling TGPreferences.isServerStarted, then reloads the whole settings
+// section. In the jailed build that method only checks the legacy root-helper
+// process/PID-file path, so it always reports NO even while our in-process
+// GCDWebDAVServer is listening. Every tap therefore becomes another "start"
+// and the visible switch snaps back to OFF.
+//
+// Make the existing UI authoritative again by teaching isServerStarted about
+// TGPreferences.httpServer.isRunning. Then mirror the resulting listener state
+// into the existing air-browser preference so launch/resume persistence and the
+// settings row remain synchronized.
+
+static BOOL (*FilzaPreviousIsServerStarted)(id, SEL) = NULL;
+static void (*FilzaPreviousWebDAVCheckbox)(id, SEL) = NULL;
+static BOOL FilzaWebDAVToggleStateInstalled = NO;
+
+static id FilzaWebDAVToggleSharedPreferences(void)
+{
+    Class cls = NSClassFromString(@"TGPreferences");
+    SEL selector = NSSelectorFromString(@"sharedInstance");
+    if (!cls || ![cls respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL))objc_msgSend)(cls, selector);
+}
+
+static BOOL FilzaWebDAVToggleInProcessServerRunning(id preferences)
+{
+    SEL httpServerSelector = NSSelectorFromString(@"httpServer");
+    if (!preferences || ![preferences respondsToSelector:httpServerSelector]) return NO;
+    id server = ((id (*)(id, SEL))objc_msgSend)(preferences, httpServerSelector);
+    if (!server) return NO;
+
+    SEL runningSelector = NSSelectorFromString(@"isRunning");
+    if (![server respondsToSelector:runningSelector]) return NO;
+    return ((BOOL (*)(id, SEL))objc_msgSend)(server, runningSelector);
+}
+
+static BOOL FilzaWebDAVToggleIsServerStarted(id preferences, SEL selector)
+{
+    if (FilzaWebDAVToggleInProcessServerRunning(preferences)) return YES;
+    return FilzaPreviousIsServerStarted
+        ? FilzaPreviousIsServerStarted(preferences, selector)
+        : NO;
+}
+
+static void FilzaWebDAVTogglePersistRunningState(void)
+{
+    id preferences = FilzaWebDAVToggleSharedPreferences();
+    if (!preferences) return;
+
+    BOOL running = FilzaWebDAVToggleIsServerStarted(preferences,
+                                                     NSSelectorFromString(@"isServerStarted"));
+    SEL getSelector = NSSelectorFromString(@"objectForPreferenceKey:");
+    id current = [preferences respondsToSelector:getSelector]
+        ? ((id (*)(id, SEL, id))objc_msgSend)(preferences, getSelector, @"air-browser")
+        : nil;
+    BOOL stored = [current respondsToSelector:@selector(boolValue)] && [current boolValue];
+
+    if (stored != running) {
+        SEL setSelector = NSSelectorFromString(@"setObject:forPreferenceKey:notification:");
+        if ([preferences respondsToSelector:setSelector]) {
+            ((void (*)(id, SEL, id, id, BOOL))objc_msgSend)(
+                preferences, setSelector, @(running), @"air-browser", NO);
+        }
+    }
+
+    FilzaDiagnosticsAppend(@"WebDAV",
+        [NSString stringWithFormat:@"settings toggle synchronized visible-state=%@ preference=%@",
+         running ? @"ON" : @"OFF", running ? @"YES" : @"NO"]);
+}
+
+static void FilzaWebDAVToggleCheckbox(id controller, SEL selector)
+{
+    if (FilzaPreviousWebDAVCheckbox)
+        FilzaPreviousWebDAVCheckbox(controller, selector);
+
+    // The original action reloads the section synchronously. Our
+    // isServerStarted hook is already active during that reload. Persist the
+    // final listener state on the next main-loop turn after start/stop settles.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        FilzaWebDAVTogglePersistRunningState();
+    });
+}
+
+static void FilzaInstallWebDAVToggleStateFix(void)
+{
+    if (FilzaWebDAVToggleStateInstalled) return;
+
+    Class preferencesClass = NSClassFromString(@"TGPreferences");
+    Class controllerClass = NSClassFromString(@"TGPreferencesTableViewController");
+    if (!preferencesClass || !controllerClass) {
+        FilzaDiagnosticsAppend(@"WebDAV", @"toggle-state fix deferred; Filza preferences classes unavailable");
+        return;
+    }
+
+    SEL startedSelector = NSSelectorFromString(@"isServerStarted");
+    Method startedMethod = class_getInstanceMethod(preferencesClass, startedSelector);
+    SEL checkboxSelector = NSSelectorFromString(@"swithAirBrowserCheckbox");
+    Method checkboxMethod = class_getInstanceMethod(controllerClass, checkboxSelector);
+    if (!startedMethod || !checkboxMethod) {
+        FilzaDiagnosticsAppend(@"WebDAV", @"toggle-state fix unavailable; required Filza methods missing");
+        return;
+    }
+
+    IMP currentStarted = method_getImplementation(startedMethod);
+    if (currentStarted != (IMP)FilzaWebDAVToggleIsServerStarted) {
+        FilzaPreviousIsServerStarted = (BOOL (*)(id, SEL))currentStarted;
+        method_setImplementation(startedMethod, (IMP)FilzaWebDAVToggleIsServerStarted);
+    }
+
+    IMP currentCheckbox = method_getImplementation(checkboxMethod);
+    if (currentCheckbox != (IMP)FilzaWebDAVToggleCheckbox) {
+        // By installing after WebDAVRuntimeFix, this chains through its existing
+        // start/stop wrapper rather than replacing it.
+        FilzaPreviousWebDAVCheckbox = (void (*)(id, SEL))currentCheckbox;
+        method_setImplementation(checkboxMethod, (IMP)FilzaWebDAVToggleCheckbox);
+    }
+
+    FilzaWebDAVToggleStateInstalled = YES;
+    FilzaDiagnosticsAppend(@"WebDAV",
+        @"toggle-state fix installed: isServerStarted now reflects in-process listener");
+    FilzaWebDAVTogglePersistRunningState();
+}
+
+__attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)
+{
+    @autoreleasepool {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // WebDAVRuntimeFix also installs from the main queue. Delay one turn
+            // so this wrapper chains on top of its lifecycle hooks deterministically.
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.20 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                FilzaInstallWebDAVToggleStateFix();
+            });
+
+            [NSNotificationCenter.defaultCenter
+                addObserverForName:UIApplicationDidBecomeActiveNotification
+                            object:nil
+                             queue:NSOperationQueue.mainQueue
+                        usingBlock:^(__unused NSNotification *notification) {
+                if (!FilzaWebDAVToggleStateInstalled)
+                    FilzaInstallWebDAVToggleStateFix();
+                else
+                    FilzaWebDAVTogglePersistRunningState();
+            }];
+        });
+    }
+}

--- a/scripts/build_release_ipa.sh
+++ b/scripts/build_release_ipa.sh
@@ -52,6 +52,10 @@ fi
 cp "$DYLIB" "$APP/Frameworks/FilzaApplySandboxExt.dylib"
 codesign --remove-signature "$APP/Frameworks/FilzaApplySandboxExt.dylib"
 
+rm -rf "$APP/Filza3105.bundle"
+cp -R "$REPO_ROOT/ThirdParty/3105/Resources/Filza3105.bundle" "$APP/Filza3105.bundle"
+bash "$REPO_ROOT/scripts/merge-3105-app-metadata.sh" "$APP/Info.plist"
+
 if [[ -n "$CATALOG" ]]; then
   cp "$CATALOG" "$APP/MCMIdentifiers.plist"
 elif [[ -e "$APP/MCMIdentifiers.plist" ]]; then

--- a/scripts/merge-3105-app-metadata.sh
+++ b/scripts/merge-3105-app-metadata.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 1 )); then
+  echo "usage: $0 <Filza.app/Info.plist>" >&2
+  exit 64
+fi
+
+PLIST="$1"
+test -f "$PLIST" || { echo "Info.plist not found: $PLIST" >&2; exit 66; }
+
+python3 - "$PLIST" <<'PY'
+import plistlib
+import sys
+
+path = sys.argv[1]
+with open(path, 'rb') as fh:
+    info = plistlib.load(fh)
+
+patch_uti = 'com.yangjiii.3105.patch-package'
+patch_scheme = 'threeoneosfive'
+
+document_types = list(info.get('CFBundleDocumentTypes') or [])
+if not any(patch_uti in (entry.get('LSItemContentTypes') or []) for entry in document_types if isinstance(entry, dict)):
+    document_types.append({
+        'CFBundleTypeName': '3105 Patch Package',
+        'CFBundleTypeRole': 'Editor',
+        'LSHandlerRank': 'Owner',
+        'LSItemContentTypes': [patch_uti],
+    })
+info['CFBundleDocumentTypes'] = document_types
+
+url_types = list(info.get('CFBundleURLTypes') or [])
+if not any(patch_scheme in (entry.get('CFBundleURLSchemes') or []) for entry in url_types if isinstance(entry, dict)):
+    url_types.append({
+        'CFBundleURLName': 'com.yangjiii.3105.patch-import',
+        'CFBundleURLSchemes': [patch_scheme],
+    })
+info['CFBundleURLTypes'] = url_types
+
+uti_declarations = list(info.get('UTExportedTypeDeclarations') or [])
+if not any(entry.get('UTTypeIdentifier') == patch_uti for entry in uti_declarations if isinstance(entry, dict)):
+    uti_declarations.append({
+        'UTTypeConformsTo': ['public.data'],
+        'UTTypeDescription': '3105 Patch Package',
+        'UTTypeIdentifier': patch_uti,
+        'UTTypeTagSpecification': {
+            'public.filename-extension': ['3105'],
+            'public.mime-type': 'application/x-3105-patch',
+        },
+    })
+info['UTExportedTypeDeclarations'] = uti_declarations
+info['LSSupportsOpeningDocumentsInPlace'] = True
+
+with open(path, 'wb') as fh:
+    plistlib.dump(info, fh, fmt=plistlib.FMT_XML, sort_keys=False)
+PY
+
+plutil -lint "$PLIST" >/dev/null
+plutil -extract CFBundleDocumentTypes xml1 -o - "$PLIST" | grep -Fq 'com.yangjiii.3105.patch-package'
+plutil -extract CFBundleURLTypes xml1 -o - "$PLIST" | grep -Fq 'threeoneosfive'
+plutil -extract UTExportedTypeDeclarations xml1 -o - "$PLIST" | grep -Fq 'application/x-3105-patch'
+
+echo "Merged 3105 1.0 document and URL import metadata into $PLIST"

--- a/scripts/stage-3105-v1.sh
+++ b/scripts/stage-3105-v1.sh
@@ -71,7 +71,8 @@ grep -Fq 'FileOperationCoordinator' "$ROOT/Sources/FileBrowserView.swift"
 grep -Fq 'importPackage(from:' "$ROOT/Sources/PatchProjectsView.swift"
 grep -Fq 'PatchImportSource' "$ROOT/Sources/PatchDraftCoordinator.swift"
 grep -Fq 'ZIPArchiveWriter' "$ROOT/Sources/FileManagerService.swift"
-grep -Fq 'bulk' "$ROOT/Resources/Filza3105.bundle/en.lproj/Localizable.strings"
+grep -Fq '"cleaner.select_all_results"' "$ROOT/Resources/Filza3105.bundle/en.lproj/Localizable.strings"
+grep -Fq '"browser.copy"' "$ROOT/Resources/Filza3105.bundle/en.lproj/Localizable.strings"
 plutil -lint "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist" >/dev/null
 
 echo "Staged 3105 1.0 from ${UPSTREAM_OWNER}/${UPSTREAM_REPO}@${UPSTREAM_COMMIT}"

--- a/scripts/stage-3105-v1.sh
+++ b/scripts/stage-3105-v1.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="ThirdParty/3105"
+UPSTREAM_OWNER="NightVibes33"
+UPSTREAM_REPO="3105"
+UPSTREAM_COMMIT="438f3ccae6a436d0017185407bc286e55c357883"
+ARCHIVE_URL="https://codeload.github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tar.gz/${UPSTREAM_COMMIT}"
+
+for path in "$ROOT" "$ROOT/Sources" "$ROOT/Resources/Filza3105.bundle"; do
+  test -d "$path" || { echo "Missing 3105 integration path: $path" >&2; exit 1; }
+done
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/filza-3105-v1.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fL --retry 3 --retry-delay 2 "$ARCHIVE_URL" -o "$TMP/3105.tar.gz"
+tar -xzf "$TMP/3105.tar.gz" -C "$TMP"
+SRC="$(find "$TMP" -maxdepth 1 -type d -name '3105-*' -print -quit)"
+test -n "$SRC" || { echo "Could not locate extracted 3105 source tree" >&2; exit 1; }
+UPSTREAM="$SRC/ThreeOneOSFive"
+
+test -f "$UPSTREAM/helpers/FileOperationCoordinator.swift"
+test -f "$UPSTREAM/helpers/ZIPArchiveWriter.swift"
+test -f "$UPSTREAM/views/FileBrowserView.swift"
+test -f "$UPSTREAM/views/PatchProjectsView.swift"
+test -f "$UPSTREAM/Info.plist"
+
+copy_source() {
+  local relative="$1"
+  local destination="$2"
+  test -f "$UPSTREAM/$relative" || { echo "Missing upstream 3105 file: $relative" >&2; exit 1; }
+  cp "$UPSTREAM/$relative" "$ROOT/Sources/$destination"
+}
+
+# Files changed by upstream 1.0. Unchanged Filza-adapted files remain in place.
+copy_source helpers/AppIconHelper.m AppIconHelper.m
+copy_source helpers/CleanerCatalog.swift CleanerCatalog.swift
+copy_source helpers/ContainerBrowserLogic.swift ContainerBrowserLogic.swift
+copy_source helpers/ContainerStore.swift ContainerStore.swift
+copy_source helpers/FileManagerService.swift FileManagerService.swift
+copy_source helpers/FileOperationCoordinator.swift FileOperationCoordinator.swift
+copy_source helpers/PatchDraftCoordinator.swift PatchDraftCoordinator.swift
+copy_source helpers/PatchDraftService.swift PatchDraftService.swift
+copy_source helpers/PatchPackageCodec.swift PatchPackageCodec.swift
+copy_source helpers/PatchProjectLibrary.swift PatchProjectLibrary.swift
+copy_source helpers/PatchProjectModels.swift PatchProjectModels.swift
+copy_source helpers/PatchProjectStore.swift PatchProjectStore.swift
+copy_source helpers/PatchTransaction.swift PatchTransaction.swift
+copy_source helpers/ZIPArchiveWriter.swift ZIPArchiveWriter.swift
+copy_source views/AppDataBrowserView.swift AppDataBrowserView.swift
+copy_source views/CleanerView.swift CleanerView.swift
+copy_source views/FileBrowserView.swift FileBrowserView.swift
+copy_source views/FolderPatchSelectionView.swift FolderPatchSelectionView.swift
+copy_source views/PatchProjectEditorView.swift PatchProjectEditorView.swift
+copy_source views/PatchProjectsView.swift PatchProjectsView.swift
+copy_source views/WallpaperLabView.swift WallpaperLabView.swift
+
+for lang in en vi zh-Hans; do
+  test -f "$UPSTREAM/$lang.lproj/Localizable.strings"
+  mkdir -p "$ROOT/Resources/Filza3105.bundle/$lang.lproj"
+  cp "$UPSTREAM/$lang.lproj/Localizable.strings" \
+     "$ROOT/Resources/Filza3105.bundle/$lang.lproj/Localizable.strings"
+done
+
+# Keep a copy of upstream 1.0's app metadata for deterministic IPA merging.
+cp "$UPSTREAM/Info.plist" "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist"
+
+# Fail closed if the source refresh did not actually bring in 1.0 behavior.
+grep -Fq 'FileOperationCoordinator' "$ROOT/Sources/FileBrowserView.swift"
+grep -Fq 'importPackage(from:' "$ROOT/Sources/PatchProjectsView.swift"
+grep -Fq 'PatchImportSource' "$ROOT/Sources/PatchDraftCoordinator.swift"
+grep -Fq 'ZIPArchiveWriter' "$ROOT/Sources/FileManagerService.swift"
+grep -Fq 'bulk' "$ROOT/Resources/Filza3105.bundle/en.lproj/Localizable.strings"
+plutil -lint "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist" >/dev/null
+
+echo "Staged 3105 1.0 from ${UPSTREAM_OWNER}/${UPSTREAM_REPO}@${UPSTREAM_COMMIT}"


### PR DESCRIPTION
Updates the embedded 3105 workspace from the previous beta-3 source pin to upstream 1.0 (`438f3ccae6a436d0017185407bc286e55c357883`) while retaining Filza-specific hosting/navigation/resource adaptations.

Also fixes Filza's WebDAV settings switch state: the stock `isServerStarted` checks the legacy helper/PID path and never sees the jailed in-process GCDWebDAVServer, causing the switch to behave as if it is always off. The new shim makes `isServerStarted` reflect the in-process listener and synchronizes the existing `air-browser` preference.

The stable `main` baseline is intentionally unchanged until the full arm64/IPA workflow passes.

## Summary by Sourcery

Update Filza’s embedded 3105 workspace to upstream 1.0 while wiring external document/URL imports into the embedded Patches UI and correcting WebDAV settings toggle state persistence.

New Features:
- Support opening 3105 patch packages and custom threeoneosfive:// URLs directly into the embedded 3105 Patches workspace from Filza and other apps.
- Enable full 3105 1.0 file operations, cleaner improvements, patch imports, ZIP handling, and updated localization within the embedded workspace.
- Expose the 3105 patch document type and URL scheme in Filza’s Info.plist so the app owns 3105 patch files and import URLs.

Bug Fixes:
- Fix WebDAV settings switch so it reflects the actual in-process GCDWebDAVServer listener state and keeps the air-browser preference synchronized.

Enhancements:
- Embed the 3105 1.0 FileOperationCoordinator and related helpers into Filza’s host, maintaining persistent Close controls and multi-tab routing.
- Route initial external 3105 imports into the Patches tab on first appearance and ensure tab selection tracks ongoing import requests.
- Improve diagnostics around 3105 workspace presentation, external import routing, and WebDAV toggle behavior.

Build:
- Add QuickLook to the tweak’s linked frameworks and introduce a pinned staging script to overlay the exact 3105 1.0 upstream sources and resources before Swift compilation.
- Integrate a metadata merge script into the IPA build to inject 3105 document/URL handling entries into Filza.app’s Info.plist and copy the staged Filza3105.bundle into the app bundle.
- Extend pre-build sanity checks to require 3105 1.0 coordinators, ZIP writer, resources, metadata, and the WebDAV toggle fix to be present.

Documentation:
- Document the new 3105 1.0 source pin, staging workflow, and Filza-specific embedding adaptations in UPSTREAM.md.