### PR TITLE
Port full current mond root and fix WebDAV OFF transition

### DIFF
--- a/.github/workflows/verify-safe-fixes.yml
+++ b/.github/workflows/verify-safe-fixes.yml
@@ -19,6 +19,7 @@ jobs:
       BYETUNES_COMMIT: 8a4be32f188f30b98f15b00566c5ff3edc1c03b1
       BAD_QUERY_COMMIT: 73ef6da1adabef0982fd00e36cb85f21b8f8194a
       THREEONE_COMMIT: 438f3ccae6a436d0017185407bc286e55c357883
+      MOND_COMMIT: 4a37bfca5cb4abb2c99891972365d872d700525e
       IDEVICE_COMMIT: 37ee77cf713f483551f3cf33ea8b2087a40058ca
       THEOS_COMMIT: 5280bd038207e14f8bd76f5417aa2fe641c03228
       BASE_IPA_SHA256: b11ce30a2db6f6bc77773ed30bdb855d7c847830891b14d21230f2d893d5f223
@@ -63,9 +64,14 @@ jobs:
           test -f ThirdParty/3105/Sources/ThreeOneOSFiveContentView.swift
           test -f ThirdParty/3105/Sources/FileOperationCoordinator.swift
           test -f ThirdParty/3105/Sources/ZIPArchiveWriter.swift
+          test -f MondFullRootHost.swift
+          test -f ThirdParty/mond/UPSTREAM.md
           test -f WebDAVToggleStateFix.m
           test -f ThirdParty/GCDWebServer/GCDWebDAVServer/GCDWebDAVServer.m
           grep -Fq "$THREEONE_COMMIT" scripts/stage-3105-v1.sh
+          grep -Fq "$MOND_COMMIT" ThirdParty/mond/UPSTREAM.md
+          grep -Fq "$MOND_COMMIT" MondFullRootHost.swift
+          grep -Fq 'MondFullRootHost.swift' Makefile
           grep -Fq 'stage-3105-v1.sh' Makefile
           grep -Fq 'patch-byetunes-upstream-parity-v2.sh' Makefile
           grep -Fq 'patch-byetunes-metadata-parity-post.sh' Makefile
@@ -184,13 +190,25 @@ jobs:
 
           grep -aFq 'Gestalt Editor' "$DYLIB"
           grep -aFq 'MondGestaltHostFactory' "$DYLIB"
+          grep -aFq 'MondFullHostFactory' "$DYLIB"
+          grep -aFq 'constructing full current mond root commit=' "$DYLIB"
+          grep -aFq 'full upstream root appeared commit=' "$DYLIB"
+          grep -aFq "$MOND_COMMIT" "$DYLIB"
+          grep -aFq 'Run Exploit' "$DYLIB"
+          grep -aFq 'Generate Token' "$DYLIB"
+          grep -aFq 'Keep Alive' "$DYLIB"
+          grep -aFq 'Respring' "$DYLIB"
+          grep -aFq 'HouseArrest is still in development' "$DYLIB"
           grep -aFq 'Filza3105HostFactory' "$DYLIB"
           grep -aFq 'ByeTunesEmbeddedHostFactory' "$DYLIB"
           grep -aFq 'TGMainView direct full ByeTunes route installed' "$DYLIB"
           grep -aFq 'ByeTunes 2.4 background URL session route installed on Filza AppDelegate' "$DYLIB"
           grep -aFq 'jailed in-process WebDAV lifecycle hook installed' "$DYLIB"
-          grep -aFq 'toggle-state fix installed: isServerStarted now reflects in-process listener' "$DYLIB"
-          grep -aFq 'settings toggle synchronized visible-state=' "$DYLIB"
+          grep -aFq 'toggle-state fix installed: listener getter is observation-only and OFF transitions are explicit' "$DYLIB"
+          grep -aFq 'settings toggle requested ' "$DYLIB"
+          grep -aFq 'toggle transition complete desired=' "$DYLIB"
+          ! grep -aFq 'toggle-state fix installed: isServerStarted now reflects in-process listener' "$DYLIB"
+          ! grep -aFq 'settings toggle synchronized visible-state=' "$DYLIB"
 
           grep -aFq 'full upstream 3105 1.0 workspace appeared' "$DYLIB"
           grep -aFq 'constructing 3105 1.0 Patches for external import' "$DYLIB"
@@ -291,6 +309,9 @@ jobs:
           bash scripts/merge-3105-app-metadata.sh "$APP/Info.plist"
 
           test -s "$APP/Frameworks/FilzaApplySandboxExt.dylib"
+          grep -aFq 'MondFullHostFactory' "$APP/Frameworks/FilzaApplySandboxExt.dylib"
+          grep -aFq "$MOND_COMMIT" "$APP/Frameworks/FilzaApplySandboxExt.dylib"
+          grep -aFq 'toggle transition complete desired=' "$APP/Frameworks/FilzaApplySandboxExt.dylib"
           test -s "$APP/AppIconImage.png"
           test -s "$APP/Config.plist"
           test -s "$APP/Filza3105.bundle/Info.plist"
@@ -330,6 +351,7 @@ jobs:
             ThirdParty/3105/Resources/Filza3105.bundle/UpstreamAppInfo.plist
             ThirdParty/3105/UPSTREAM.md
             ThirdParty/3105/LICENSE
+            ThirdParty/mond/UPSTREAM.md
           if-no-files-found: error
           include-hidden-files: true
           retention-days: 14

--- a/FilzaMondBridge.m
+++ b/FilzaMondBridge.m
@@ -6,6 +6,8 @@
 #import "FilzaMondBridge.h"
 #import "GestaltManager.h"
 
+static NSString * const FMCanonicalGestaltPath = @"/private/var/containers/Shared/SystemGroup/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist";
+
 static UIViewController *FMActiveController(void)
 {
     UIWindow *window = nil;
@@ -42,7 +44,7 @@ static UIViewController *FMActiveController(void)
 static void FMShowUnavailable(UIViewController *source, NSString *message)
 {
     UIAlertController *alert = [UIAlertController
-        alertControllerWithTitle:@"Gestalt Editor unavailable"
+        alertControllerWithTitle:@"mond unavailable"
         message:message
         preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"OK"
@@ -52,26 +54,26 @@ static void FMShowUnavailable(UIViewController *source, NSString *message)
 
 static UIViewController *FMCreateHost(NSString *path)
 {
-    Class factory = NSClassFromString(@"MondGestaltHostFactory");
+    Class factory = NSClassFromString(@"MondFullHostFactory");
     SEL selector = NSSelectorFromString(@"makeViewControllerWithPath:");
     if (!factory || ![factory respondsToSelector:selector]) {
-        FilzaDiagnosticsAppend(@"Gestalt", @"complete embedded Gestalt host factory unavailable");
+        FilzaDiagnosticsAppend(@"mond", @"full current mond host factory unavailable");
         return nil;
     }
 
     UIViewController *controller =
-        ((id (*)(id, SEL, id))objc_msgSend)(factory, selector, path);
+        ((id (*)(id, SEL, id))objc_msgSend)(factory, selector, path ?: FMCanonicalGestaltPath);
     if (![controller isKindOfClass:UIViewController.class]) {
-        FilzaDiagnosticsAppend(@"Gestalt", @"complete embedded Gestalt host returned no controller");
+        FilzaDiagnosticsAppend(@"mond", @"full current mond host returned no controller");
         return nil;
     }
     return controller;
 }
 
-@interface FMGestaltNavigationController : UINavigationController
+@interface FMMondNavigationController : UINavigationController
 @end
 
-@implementation FMGestaltNavigationController
+@implementation FMMondNavigationController
 - (void)fm_close
 {
     [self dismissViewControllerAnimated:YES completion:nil];
@@ -82,7 +84,7 @@ static BOOL FMPresentHost(UIViewController *source, NSString *path)
 {
     UIViewController *controller = FMCreateHost(path);
     if (!controller) {
-        FMShowUnavailable(source, @"The complete Gestalt Editor could not be created.");
+        FMShowUnavailable(source, @"The full mond workspace could not be created.");
         return NO;
     }
 
@@ -90,16 +92,17 @@ static BOOL FMPresentHost(UIViewController *source, NSString *path)
     if (navigation && !source.presentedViewController) {
         [navigation pushViewController:controller animated:YES];
     } else {
-        FMGestaltNavigationController *wrapper =
-            [[FMGestaltNavigationController alloc] initWithRootViewController:controller];
+        FMMondNavigationController *wrapper =
+            [[FMMondNavigationController alloc] initWithRootViewController:controller];
         controller.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
             initWithBarButtonSystemItem:UIBarButtonSystemItemClose
             target:wrapper action:@selector(fm_close)];
         wrapper.modalPresentationStyle = UIModalPresentationFullScreen;
         [source presentViewController:wrapper animated:YES completion:nil];
     }
-    FilzaDiagnosticsAppend(@"Gestalt",
-        [NSString stringWithFormat:@"presented complete Gestalt Editor directly using %@", path]);
+    FilzaDiagnosticsAppend(@"mond",
+        [NSString stringWithFormat:@"presented full current mond workspace using Gestalt path %@",
+         path ?: FMCanonicalGestaltPath]);
     return YES;
 }
 
@@ -108,28 +111,27 @@ void FilzaMondPresentFromController(UIViewController *source)
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *presenter = source ?: FMActiveController();
         if (!presenter) {
-            FilzaDiagnosticsAppend(@"Gestalt", @"no presenter available");
+            FilzaDiagnosticsAppend(@"mond", @"no presenter available");
             return;
         }
 
+        // Resolve/prewarm MobileGestalt in the background, but never make mond's
+        // root UI conditional on Gestalt access.  Upstream mond opens first and
+        // lets Settings > Run Exploit change access/method at runtime.
         __weak UIViewController *weakPresenter = presenter;
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
             NSString *detail = nil;
-            NSString *path = FilzaGestaltResolvePath(&detail);
+            NSString *resolvedPath = FilzaGestaltResolvePath(&detail);
+            NSString *hostPath = resolvedPath.length ? resolvedPath : FMCanonicalGestaltPath;
+            FilzaDiagnosticsAppend(@"mond", resolvedPath.length
+                ? [NSString stringWithFormat:@"prewarmed MobileGestalt access: %@", detail ?: resolvedPath]
+                : [NSString stringWithFormat:@"opening mond before Gestalt access; Settings can run exploit: %@",
+                   detail ?: @"no access yet"]);
+
             dispatch_async(dispatch_get_main_queue(), ^{
                 UIViewController *resolvedPresenter = weakPresenter ?: FMActiveController();
                 if (!resolvedPresenter) return;
-                if (!path.length) {
-                    NSString *reason = detail ?:
-                        @"The MobileGestalt property list could not be opened.";
-                    FilzaDiagnosticsAppend(@"Gestalt",
-                        [NSString stringWithFormat:@"MobileGestalt access failed: %@", reason]);
-                    FMShowUnavailable(resolvedPresenter, reason);
-                    return;
-                }
-                FilzaDiagnosticsAppend(@"Gestalt",
-                    [NSString stringWithFormat:@"verified MobileGestalt access: %@", detail ?: path]);
-                FMPresentHost(resolvedPresenter, path);
+                FMPresentHost(resolvedPresenter, hostPath);
             });
         });
     });
@@ -145,8 +147,9 @@ __attribute__((constructor)) static void FilzaMondPrewarm(void)
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
         NSString *detail = nil;
         NSString *path = FilzaGestaltResolvePath(&detail);
-        FilzaDiagnosticsAppend(@"Gestalt", path.length
-            ? @"prewarmed MobileGestalt access for direct presentation"
-            : [NSString stringWithFormat:@"MobileGestalt prewarm unavailable: %@", detail ?: @"unknown"]);
+        FilzaDiagnosticsAppend(@"mond", path.length
+            ? @"prewarmed MobileGestalt access for full mond root"
+            : [NSString stringWithFormat:@"MobileGestalt prewarm unavailable; mond remains launchable: %@",
+               detail ?: @"unknown"]);
     });
 }

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ BYETUNES_SWIFT_FILES := $(shell find $(BYETUNES_ROOT) -type f -name '*.swift' ! 
 # exact immutable 1.0 upstream files before compilation while preserving the
 # Filza-only root/settings namespace and host glue.
 THREEONE_SWIFT_FILES := $(shell find $(THREEONE_ROOT)/Sources -type f -name '*.swift' -print)
-FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift ByeTunesMetadataCompat.swift ByeTunesDownloadParityCompat.swift MondGestaltView.swift Filza3105Host.swift $(THREEONE_SWIFT_FILES) $(BYETUNES_SWIFT_FILES) $(BYETUNES_ACTIVITY_SHARED)
+FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift ByeTunesMetadataCompat.swift ByeTunesDownloadParityCompat.swift MondGestaltView.swift MondFullRootHost.swift Filza3105Host.swift $(THREEONE_SWIFT_FILES) $(BYETUNES_SWIFT_FILES) $(BYETUNES_ACTIVITY_SHARED)
 
 FilzaApplySandboxExt_CFLAGS = -I$(PWD)/compat -I$(PWD) -I$(PWD)/XPF/src -I$(PWD)/XPF/external/ChOma/include -I$(IDEVICE_VENDOR)/include -I$(PWD)/$(BAD_QUERY_ROOT)/bad_query -I$(PWD)/$(THREEONE_ROOT)/Sources \
     -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Core -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Requests -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Responses -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebDAVServer \
@@ -94,6 +94,7 @@ before-FilzaApplySandboxExt-all::
 	@test -f "FilzaMondBridge.m" || (echo "Missing FilzaMondBridge.m" >&2; exit 1)
 	@test -f "FilzaMainToolbarGestalt.m" || (echo "Missing FilzaMainToolbarGestalt.m" >&2; exit 1)
 	@test -f "MondGestaltView.swift" || (echo "Missing MondGestaltView.swift" >&2; exit 1)
+	@test -f "MondFullRootHost.swift" || (echo "Missing full current mond root host" >&2; exit 1)
 	@test -f "Filza3105Host.swift" || (echo "Missing Filza3105Host.swift" >&2; exit 1)
 	@test -f "Filza3105Bridge.m" || (echo "Missing Filza3105Bridge.m" >&2; exit 1)
 	@test -f "scripts/stage-3105-v1.sh" || (echo "Missing pinned 3105 1.0 staging script" >&2; exit 1)

--- a/MondFullRootHost.swift
+++ b/MondFullRootHost.swift
@@ -1,0 +1,468 @@
+import SwiftUI
+import UIKit
+import AVFoundation
+import WebKit
+import Combine
+
+// Full embedded mond shell based on rooootdev/mond main at
+// 4a37bfca5cb4abb2c99891972365d872d700525e.  Filza remains the UIApplication
+// owner, so mond's @main entry point is adapted into this host while its current
+// navigation hierarchy and settings behavior are preserved.
+
+private let mondEmbeddedUpstreamCommit = "4a37bfca5cb4abb2c99891972365d872d700525e"
+private let mondEmbeddedCanonicalGestaltPath = "/private/var/containers/Shared/SystemGroup/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist"
+
+private func mondRootIssueSandboxToken(path: String) -> String? {
+    typealias IssueFunction = @convention(c) (
+        UnsafePointer<CChar>?, UnsafePointer<CChar>?, Int32, Int32
+    ) -> UnsafeMutablePointer<CChar>?
+    guard let library = dlopen("/usr/lib/system/libsystem_sandbox.dylib", RTLD_NOW) else { return nil }
+    defer { dlclose(library) }
+    guard let symbol = dlsym(library, "sandbox_extension_issue_file") else { return nil }
+    let issue = unsafeBitCast(symbol, to: IssueFunction.self)
+    let pointer = path.withCString {
+        issue("com.apple.app-sandbox.read-write", $0, 0, 0)
+    }
+    guard let pointer else { return nil }
+    defer { free(pointer) }
+    return String(cString: pointer)
+}
+
+private func mondRootConsumeSandboxToken(_ token: String) -> Int64? {
+    typealias ConsumeFunction = @convention(c) (UnsafePointer<CChar>?) -> Int64
+    guard !token.isEmpty,
+          let library = dlopen("/usr/lib/system/libsystem_sandbox.dylib", RTLD_NOW) else { return nil }
+    defer { dlclose(library) }
+    guard let symbol = dlsym(library, "sandbox_extension_consume") else { return nil }
+    let consume = unsafeBitCast(symbol, to: ConsumeFunction.self)
+    return token.withCString { consume($0) }
+}
+
+private var mondRootKeepAlivePlayer: AVAudioPlayer?
+private var mondRootKeepAliveTimer: Timer?
+
+@MainActor
+private func mondRootKeepAlive() {
+    guard mondRootKeepAlivePlayer == nil else { return }
+    try? AVAudioSession.sharedInstance().setCategory(.playback, options: .mixWithOthers)
+    try? AVAudioSession.sharedInstance().setActive(true)
+
+    let sampleRate = 8_000
+    let samples = Int(Double(sampleRate) * 0.5)
+    var wave = Data("RIFF".utf8)
+    wave.append(withUnsafeBytes(of: UInt32(36 + samples * 2).littleEndian) { Data($0) })
+    wave.append(Data("WAVEfmt ".utf8))
+    wave.append(withUnsafeBytes(of: UInt32(16).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt16(1).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt16(1).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt32(sampleRate).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt32(sampleRate * 2).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt16(2).littleEndian) { Data($0) })
+    wave.append(withUnsafeBytes(of: UInt16(16).littleEndian) { Data($0) })
+    wave.append(Data("data".utf8))
+    wave.append(withUnsafeBytes(of: UInt32(samples * 2).littleEndian) { Data($0) })
+    wave.append(Data(count: samples * 2))
+
+    mondRootKeepAlivePlayer = try? AVAudioPlayer(data: wave)
+    mondRootKeepAlivePlayer?.volume = 0
+    mondRootKeepAlivePlayer?.numberOfLoops = -1
+    mondRootKeepAlivePlayer?.play()
+    mondRootKeepAliveTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+        mondRootKeepAlivePlayer?.play()
+    }
+    FilzaDiagnosticsAppend("mond", "Keep Alive started")
+}
+
+@MainActor
+private func mondRootLetDie() {
+    mondRootKeepAliveTimer?.invalidate()
+    mondRootKeepAliveTimer = nil
+    mondRootKeepAlivePlayer?.stop()
+    mondRootKeepAlivePlayer = nil
+    try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    FilzaDiagnosticsAppend("mond", "Keep Alive stopped")
+}
+
+private let mondRootRespringDocument = """
+<!DOCTYPE html><html><body>
+<iframe id="frame" srcdoc="" sandbox="allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-presentation allow-scripts"></iframe>
+<script>
+const frame=document.getElementById('frame');
+const r=`<html><body><script>
+const c=document.createElement('div');c.style.cssText='perspective:1px;perspective-origin:9999999% 9999999%;';document.body.appendChild(c);
+for(let i=0;i<500;i++){const d=document.createElement('div');d.style.cssText='position:absolute;width:100vw;height:100vh;backdrop-filter:blur(100px);-webkit-backdrop-filter:blur(100px);transform:translate3d(100000px,100000px,'+i+'px) rotateY(90deg);';c.appendChild(d);}
+setInterval(()=>{navigator.share({title:'R',text:'R'.repeat(100000)}).catch(()=>{});const x=new Uint8Array(1024*1024*10);crypto.getRandomValues(x);},0);
+<\\/script></body></html>`;frame.srcdoc=r;
+</script></body></html>
+"""
+
+private struct MondRootRespringView: UIViewRepresentable {
+    func makeUIView(context: Context) -> WKWebView { WKWebView() }
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        webView.loadHTMLString(mondRootRespringDocument, baseURL: nil)
+    }
+}
+
+private struct MondEmbeddedLogView: View {
+    @State private var log = ""
+    private let timer = Timer.publish(every: 0.35, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollViewReader { proxy in
+                ScrollView(showsIndicators: false) {
+                    Text(log.isEmpty ? "mond logs will appear here." : log)
+                        .font(.system(size: 10, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                        .padding(16)
+                    Color.clear.frame(height: 1).id("mond-log-bottom")
+                }
+                .frame(minHeight: 205, maxHeight: max(205, geometry.size.height))
+                .background(Color(uiColor: .secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+                .onAppear {
+                    reload()
+                    proxy.scrollTo("mond-log-bottom", anchor: .bottom)
+                }
+                .onReceive(timer) { _ in
+                    let old = log
+                    reload()
+                    if old != log { proxy.scrollTo("mond-log-bottom", anchor: .bottom) }
+                }
+                .contextMenu {
+                    Button {
+                        UIPasteboard.general.string = log
+                    } label: {
+                        Label("Copy Output", systemImage: "doc.on.doc")
+                    }
+                }
+            }
+        }
+        .frame(height: 240)
+    }
+
+    private func reload() {
+        let url = URL(fileURLWithPath: FilzaDiagnosticsDirectory(), isDirectory: true)
+            .appendingPathComponent("Runtime.log")
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return }
+        let relevant = text.split(separator: "\n", omittingEmptySubsequences: true).filter { line in
+            let value = line.lowercased()
+            return value.contains("mond") || value.contains("gestalt") ||
+                   value.contains("bad_query") || value.contains("(bq)") ||
+                   value.contains("cmg") || value.contains("poster") ||
+                   value.contains("housearrest") || value.contains("mcm")
+        }
+        log = relevant.suffix(180).joined(separator: "\n")
+    }
+}
+
+private struct MondGestaltControllerDestination: UIViewControllerRepresentable {
+    let path: String
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        let controller = MondGestaltHostFactory.makeViewController(path: path)
+        controller.title = "MobileGestalt"
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+private struct MondPosterBoardDestination: View {
+    var body: some View {
+        // Filza already carries the complete current PosterBoard workspace and
+        // its validated archive/write path.  Expose it at mond's PosterBoard
+        // destination instead of duplicating a second write engine.
+        WallpaperLabView()
+    }
+}
+
+private struct MondCurrentSettingsView: View {
+    let gestaltPath: String
+
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("method") private var method = "bad_query"
+    @AppStorage("ka_on") private var keepAlive = true
+    @AppStorage("token") private var token = ""
+
+    @State private var exploitSucceeded = false
+    @State private var accessStatus = ""
+    @State private var runningExploit = false
+    @State private var showConfirm = false
+    @State private var showRespring = false
+
+    private var gestaltDirectory: String {
+        (gestaltPath as NSString).deletingLastPathComponent
+    }
+
+    private var tokenValid: Bool {
+        !token.isEmpty && (mondRootConsumeSandboxToken(token) ?? -1) >= 0
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Button {
+                        if let url = URL(string: "https://github.com/rooootdev/mond") {
+                            UIApplication.shared.open(url)
+                        }
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "moon.stars.fill")
+                                .font(.title2)
+                                .frame(width: 45, height: 45)
+                                .background(.quaternary, in: RoundedRectangle(cornerRadius: 12))
+                            VStack(alignment: .leading) {
+                                Text("mond").font(.headline)
+                                Text(String(mondEmbeddedUpstreamCommit.prefix(7)))
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .fontWeight(.semibold)
+                                .foregroundStyle(.tertiary)
+                                .imageScale(.small)
+                        }
+                    }
+                    .foregroundStyle(.primary)
+                }
+
+                Section {
+                    Picker("Method", selection: $method) {
+                        Text("bad_query").tag("bad_query")
+                        Text("cmg").tag("cmg")
+                    }
+                    .pickerStyle(.segmented)
+
+                    Button(runningExploit ? "Running…" : "Run Exploit") {
+                        runExploit()
+                    }
+                    .disabled(runningExploit)
+                } header: {
+                    Label("Exploit", systemImage: "wrench.and.screwdriver")
+                } footer: {
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(method == "cmg"
+                             ? "**CMG:** Supports iOS 27.0 b1 - b4. PosterBoard wont work with this method. Only use this when bad_query isnt working for you."
+                             : "**bad_query:** Supports iOS 27.0 b1 - b4. By [forcequit](https://github.com/forcequitOS).")
+                        if !accessStatus.isEmpty { Text(accessStatus) }
+                    }
+                }
+
+                Section {
+                    HStack {
+                        TextField("Sandbox Extension Token.", text: $token)
+                            .lineLimit(1)
+                        Spacer()
+                        Button {
+                            UIPasteboard.general.string = token
+                        } label: {
+                            Image(systemName: "document.on.document")
+                        }
+                        .disabled(token.isEmpty)
+                    }
+                    .contextMenu {
+                        Text("Class: \(token.split(separator: ";").first { $0.contains("com.apple") }.map(String.init) ?? "N/A")")
+                        Text("Path: \(token.split(separator: ";").last.map(String.init) ?? "N/A")")
+                        Button {
+                            UIPasteboard.general.string = token
+                        } label: {
+                            Label("Copy token", systemImage: "doc.on.doc")
+                        }
+                    }
+
+                    Button("Generate Token") { generateToken() }
+                        .disabled(!exploitSucceeded)
+                } header: {
+                    Label("Token", systemImage: "key")
+                } footer: {
+                    if !token.isEmpty && token != "Failed to get token." {
+                        Text(tokenValid ? "Your sandbox token is valid." : "Your sandbox token is invalid.")
+                    }
+                    if !exploitSucceeded {
+                        Text("Disabled because exploit access has not been verified. Run Exploit first.")
+                    }
+                }
+
+                Section {
+                    Toggle("Keep Alive", isOn: $keepAlive)
+                        .onChange(of: keepAlive) { enabled in
+                            if enabled { mondRootKeepAlive() } else { mondRootLetDie() }
+                        }
+                } header: {
+                    Label("Settings", systemImage: "gear")
+                }
+
+                Section {
+                    Button("Respring") { showConfirm = true }
+                } header: {
+                    Label("Tools", systemImage: "wrench.and.screwdriver")
+                } footer: {
+                    Text("Respring method by [neon](https://github.com/neonmodder123), swift implementation by [skadz](https://github.com/skadz108).")
+                }
+
+                Section {
+                    Link("roooot — Main developer", destination: URL(string: "https://github.com/rooootdev")!)
+                    Link("forcequit — The bad_query exploit", destination: URL(string: "https://github.com/forcequitOS")!)
+                    Link("johnny — MCM bug-class work", destination: URL(string: "https://github.com/0xjohnnydev")!)
+                    Link("jailbreak.party — PartyUI / GestaltView", destination: URL(string: "https://github.com/jailbreakdotparty")!)
+                } header: {
+                    Label("Credits", systemImage: "person.3.fill")
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .onAppear {
+                method = FilzaGestaltPreferredMethod()
+                exploitSucceeded = FileManager.default.isReadableFile(atPath: gestaltPath)
+                if keepAlive { mondRootKeepAlive() }
+            }
+            .onChange(of: method) { newMethod in
+                FilzaGestaltSetPreferredMethod(newMethod)
+                exploitSucceeded = false
+                accessStatus = "Method changed to \(newMethod). Tap Run Exploit to refresh access."
+            }
+            .alert("Are you sure?", isPresented: $showConfirm) {
+                Button("Cancel", role: .cancel) {}
+                Button("Confirm") {
+                    FilzaDiagnosticsAppend("mond", "Respring confirmed")
+                    showRespring = true
+                }
+            } message: {
+                Text("Confirm that you want to respring.")
+            }
+            .overlay {
+                if showRespring {
+                    MondRootRespringView()
+                        .brightness(-1.0)
+                        .ignoresSafeArea()
+                }
+            }
+        }
+    }
+
+    private func runExploit() {
+        FilzaGestaltSetPreferredMethod(method)
+        runningExploit = true
+        accessStatus = "Running \(method)…"
+        FilzaDiagnosticsAppend("mond", "Run Exploit selected method=\(method)")
+        DispatchQueue.global(qos: .userInitiated).async {
+            var detail: NSString?
+            let path = FilzaGestaltRefreshAccess(&detail)
+            DispatchQueue.main.async {
+                runningExploit = false
+                let detailText = detail.map(String.init)
+                exploitSucceeded = path?.isEmpty == false
+                if let path, !path.isEmpty {
+                    accessStatus = detailText ?? "Access active: \(path)"
+                    FilzaDiagnosticsAppend("mond", "exploit access active path=\(path)")
+                } else {
+                    accessStatus = detailText ?? "Access failed"
+                    FilzaDiagnosticsAppend("mond", "exploit access failed: \(accessStatus)")
+                }
+            }
+        }
+    }
+
+    private func generateToken() {
+        guard let generated = mondRootIssueSandboxToken(path: gestaltDirectory) else {
+            token = "Failed to get token."
+            FilzaDiagnosticsAppend("mond", "Generate Token failed")
+            return
+        }
+        token = generated
+        FilzaDiagnosticsAppend("mond", "Generate Token completed")
+    }
+}
+
+private struct MondCurrentRootView: View {
+    let gestaltPath: String
+
+    @AppStorage("method") private var method = "bad_query"
+    @State private var showSettings = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    MondEmbeddedLogView()
+                        .listRowInsets(EdgeInsets(top: 14, leading: 18, bottom: 14, trailing: 18))
+                } header: {
+                    Label("Logs", systemImage: "apple.terminal")
+                }
+
+                Section {
+                    NavigationLink {
+                        MondGestaltControllerDestination(path: gestaltPath)
+                            .ignoresSafeArea(edges: .bottom)
+                    } label: {
+                        Text("MobileGestalt")
+                    }
+
+                    NavigationLink {
+                        MondPosterBoardDestination()
+                    } label: {
+                        Text("PosterBoard")
+                    }
+                    .disabled(method == "cmg")
+
+                    NavigationLink {
+                        Text("HouseArrest is still in development and is not enabled in the current upstream build.")
+                            .padding()
+                            .navigationTitle("HouseArrest")
+                    } label: {
+                        Text("HouseArrest")
+                    }
+                    .disabled(true)
+                } header: {
+                    Label("Tweaks", systemImage: "paintbrush")
+                } footer: {
+                    if method == "cmg" {
+                        Text("Only MobileGestalt is available when method is set to cmg.\nHouseArrest is still in development and may not work as expected.")
+                    } else {
+                        Text("HouseArrest is still in development and may not work as expected.")
+                    }
+                }
+            }
+            .navigationTitle("mond")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showSettings = true
+                    } label: {
+                        Image(systemName: "gear")
+                    }
+                }
+            }
+            .sheet(isPresented: $showSettings) {
+                MondCurrentSettingsView(gestaltPath: gestaltPath)
+            }
+            .onAppear {
+                method = FilzaGestaltPreferredMethod()
+                FilzaDiagnosticsAppend("mond",
+                    "full upstream root appeared commit=\(mondEmbeddedUpstreamCommit)")
+            }
+        }
+    }
+}
+
+@objc(MondFullHostFactory)
+public final class MondFullHostFactory: NSObject {
+    @objc(makeViewControllerWithPath:)
+    public static func makeViewController(path: String) -> UIViewController {
+        let effectivePath = path.isEmpty ? mondEmbeddedCanonicalGestaltPath : path
+        FilzaDiagnosticsAppend("mond",
+            "constructing full current mond root commit=\(mondEmbeddedUpstreamCommit)")
+        let controller = UIHostingController(rootView: MondCurrentRootView(gestaltPath: effectivePath))
+        controller.title = "mond"
+        controller.view.backgroundColor = .systemGroupedBackground
+        return controller
+    }
+}

--- a/ThirdParty/mond/UPSTREAM.md
+++ b/ThirdParty/mond/UPSTREAM.md
@@ -1,0 +1,21 @@
+# mond integration provenance
+
+The embedded mond workspace is adapted from:
+
+- Repository: `rooootdev/mond`
+- Branch inspected: `main`
+- Pinned commit: `4a37bfca5cb4abb2c99891972365d872d700525e`
+- Commit message: `Update ContentView.swift`
+
+The current upstream root at that commit contains:
+
+- `mond/views/App/ContentView.swift` — `mond` navigation root, Logs, MobileGestalt, PosterBoard, disabled HouseArrest, Settings toolbar
+- `mond/views/App/LogView.swift` — live terminal-style output
+- `mond/views/App/SettingsView.swift` — bad_query/cmg selector, Run Exploit, sandbox token, Keep Alive, Respring, credits
+- `mond/views/Tweaks/GestaltView.swift` — MobileGestalt editor
+- `mond/views/Tweaks/PosterView.swift` — PosterBoard UI
+- `mond/views/Tweaks/SantanderView.swift` — HouseArrest work-in-progress UI
+
+Filza remains the owning iOS application, so upstream's `@main struct mond: App` cannot be embedded verbatim. `MondFullRootHost.swift` adapts the current root/settings lifecycle into a `UIHostingController`, while the existing complete Gestalt implementation and Filza's validated PosterBoard workspace are used as the corresponding destinations. The visible navigation hierarchy and current upstream HouseArrest availability/footer are preserved.
+
+Do not update this pin without comparing the upstream root/settings/tweak views and rebuilding the complete arm64 IPA.

--- a/WebDAVToggleStateFix.m
+++ b/WebDAVToggleStateFix.m
@@ -6,17 +6,13 @@
 
 #import "FilzaDiagnostics.h"
 
-// The original Filza settings action decides whether the WebDAV switch is ON
-// by calling TGPreferences.isServerStarted, then reloads the whole settings
-// section. In the jailed build that method only checks the legacy root-helper
-// process/PID-file path, so it always reports NO even while our in-process
-// GCDWebDAVServer is listening. Every tap therefore becomes another "start"
-// and the visible switch snaps back to OFF.
-//
-// Make the existing UI authoritative again by teaching isServerStarted about
-// TGPreferences.httpServer.isRunning. Then mirror the resulting listener state
-// into the existing air-browser preference so launch/resume persistence and the
-// settings row remain synchronized.
+// Filza's stock WebDAV settings row asks TGPreferences.isServerStarted to
+// decide whether a tap means Start or Stop.  The jailed build uses an
+// in-process GCDWebDAVServer rather than Filza's legacy helper/PID path, so the
+// getter must observe that listener.  It must NOT mutate the air-browser
+// preference: doing so from a state getter creates a feedback loop where an
+// in-flight stop is observed as still-running and the preference is forced
+// back to YES before the server has finished stopping.
 
 static BOOL (*FilzaPreviousIsServerStarted)(id, SEL) = NULL;
 static void (*FilzaPreviousWebDAVCheckbox)(id, SEL) = NULL;
@@ -30,62 +26,126 @@ static id FilzaWebDAVToggleSharedPreferences(void)
     return ((id (*)(id, SEL))objc_msgSend)(cls, selector);
 }
 
+static id FilzaWebDAVToggleHTTPServer(id preferences)
+{
+    SEL selector = NSSelectorFromString(@"httpServer");
+    if (!preferences || ![preferences respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL))objc_msgSend)(preferences, selector);
+}
+
 static BOOL FilzaWebDAVToggleInProcessServerRunning(id preferences)
 {
-    SEL httpServerSelector = NSSelectorFromString(@"httpServer");
-    if (!preferences || ![preferences respondsToSelector:httpServerSelector]) return NO;
-    id server = ((id (*)(id, SEL))objc_msgSend)(preferences, httpServerSelector);
-    if (!server) return NO;
-
+    id server = FilzaWebDAVToggleHTTPServer(preferences);
     SEL runningSelector = NSSelectorFromString(@"isRunning");
-    if (![server respondsToSelector:runningSelector]) return NO;
+    if (!server || ![server respondsToSelector:runningSelector]) return NO;
     return ((BOOL (*)(id, SEL))objc_msgSend)(server, runningSelector);
 }
 
 static BOOL FilzaWebDAVToggleIsServerStarted(id preferences, SEL selector)
 {
-    if (FilzaWebDAVToggleInProcessServerRunning(preferences)) return YES;
+    id server = FilzaWebDAVToggleHTTPServer(preferences);
+    if (server && [server respondsToSelector:NSSelectorFromString(@"isRunning")]) {
+        // Observation only.  Never write UserDefaults from this getter.
+        return FilzaWebDAVToggleInProcessServerRunning(preferences);
+    }
     return FilzaPreviousIsServerStarted
         ? FilzaPreviousIsServerStarted(preferences, selector)
         : NO;
 }
 
-static void FilzaWebDAVTogglePersistRunningState(void)
+static void FilzaWebDAVToggleSetEnabledPreference(id preferences, BOOL enabled)
 {
-    id preferences = FilzaWebDAVToggleSharedPreferences();
-    if (!preferences) return;
+    SEL selector = NSSelectorFromString(@"setObject:forPreferenceKey:notification:");
+    if (!preferences || ![preferences respondsToSelector:selector]) return;
 
-    BOOL running = FilzaWebDAVToggleIsServerStarted(preferences,
-                                                     NSSelectorFromString(@"isServerStarted"));
-    SEL getSelector = NSSelectorFromString(@"objectForPreferenceKey:");
-    id current = [preferences respondsToSelector:getSelector]
-        ? ((id (*)(id, SEL, id))objc_msgSend)(preferences, getSelector, @"air-browser")
-        : nil;
-    BOOL stored = [current respondsToSelector:@selector(boolValue)] && [current boolValue];
+    NSMethodSignature *signature = [preferences methodSignatureForSelector:selector];
+    if (!signature || signature.numberOfArguments < 5) return;
 
-    if (stored != running) {
-        SEL setSelector = NSSelectorFromString(@"setObject:forPreferenceKey:notification:");
-        if ([preferences respondsToSelector:setSelector]) {
-            ((void (*)(id, SEL, id, id, BOOL))objc_msgSend)(
-                preferences, setSelector, @(running), @"air-browser", NO);
-        }
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.target = preferences;
+    invocation.selector = selector;
+
+    __unsafe_unretained id value = @(enabled);
+    __unsafe_unretained id key = @"air-browser";
+    [invocation setArgument:&value atIndex:2];
+    [invocation setArgument:&key atIndex:3];
+
+    const char *type = [signature getArgumentTypeAtIndex:4];
+    while (type && strchr("rnNoORV", type[0])) type++;
+    if (type && type[0] == '@') {
+        __unsafe_unretained id notification = nil;
+        [invocation setArgument:&notification atIndex:4];
+    } else if (type && (type[0] == 'B' || type[0] == 'c')) {
+        BOOL notification = NO;
+        [invocation setArgument:&notification atIndex:4];
+    } else {
+        NSUInteger zero = 0;
+        [invocation setArgument:&zero atIndex:4];
     }
 
+    @try {
+        [invocation invoke];
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+            [NSString stringWithFormat:@"toggle could not persist air-browser=%@: %@",
+             enabled ? @"YES" : @"NO", exception.reason ?: exception.name]);
+    }
+}
+
+static void FilzaWebDAVToggleCallLifecycle(id preferences, BOOL shouldRun)
+{
+    SEL selector = NSSelectorFromString(shouldRun ? @"startAirBrowser" : @"stopAirBrowser");
+    if (!preferences || ![preferences respondsToSelector:selector]) return;
+    ((void (*)(id, SEL))objc_msgSend)(preferences, selector);
+}
+
+static void FilzaWebDAVToggleFinishTransition(id preferences, BOOL shouldRun, NSInteger attempt)
+{
+    BOOL running = FilzaWebDAVToggleInProcessServerRunning(preferences);
+    if (running != shouldRun && attempt == 0) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+            [NSString stringWithFormat:@"toggle transition retry desired=%@ observed=%@",
+             shouldRun ? @"ON" : @"OFF", running ? @"ON" : @"OFF"]);
+        FilzaWebDAVToggleCallLifecycle(preferences, shouldRun);
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+            FilzaWebDAVToggleFinishTransition(preferences, shouldRun, 1);
+        });
+        return;
+    }
+
+    running = FilzaWebDAVToggleInProcessServerRunning(preferences);
+    FilzaWebDAVToggleSetEnabledPreference(preferences, running);
     FilzaDiagnosticsAppend(@"WebDAV",
-        [NSString stringWithFormat:@"settings toggle synchronized visible-state=%@ preference=%@",
-         running ? @"ON" : @"OFF", running ? @"YES" : @"NO"]);
+        [NSString stringWithFormat:@"toggle transition complete desired=%@ observed=%@ preference=%@",
+         shouldRun ? @"ON" : @"OFF", running ? @"ON" : @"OFF",
+         running ? @"YES" : @"NO"]);
 }
 
 static void FilzaWebDAVToggleCheckbox(id controller, SEL selector)
 {
+    id preferences = FilzaWebDAVToggleSharedPreferences();
+    BOOL wasRunning = FilzaWebDAVToggleIsServerStarted(preferences,
+                                                        NSSelectorFromString(@"isServerStarted"));
+    BOOL shouldRun = !wasRunning;
+
+    FilzaDiagnosticsAppend(@"WebDAV",
+        [NSString stringWithFormat:@"settings toggle requested %@ -> %@",
+         wasRunning ? @"ON" : @"OFF", shouldRun ? @"ON" : @"OFF"]);
+
+    // Chain through WebDAVRuntimeFix and then Filza's original settings action.
+    // The original action gets the corrected isServerStarted value and therefore
+    // chooses the intended Start/Stop branch.
     if (FilzaPreviousWebDAVCheckbox)
         FilzaPreviousWebDAVCheckbox(controller, selector);
 
-    // The original action reloads the section synchronously. Our
-    // isServerStarted hook is already active during that reload. Persist the
-    // final listener state on the next main-loop turn after start/stop settles.
-    dispatch_async(dispatch_get_main_queue(), ^{
-        FilzaWebDAVTogglePersistRunningState();
+    // Give GCDWebServer one run-loop turn to bind/unbind.  If the listener did
+    // not reach the state implied by the user's tap, call the already-hooked
+    // TGPreferences lifecycle method once and verify again.  Preference state
+    // is written only after this transition, never from the getter.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.08 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        FilzaWebDAVToggleFinishTransition(preferences, shouldRun, 0);
     });
 }
 
@@ -117,24 +177,22 @@ static void FilzaInstallWebDAVToggleStateFix(void)
 
     IMP currentCheckbox = method_getImplementation(checkboxMethod);
     if (currentCheckbox != (IMP)FilzaWebDAVToggleCheckbox) {
-        // By installing after WebDAVRuntimeFix, this chains through its existing
-        // start/stop wrapper rather than replacing it.
         FilzaPreviousWebDAVCheckbox = (void (*)(id, SEL))currentCheckbox;
         method_setImplementation(checkboxMethod, (IMP)FilzaWebDAVToggleCheckbox);
     }
 
     FilzaWebDAVToggleStateInstalled = YES;
     FilzaDiagnosticsAppend(@"WebDAV",
-        @"toggle-state fix installed: isServerStarted now reflects in-process listener");
-    FilzaWebDAVTogglePersistRunningState();
+        @"toggle-state fix installed: listener getter is observation-only and OFF transitions are explicit");
 }
 
 __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)
 {
     @autoreleasepool {
         dispatch_async(dispatch_get_main_queue(), ^{
-            // WebDAVRuntimeFix also installs from the main queue. Delay one turn
-            // so this wrapper chains on top of its lifecycle hooks deterministically.
+            // WebDAVRuntimeFix installs from the main queue as well.  Chain on
+            // top after it so startAirBrowser/stopAirBrowser remain the real
+            // in-process lifecycle implementation.
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.20 * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
                 FilzaInstallWebDAVToggleStateFix();
@@ -147,8 +205,8 @@ __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)
                         usingBlock:^(__unused NSNotification *notification) {
                 if (!FilzaWebDAVToggleStateInstalled)
                     FilzaInstallWebDAVToggleStateFix();
-                else
-                    FilzaWebDAVTogglePersistRunningState();
+                // Intentionally do not synchronize air-browser here.  App
+                // activation is an observation event, not a user toggle.
             }];
         });
     }


### PR DESCRIPTION
Replaces the Gestalt-only mond route with a full embedded mond root based on rooootdev/mond main commit `4a37bfca5cb4abb2c99891972365d872d700525e`: Logs, Tweaks, MobileGestalt, PosterBoard, disabled HouseArrest, exploit method settings, token controls, Keep Alive, and Respring are exposed from the mond root while Filza remains the UIApplication owner.

Also fixes the WebDAV regression where state synchronization could rewrite `air-browser=YES` while a stop was still in flight. `isServerStarted` is now observation-only; the checkbox records the intended ON/OFF transition, chains through the existing in-process lifecycle hooks, verifies the listener, retries that intended lifecycle once if needed, and only then persists the observed final state.

This PR stays isolated until the complete arm64/IPA workflow passes.

## Summary by Sourcery

Integrate a full embedded mond root workspace into Filza and harden WebDAV state handling to make OFF transitions explicit and avoid preference feedback loops.

New Features:
- Add a MondFullRootHost SwiftUI shell that embeds the current mond root, exposing logs, tweaks, MobileGestalt, PosterBoard, exploit controls, sandbox token handling, keep-alive, and respring tools from within Filza.
- Present the mond workspace directly from Filza via an updated bridge that uses the full mond host factory and a canonical MobileGestalt path while keeping mond launch independent of Gestalt access.

Bug Fixes:
- Fix WebDAV toggle state desynchronization by making isServerStarted observation-only, driving start/stop via the checkbox intent, verifying the in-process server listener, and only persisting the final air-browser preference after the transition completes.

Enhancements:
- Refine mond diagnostics, navigation, and settings integration so exploit method selection, Gestalt access prewarming, and PosterBoard availability follow upstream mond behavior within Filza.
- Improve WebDAV diagnostics and lifecycle chaining so runtime hooks coexist predictably with Filza's original settings actions and app activation events remain observation-only.

Build:
- Include MondFullRootHost.swift in the FilzaApplySandboxExt Swift build and add a Makefile preflight check to ensure the full mond root host is present before compilation.