### PR TITLE
Embed current upstream mond app instead of Gestalt-only reconstruction

### DIFF
--- a/FilzaApplySandboxExt-Bridging-Header.h
+++ b/FilzaApplySandboxExt-Bridging-Header.h
@@ -12,3 +12,8 @@
 #import "MCMBridge.h"
 #import "ThirdParty/bad_query/bad_query/bad_query.h"
 #import "ThirdParty/3105/Sources/AppIconHelper.h"
+
+// Current mond carries its own bad_query snapshot. Its exported C symbols are
+// deterministically namespaced during staging so it can coexist with Filza's
+// existing bad_query integration without changing 3105 or access-map behavior.
+#import "ThirdParty/mond-current/Generated/mond_bad_query.h"

--- a/FilzaMondBridge.m
+++ b/FilzaMondBridge.m
@@ -4,7 +4,6 @@
 
 #import "FilzaDiagnostics.h"
 #import "FilzaMondBridge.h"
-#import "GestaltManager.h"
 
 static UIViewController *FMActiveController(void)
 {
@@ -42,7 +41,7 @@ static UIViewController *FMActiveController(void)
 static void FMShowUnavailable(UIViewController *source, NSString *message)
 {
     UIAlertController *alert = [UIAlertController
-        alertControllerWithTitle:@"Gestalt Editor unavailable"
+        alertControllerWithTitle:@"mond unavailable"
         message:message
         preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction actionWithTitle:@"OK"
@@ -50,56 +49,48 @@ static void FMShowUnavailable(UIViewController *source, NSString *message)
     [source presentViewController:alert animated:YES completion:nil];
 }
 
-static UIViewController *FMCreateHost(NSString *path)
+static UIViewController *FMCreateHost(void)
 {
-    Class factory = NSClassFromString(@"MondGestaltHostFactory");
-    SEL selector = NSSelectorFromString(@"makeViewControllerWithPath:");
+    Class factory = NSClassFromString(@"MondEmbeddedHostFactory");
+    SEL selector = NSSelectorFromString(@"makeViewController");
     if (!factory || ![factory respondsToSelector:selector]) {
-        FilzaDiagnosticsAppend(@"Gestalt", @"complete embedded Gestalt host factory unavailable");
+        FilzaDiagnosticsAppend(@"mond", @"current embedded mond host factory unavailable");
         return nil;
     }
 
-    UIViewController *controller =
-        ((id (*)(id, SEL, id))objc_msgSend)(factory, selector, path);
-    if (![controller isKindOfClass:UIViewController.class]) {
-        FilzaDiagnosticsAppend(@"Gestalt", @"complete embedded Gestalt host returned no controller");
+    @try {
+        UIViewController *controller =
+            ((UIViewController *(*)(id, SEL))objc_msgSend)(factory, selector);
+        if (![controller isKindOfClass:UIViewController.class]) {
+            FilzaDiagnosticsAppend(@"mond", @"current embedded mond host returned no controller");
+            return nil;
+        }
+        return controller;
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"mond", [NSString stringWithFormat:
+            @"current embedded mond host exception: %@",
+            exception.reason ?: exception.name]);
         return nil;
     }
-    return controller;
 }
 
-@interface FMGestaltNavigationController : UINavigationController
-@end
-
-@implementation FMGestaltNavigationController
-- (void)fm_close
+static BOOL FMPresentHost(UIViewController *source)
 {
-    [self dismissViewControllerAnimated:YES completion:nil];
-}
-@end
-
-static BOOL FMPresentHost(UIViewController *source, NSString *path)
-{
-    UIViewController *controller = FMCreateHost(path);
+    UIViewController *controller = FMCreateHost();
     if (!controller) {
-        FMShowUnavailable(source, @"The complete Gestalt Editor could not be created.");
+        FMShowUnavailable(source, @"The current mond interface could not be created.");
         return NO;
     }
 
-    UINavigationController *navigation = source.navigationController;
-    if (navigation && !source.presentedViewController) {
-        [navigation pushViewController:controller animated:YES];
-    } else {
-        FMGestaltNavigationController *wrapper =
-            [[FMGestaltNavigationController alloc] initWithRootViewController:controller];
-        controller.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
-            initWithBarButtonSystemItem:UIBarButtonSystemItemClose
-            target:wrapper action:@selector(fm_close)];
-        wrapper.modalPresentationStyle = UIModalPresentationFullScreen;
-        [source presentViewController:wrapper animated:YES completion:nil];
-    }
-    FilzaDiagnosticsAppend(@"Gestalt",
-        [NSString stringWithFormat:@"presented complete Gestalt Editor directly using %@", path]);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *target = source;
+        while (target.presentedViewController)
+            target = target.presentedViewController;
+        [target presentViewController:controller animated:YES completion:^{
+            FilzaDiagnosticsAppend(@"mond",
+                @"presented full current mond root directly");
+        }];
+    });
     return YES;
 }
 
@@ -108,30 +99,10 @@ void FilzaMondPresentFromController(UIViewController *source)
     dispatch_async(dispatch_get_main_queue(), ^{
         UIViewController *presenter = source ?: FMActiveController();
         if (!presenter) {
-            FilzaDiagnosticsAppend(@"Gestalt", @"no presenter available");
+            FilzaDiagnosticsAppend(@"mond", @"no presenter available");
             return;
         }
-
-        __weak UIViewController *weakPresenter = presenter;
-        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-            NSString *detail = nil;
-            NSString *path = FilzaGestaltResolvePath(&detail);
-            dispatch_async(dispatch_get_main_queue(), ^{
-                UIViewController *resolvedPresenter = weakPresenter ?: FMActiveController();
-                if (!resolvedPresenter) return;
-                if (!path.length) {
-                    NSString *reason = detail ?:
-                        @"The MobileGestalt property list could not be opened.";
-                    FilzaDiagnosticsAppend(@"Gestalt",
-                        [NSString stringWithFormat:@"MobileGestalt access failed: %@", reason]);
-                    FMShowUnavailable(resolvedPresenter, reason);
-                    return;
-                }
-                FilzaDiagnosticsAppend(@"Gestalt",
-                    [NSString stringWithFormat:@"verified MobileGestalt access: %@", detail ?: path]);
-                FMPresentHost(resolvedPresenter, path);
-            });
-        });
+        FMPresentHost(presenter);
     });
 }
 
@@ -140,13 +111,8 @@ void FilzaMondPresent(void)
     FilzaMondPresentFromController(FMActiveController());
 }
 
-__attribute__((constructor)) static void FilzaMondPrewarm(void)
+__attribute__((constructor)) static void FilzaMondInstall(void)
 {
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
-        NSString *detail = nil;
-        NSString *path = FilzaGestaltResolvePath(&detail);
-        FilzaDiagnosticsAppend(@"Gestalt", path.length
-            ? @"prewarmed MobileGestalt access for direct presentation"
-            : [NSString stringWithFormat:@"MobileGestalt prewarm unavailable: %@", detail ?: @"unknown"]);
-    });
+    FilzaDiagnosticsAppend(@"mond",
+        @"full current mond route installed commit=4a37bfca5cb4abb2c99891972365d872d700525e");
 }

--- a/FilzaMondCurrentHost.swift
+++ b/FilzaMondCurrentHost.swift
@@ -1,0 +1,101 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+// Current mond is compiled into Filza as source rather than launched as a
+// second UIApplication. These globals preserve mond's standalone runtime
+// contracts used by LogView and PosterBoard helpers.
+var pipe = Pipe()
+var sema = DispatchSemaphore(value: 0)
+var fm = FileManager.default
+
+private enum MondEmbeddedRuntime {
+    private static var didConfigure = false
+
+    @MainActor
+    static func configureOnce() {
+        guard !didConfigure else { return }
+        didConfigure = true
+
+        // Match mond's standalone stdout capture so the real upstream LogView
+        // receives exploit/tweak output. Filza's persistent diagnostics use a
+        // separate file-backed logger and are not dependent on stdout.
+        if !is_debugged() {
+            setvbuf(stdout, nil, _IONBF, 0)
+            dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+        }
+
+        UserDefaults.standard.register(defaults: [
+            "method": "bad_query",
+            "ka_on": true
+        ])
+
+        if UserDefaults.standard.bool(forKey: "ka_on") {
+            keep_alive()
+        }
+
+        FilzaDiagnosticsAppend(
+            "mond",
+            "current upstream runtime configured commit=4a37bfca5cb4abb2c99891972365d872d700525e"
+        )
+    }
+}
+
+private struct MondEmbeddedRoot: View {
+    @StateObject private var state = MondCurrentAppState()
+    @State private var didAppear = false
+
+    var body: some View {
+        MondCurrentContentView()
+            .environmentObject(state)
+            .onAppear {
+                guard !didAppear else { return }
+                didAppear = true
+
+                MondEmbeddedRuntime.configureOnce()
+                if !is_supported() {
+                    MondCurrentAlertinator.shared.alert(
+                        title: "Not supported!",
+                        body: "Your iOS version may not be supported by mond.\nMond only supports iOS 27.0 beta 1 - beta 4."
+                    )
+                }
+
+                grant_all(state: state)
+                FilzaDiagnosticsAppend(
+                    "mond",
+                    "current upstream ContentView appeared; access initialization started"
+                )
+            }
+            .overlay {
+                if state.show_respring {
+                    MondCurrentRespringView()
+                        .brightness(-1.0)
+                        .ignoresSafeArea()
+                        .onAppear {
+                            print("(respring) respringing now...")
+                        }
+                }
+            }
+    }
+}
+
+@objc(MondEmbeddedHostFactory)
+public final class MondEmbeddedHostFactory: NSObject {
+    @objc public static func makeViewController() -> UIViewController {
+        MondEmbeddedRuntime.configureOnce()
+        let controller = UIHostingController(rootView: MondEmbeddedRoot())
+        controller.title = "mond"
+        controller.modalPresentationStyle = .pageSheet
+        if let sheet = controller.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.selectedDetentIdentifier = .large
+            sheet.prefersGrabberVisible = true
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+        }
+        FilzaDiagnosticsAppend(
+            "mond",
+            "constructed full current mond root at 4a37bfca5cb4abb2c99891972365d872d700525e"
+        )
+        return controller
+    }
+}

--- a/FilzaMondCurrentHost.swift
+++ b/FilzaMondCurrentHost.swift
@@ -99,3 +99,14 @@ public final class MondEmbeddedHostFactory: NSObject {
         return controller
     }
 }
+
+// Keep the old Objective-C factory ABI so existing quick-action/tooling probes
+// do not break. It no longer creates the old Gestalt-only reconstruction: every
+// legacy call is forwarded to the complete current mond root.
+@objc(MondGestaltHostFactory)
+public final class MondGestaltHostFactory: NSObject {
+    @objc(makeViewControllerWithPath:)
+    public static func makeViewController(withPath ignoredPath: String) -> UIViewController {
+        MondEmbeddedHostFactory.makeViewController()
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,14 @@ BYETUNES_ACTIVITY_SHARED := ByeTunes/MusicManagerActivityShared/DownloadLiveActi
 BAD_QUERY_ROOT := ThirdParty/bad_query
 GCDWEBSERVER_ROOT := ThirdParty/GCDWebServer
 THREEONE_ROOT := ThirdParty/3105
+MOND_CURRENT_ROOT := ThirdParty/mond-current
+MOND_GEN := $(MOND_CURRENT_ROOT)/Generated
 
 FilzaApplySandboxExt_FILES = Tweak.m AppsMusicFix.m AppsManagerPresentationFix.m AppProxyMetadataFix.m AppMetadataRetryFix.m AppIconResourceProxyFix.m VirtualBackendFix.m SystemPathDiagnostics.m BadQuerySystemProbe.m GestaltManager.m FilzaMondBridge.m FilzaMainToolbarGestalt.m Filza3105Bridge.m ByeTunesMusicBridge.m ByeTunesFilzaLibraryEmbed.m ByeTunesFullAppLauncher.m FilzaDiagnostics.m FilzaQuickActions.m WebDAVRuntimeFix.m WebDAVToggleStateFix.m ArchiveSafety.m ArchiveCreationSafety.m RuntimeStability.m CompatibilityDiagnostics.m CVE43724RieCompatibility.m MCMBridge.m MCMFilzaIntegration.m PosterBoardFeature.m
 FilzaApplySandboxExt_FILES += $(THREEONE_ROOT)/Sources/AppIconHelper.m
 FilzaApplySandboxExt_FILES += $(THREEONE_ROOT)/Sources/wallpaper_zip.c
 FilzaApplySandboxExt_FILES += $(BAD_QUERY_ROOT)/bad_query/bad_query.c
+FilzaApplySandboxExt_FILES += $(MOND_GEN)/mond_bad_query.c
 
 GCDWEBSERVER_OBJC_FILES := $(shell find $(GCDWEBSERVER_ROOT)/GCDWebServer $(GCDWEBSERVER_ROOT)/GCDWebDAVServer -type f -name '*.m' -print)
 FilzaApplySandboxExt_FILES += $(GCDWEBSERVER_OBJC_FILES)
@@ -33,13 +36,65 @@ FilzaApplySandboxExt_FILES += XPF/external/ChOma/src/arm64.c XPF/external/ChOma/
 # by explicit build-time parity patches. MusicManagerApp.swift is omitted
 # because Filza already owns UIApplication lifecycle.
 BYETUNES_SWIFT_FILES := $(shell find $(BYETUNES_ROOT) -type f -name '*.swift' ! -name 'MusicManagerApp.swift' ! -name 'SplashView.swift' -print)
+
 # The vendored 3105 tree is a rollback baseline. stage-3105-v1.sh overlays the
 # exact immutable 1.0 upstream files before compilation while preserving the
 # Filza-only root/settings namespace and host glue.
 THREEONE_SWIFT_FILES := $(shell find $(THREEONE_ROOT)/Sources -type f -name '*.swift' -print)
-FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift ByeTunesMetadataCompat.swift ByeTunesDownloadParityCompat.swift MondGestaltView.swift Filza3105Host.swift $(THREEONE_SWIFT_FILES) $(BYETUNES_SWIFT_FILES) $(BYETUNES_ACTIVITY_SHARED)
 
-FilzaApplySandboxExt_CFLAGS = -I$(PWD)/compat -I$(PWD) -I$(PWD)/XPF/src -I$(PWD)/XPF/external/ChOma/include -I$(IDEVICE_VENDOR)/include -I$(PWD)/$(BAD_QUERY_ROOT)/bad_query -I$(PWD)/$(THREEONE_ROOT)/Sources \
+# Current mond is staged from immutable upstream revisions before compilation.
+# Paths are explicit because GNU make evaluates find/wildcard expressions before
+# the before-...-all staging hook runs.
+MOND_SWIFT_FILES := \
+    $(MOND_GEN)/Mond/exploit_cmg.swift \
+    $(MOND_GEN)/Mond/exploit_unsbx.swift \
+    $(MOND_GEN)/Mond/helpers_keepalive.swift \
+    $(MOND_GEN)/Mond/helpers_mg.swift \
+    $(MOND_GEN)/Mond/helpers_poster.swift \
+    $(MOND_GEN)/Mond/helpers_sbx.swift \
+    $(MOND_GEN)/Mond/helpers_utils.swift \
+    $(MOND_GEN)/Mond/views_App_ContentView.swift \
+    $(MOND_GEN)/Mond/views_App_LogView.swift \
+    $(MOND_GEN)/Mond/views_App_SettingsView.swift \
+    $(MOND_GEN)/Mond/views_Tweaks_GestaltView.swift \
+    $(MOND_GEN)/Mond/views_Tweaks_PosterView.swift \
+    $(MOND_GEN)/Mond/views_Tweaks_SantanderView.swift
+
+MOND_PARTYUI_SWIFT_FILES := \
+    $(MOND_GEN)/PartyUI/Containers_TerminalPlatter.swift \
+    $(MOND_GEN)/PartyUI/Alerts_PlainAlert.swift \
+    $(MOND_GEN)/PartyUI/Toggles_PlainToggle.swift \
+    $(MOND_GEN)/PartyUI/Toggles_PlatterToggle.swift \
+    $(MOND_GEN)/PartyUI/Utilities_Alertinator.swift \
+    $(MOND_GEN)/PartyUI/Utilities_Helpers.swift \
+    $(MOND_GEN)/PartyUI/Buttons_TranslucentButtonStyle.swift
+
+MOND_ZIP_SWIFT_FILES := \
+    $(MOND_GEN)/ZIPFoundation/Archive+BackingConfiguration.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Deprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Helpers.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+MemoryFile.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Progress.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Reading.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+ReadingDeprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Writing.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+WritingDeprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+ZIP64.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive.swift \
+    $(MOND_GEN)/ZIPFoundation/Data+Compression.swift \
+    $(MOND_GEN)/ZIPFoundation/Data+CompressionDeprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/Data+Serialization.swift \
+    $(MOND_GEN)/ZIPFoundation/Date+ZIP.swift \
+    $(MOND_GEN)/ZIPFoundation/Entry+Serialization.swift \
+    $(MOND_GEN)/ZIPFoundation/Entry+ZIP64.swift \
+    $(MOND_GEN)/ZIPFoundation/Entry.swift \
+    $(MOND_GEN)/ZIPFoundation/FileManager+ZIP.swift \
+    $(MOND_GEN)/ZIPFoundation/FileManager+ZIPDeprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/URL+ZIP.swift
+
+FilzaApplySandboxExt_SWIFT_FILES = ByeTunesEmbeddedHost.swift ByeTunesMetadataCompat.swift ByeTunesDownloadParityCompat.swift FilzaMondCurrentHost.swift Filza3105Host.swift $(MOND_SWIFT_FILES) $(MOND_PARTYUI_SWIFT_FILES) $(MOND_ZIP_SWIFT_FILES) $(THREEONE_SWIFT_FILES) $(BYETUNES_SWIFT_FILES) $(BYETUNES_ACTIVITY_SHARED)
+
+FilzaApplySandboxExt_CFLAGS = -I$(PWD)/compat -I$(PWD) -I$(PWD)/XPF/src -I$(PWD)/XPF/external/ChOma/include -I$(IDEVICE_VENDOR)/include -I$(PWD)/$(BAD_QUERY_ROOT)/bad_query -I$(PWD)/$(THREEONE_ROOT)/Sources -I$(PWD)/$(MOND_GEN) \
     -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Core -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Requests -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebServer/Responses -I$(PWD)/$(GCDWEBSERVER_ROOT)/GCDWebDAVServer \
     -I$(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)/usr/include/libxml2 \
     -fobjc-arc -include errno.h -include math.h \
@@ -50,10 +105,10 @@ FilzaApplySandboxExt_CFLAGS += -Wno-arc-performSelector-leaks
 FilzaApplySandboxExt_CCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
 FilzaApplySandboxExt_OBJCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
 FilzaApplySandboxExt_OBJCCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
-FilzaApplySandboxExt_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xcc -I$(IDEVICE_VENDOR)/include
+FilzaApplySandboxExt_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xcc -I$(IDEVICE_VENDOR)/include -Xcc -I$(PWD)/$(MOND_GEN)
 FilzaApplySandboxExt_LDFLAGS += $(IDEVICE_STATIC)
 
-FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit Security UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents ActivityKit SafariServices CFNetwork MobileCoreServices WebKit QuickLook
+FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit Security UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents ActivityKit SafariServices CFNetwork MobileCoreServices WebKit QuickLook Compression
 FilzaApplySandboxExt_PRIVATE_FRAMEWORKS = IOSurface
 FilzaApplySandboxExt_LIBRARIES = z xml2 sandbox sqlite3
 FilzaApplySandboxExt_INSTALL_TARGET_PROCESSES = Filza
@@ -61,6 +116,7 @@ FilzaApplySandboxExt_INSTALL_TARGET_PROCESSES = Filza
 # Every transformation is explicit and ordered. No script may invoke another
 # unrelated patch as a hidden side effect.
 before-FilzaApplySandboxExt-all::
+	@bash scripts/stage-mond-current.sh
 	@bash scripts/stage-3105-v1.sh
 	@bash scripts/patch-access-map-provenance.sh
 	@bash scripts/patch-byetunes-upstream-parity-v2.sh
@@ -93,7 +149,16 @@ before-FilzaApplySandboxExt-all::
 	@test -f "GestaltManager.m" || (echo "Missing GestaltManager.m" >&2; exit 1)
 	@test -f "FilzaMondBridge.m" || (echo "Missing FilzaMondBridge.m" >&2; exit 1)
 	@test -f "FilzaMainToolbarGestalt.m" || (echo "Missing FilzaMainToolbarGestalt.m" >&2; exit 1)
-	@test -f "MondGestaltView.swift" || (echo "Missing MondGestaltView.swift" >&2; exit 1)
+	@test -f "FilzaMondCurrentHost.swift" || (echo "Missing current mond host" >&2; exit 1)
+	@test -f "scripts/stage-mond-current.sh" || (echo "Missing pinned current mond staging script" >&2; exit 1)
+	@test -f "$(MOND_GEN)/Mond/views_App_ContentView.swift" || (echo "Missing current mond ContentView" >&2; exit 1)
+	@test -f "$(MOND_GEN)/Mond/views_App_SettingsView.swift" || (echo "Missing current mond SettingsView" >&2; exit 1)
+	@test -f "$(MOND_GEN)/Mond/views_Tweaks_GestaltView.swift" || (echo "Missing current mond GestaltView" >&2; exit 1)
+	@test -f "$(MOND_GEN)/Mond/views_Tweaks_PosterView.swift" || (echo "Missing current mond PosterView" >&2; exit 1)
+	@test -f "$(MOND_GEN)/Mond/views_Tweaks_SantanderView.swift" || (echo "Missing current mond SantanderView" >&2; exit 1)
+	@test -f "$(MOND_GEN)/mond_bad_query.c" || (echo "Missing current mond bad_query implementation" >&2; exit 1)
+	@test -f "$(MOND_GEN)/PartyUI/Containers_TerminalPlatter.swift" || (echo "Missing mond PartyUI TerminalPlatter" >&2; exit 1)
+	@test -f "$(MOND_GEN)/ZIPFoundation/Archive.swift" || (echo "Missing mond ZIPFoundation" >&2; exit 1)
 	@test -f "Filza3105Host.swift" || (echo "Missing Filza3105Host.swift" >&2; exit 1)
 	@test -f "Filza3105Bridge.m" || (echo "Missing Filza3105Bridge.m" >&2; exit 1)
 	@test -f "scripts/stage-3105-v1.sh" || (echo "Missing pinned 3105 1.0 staging script" >&2; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ FilzaApplySandboxExt_OBJCCFLAGS = $(FilzaApplySandboxExt_CFLAGS)
 FilzaApplySandboxExt_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xcc -I$(IDEVICE_VENDOR)/include -Xcc -I$(PWD)/$(MOND_GEN)
 FilzaApplySandboxExt_LDFLAGS += $(IDEVICE_STATIC)
 
-FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit Security UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents ActivityKit SafariServices CFNetwork MobileCoreServices WebKit QuickLook Compression
+FilzaApplySandboxExt_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation CoreMedia AudioToolbox CryptoKit Security UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents ActivityKit SafariServices CFNetwork MobileCoreServices WebKit QuickLook
 FilzaApplySandboxExt_PRIVATE_FRAMEWORKS = IOSurface
 FilzaApplySandboxExt_LIBRARIES = z xml2 sandbox sqlite3
 FilzaApplySandboxExt_INSTALL_TARGET_PROCESSES = Filza

--- a/scripts/stage-mond-current.sh
+++ b/scripts/stage-mond-current.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="ThirdParty/mond-current"
+GEN="$ROOT/Generated"
+MOND_COMMIT="4a37bfca5cb4abb2c99891972365d872d700525e"
+PARTYUI_COMMIT="830eaac8ebf8a4cbcec08d49e8746033574d1903"
+ZIPFOUNDATION_COMMIT="22787ffb59de99e5dc1fbfe80b19c97a904ad48d"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/filza-mond-current.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fetch_archive() {
+  local owner="$1" repo="$2" commit="$3" out="$4"
+  curl -fL --retry 3 --retry-delay 2 \
+    "https://codeload.github.com/${owner}/${repo}/tar.gz/${commit}" -o "$out"
+}
+
+fetch_archive rooootdev mond "$MOND_COMMIT" "$TMP/mond.tar.gz"
+fetch_archive jailbreakdotparty PartyUI "$PARTYUI_COMMIT" "$TMP/partyui.tar.gz"
+fetch_archive weichsel ZIPFoundation "$ZIPFOUNDATION_COMMIT" "$TMP/zipfoundation.tar.gz"
+
+mkdir -p "$TMP/mond" "$TMP/partyui" "$TMP/zipfoundation"
+tar -xzf "$TMP/mond.tar.gz" -C "$TMP/mond" --strip-components=1
+tar -xzf "$TMP/partyui.tar.gz" -C "$TMP/partyui" --strip-components=1
+tar -xzf "$TMP/zipfoundation.tar.gz" -C "$TMP/zipfoundation" --strip-components=1
+
+rm -rf "$GEN"
+mkdir -p "$GEN/Mond" "$GEN/PartyUI" "$GEN/ZIPFoundation" "$ROOT/Licenses"
+
+MOND_FILES=(
+  exploit/cmg.swift
+  exploit/unsbx.swift
+  helpers/keepalive.swift
+  helpers/mg.swift
+  helpers/poster.swift
+  helpers/sbx.swift
+  helpers/utils.swift
+  views/App/ContentView.swift
+  views/App/LogView.swift
+  views/App/SettingsView.swift
+  views/Tweaks/GestaltView.swift
+  views/Tweaks/PosterView.swift
+  views/Tweaks/SantanderView.swift
+)
+
+for rel in "${MOND_FILES[@]}"; do
+  test -f "$TMP/mond/mond/$rel" || { echo "Missing mond source: $rel" >&2; exit 1; }
+  dest="$GEN/Mond/${rel//\//_}"
+  cp "$TMP/mond/mond/$rel" "$dest"
+done
+
+# Use mond's vendored bad_query implementation, but namespace its exported
+# symbols so the existing Filza/3105 bad_query runtime can remain untouched.
+cp "$TMP/mond/mond/exploit/bad_query/bad_query.c" "$GEN/mond_bad_query.c"
+cp "$TMP/mond/mond/exploit/bad_query/bad_query.h" "$GEN/mond_bad_query.h"
+
+PARTY_FILES=(
+  Containers/TerminalPlatter.swift
+  Alerts/PlainAlert.swift
+  Toggles/PlainToggle.swift
+  Toggles/PlatterToggle.swift
+  Utilities/Alertinator.swift
+  Utilities/Helpers.swift
+  Buttons/TranslucentButtonStyle.swift
+)
+for rel in "${PARTY_FILES[@]}"; do
+  test -f "$TMP/partyui/Sources/PartyUI/$rel" || { echo "Missing PartyUI source: $rel" >&2; exit 1; }
+  cp "$TMP/partyui/Sources/PartyUI/$rel" "$GEN/PartyUI/${rel//\//_}"
+done
+
+# ZIPFoundation is compiled from the exact revision pinned by current mond.
+while IFS= read -r src; do
+  cp "$src" "$GEN/ZIPFoundation/$(basename "$src")"
+done < <(find "$TMP/zipfoundation/Sources/ZIPFoundation" -maxdepth 1 -type f -name '*.swift' -print | sort)
+
+python3 - "$GEN" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path(sys.argv[1])
+
+# Host-only namespacing. This avoids collisions with ByeTunes/3105 types while
+# preserving upstream view bodies and behavior.
+mond_map = {
+    'ContentView': 'MondCurrentContentView',
+    'AppState': 'MondCurrentAppState',
+    'LogView': 'MondCurrentLogView',
+    'SettingsView': 'MondCurrentSettingsView',
+    'CreditsRow': 'MondCurrentCreditsRow',
+    'GestaltView': 'MondCurrentGestaltView',
+    'PosterView': 'MondCurrentPosterView',
+    'SafariView': 'MondCurrentSafariView',
+    'Santander': 'MondCurrentSantander',
+    'AppPaths': 'MondCurrentAppPaths',
+    'TweakPaths': 'MondCurrentTweakPaths',
+    'RespringView': 'MondCurrentRespringView',
+    'Alertinator': 'MondCurrentAlertinator',
+    'TerminalPlatter': 'MondCurrentTerminalPlatter',
+    'PlainAlert': 'MondCurrentPlainAlert',
+    'PlainToggle': 'MondCurrentPlainToggle',
+    'ToggleInfoType': 'MondCurrentToggleInfoType',
+    'doubleSystemVersion': 'mondCurrentSystemVersion',
+    'bad_query_release': 'mond_bad_query_release',
+    'bad_query_list': 'mond_bad_query_list',
+    'bad_query': 'mond_bad_query',
+    'pb_error': 'MondCurrentPosterError',
+    'pb': 'MondCurrentPosterBackend',
+}
+
+party_map = {
+    'TerminalPlatter': 'MondCurrentTerminalPlatter',
+    'PlainAlert': 'MondCurrentPlainAlert',
+    'PlainToggle': 'MondCurrentPlainToggle',
+    'PlatterToggle': 'MondCurrentPlatterToggle',
+    'ToggleInfoType': 'MondCurrentToggleInfoType',
+    'Alertinator': 'MondCurrentAlertinator',
+    'TranslucentButtonStyle': 'MondCurrentTranslucentButtonStyle',
+    'cornerRad': 'MondCurrentCornerRad',
+    'AppInfo': 'MondCurrentPartyAppInfo',
+    'doubleSystemVersion': 'mondCurrentSystemVersion',
+}
+
+def rewrite(path: Path, mapping: dict[str, str], strip_imports=()):
+    text = path.read_text(encoding='utf-8')
+    for module in strip_imports:
+        text = re.sub(rf'^import\s+{re.escape(module)}\s*\n', '', text, flags=re.M)
+    # Longest tokens first keeps names such as bad_query_release intact.
+    for old in sorted(mapping, key=len, reverse=True):
+        text = re.sub(rf'\b{re.escape(old)}\b', mapping[old], text)
+    path.write_text(text, encoding='utf-8')
+
+for path in sorted((root / 'Mond').glob('*.swift')):
+    rewrite(path, mond_map, strip_imports=('PartyUI', 'ZIPFoundation'))
+
+for path in sorted((root / 'PartyUI').glob('*.swift')):
+    rewrite(path, party_map)
+
+# Namespace only the exported C API; implementation internals remain exact.
+for name in ('mond_bad_query.c', 'mond_bad_query.h'):
+    path = root / name
+    text = path.read_text(encoding='utf-8')
+    for old, new in (
+        ('bad_query_release', 'mond_bad_query_release'),
+        ('bad_query_list', 'mond_bad_query_list'),
+        ('bad_query', 'mond_bad_query'),
+    ):
+        text = re.sub(rf'\b{old}\b', new, text)
+    text = text.replace('bad_query_h', 'mond_bad_query_h')
+    path.write_text(text, encoding='utf-8')
+PY
+
+# Preserve dependency licenses and deterministic provenance.
+for spec in \
+  "$TMP/mond/LICENSE:$ROOT/Licenses/mond-LICENSE" \
+  "$TMP/partyui/LICENSE:$ROOT/Licenses/PartyUI-LICENSE" \
+  "$TMP/zipfoundation/LICENSE:$ROOT/Licenses/ZIPFoundation-LICENSE"; do
+  src="${spec%%:*}"; dst="${spec#*:}"
+  if test -f "$src"; then cp "$src" "$dst"; fi
+done
+
+cat > "$ROOT/PINNED.txt" <<EOF
+mond=$MOND_COMMIT
+PartyUI=$PARTYUI_COMMIT
+ZIPFoundation=$ZIPFOUNDATION_COMMIT
+EOF
+
+# Fail closed if the current app graph was not staged.
+grep -Fq 'navigationTitle("mond")' "$GEN/Mond/views_App_ContentView.swift"
+grep -Fq 'MondCurrentTerminalPlatter' "$GEN/Mond/views_App_ContentView.swift"
+grep -Fq 'Text("HouseArrest")' "$GEN/Mond/views_App_ContentView.swift"
+grep -Fq 'Text("Generate Token")' "$GEN/Mond/views_App_SettingsView.swift"
+grep -Fq 'Toggle("Keep Alive"' "$GEN/Mond/views_App_SettingsView.swift"
+grep -Fq 'Text("Respring")' "$GEN/Mond/views_App_SettingsView.swift"
+grep -Fq 'struct MondCurrentSantanderView' "$GEN/Mond/views_Tweaks_SantanderView.swift"
+grep -Fq 'mond_bad_query' "$GEN/mond_bad_query.c"
+test "$(find "$GEN/ZIPFoundation" -type f -name '*.swift' | wc -l | tr -d ' ')" -ge 20
+
+echo "Staged current mond ${MOND_COMMIT} with PartyUI ${PARTYUI_COMMIT} and ZIPFoundation ${ZIPFOUNDATION_COMMIT}"

--- a/scripts/stage-mond-current.sh
+++ b/scripts/stage-mond-current.sh
@@ -215,6 +215,25 @@ require_contains "$GEN/Mond/views_Tweaks_SantanderView.swift" 'struct SantanderV
 require_contains "$GEN/mond_bad_query.c" 'mond_bad_query' 'namespaced mond bad_query'
 require_contains "$GEN/ZIPFoundation/Entry.swift" 'public struct MondZIPEntry' 'namespaced ZIPFoundation Entry type'
 
+# Prove Filza is building and presenting the current full mond app rather than
+# the retired Gestalt-only reconstruction. The legacy Objective-C factory name
+# remains only as an ABI forwarder for existing toolbar/quick-action callers.
+require_contains Makefile 'FilzaMondCurrentHost.swift' 'current mond host in Swift build graph'
+require_contains Makefile '$(MOND_SWIFT_FILES)' 'current mond upstream sources in Swift build graph'
+require_contains Makefile '$(MOND_PARTYUI_SWIFT_FILES)' 'current mond PartyUI sources in Swift build graph'
+require_contains Makefile '$(MOND_ZIP_SWIFT_FILES)' 'current mond ZIPFoundation sources in Swift build graph'
+require_contains FilzaMondCurrentHost.swift '@objc(MondEmbeddedHostFactory)' 'full mond host factory'
+require_contains FilzaMondCurrentHost.swift 'MondCurrentContentView()' 'current mond root hosted by Filza'
+require_contains FilzaMondBridge.m 'full current mond route installed commit=4a37bfca5cb4abb2c99891972365d872d700525e' 'full mond bridge route'
+if grep -Fq 'MondGestaltView.swift' Makefile; then
+  echo "Current mond staging check failed: retired MondGestaltView.swift is back in the build graph" >&2
+  exit 1
+fi
+if grep -Fq 'FilzaGestaltResolvePath' FilzaMondBridge.m; then
+  echo "Current mond staging check failed: bridge still pre-gates presentation on MobileGestalt" >&2
+  exit 1
+fi
+
 if grep -Fq '.onChange(of: ka_on) { _, enabled in' "$GEN/Mond/views_App_SettingsView.swift"; then
   echo "Current mond staging check failed: iOS 17-only Keep Alive onChange form survived adaptation" >&2
   exit 1

--- a/scripts/stage-mond-current.sh
+++ b/scripts/stage-mond-current.sh
@@ -102,6 +102,8 @@ mond_map = {
     'PlainToggle': 'MondCurrentPlainToggle',
     'ToggleInfoType': 'MondCurrentToggleInfoType',
     'doubleSystemVersion': 'mondCurrentSystemVersion',
+    'sandbox_extension_consume': 'mondCurrentSandboxExtensionConsume',
+    'sandbox_extension_issue_file': 'mondCurrentSandboxExtensionIssueFile',
     'bad_query_release': 'mond_bad_query_release',
     'bad_query_list': 'mond_bad_query_list',
     'bad_query': 'mond_bad_query',
@@ -122,6 +124,13 @@ party_map = {
     'doubleSystemVersion': 'mondCurrentSystemVersion',
 }
 
+# ZIPFoundation normally lives in its own Swift module, where Entry cannot
+# collide with 3105's private SecureZIPArchive.Entry. Since the Theos target
+# embeds package source into one module, namespace only that package-level type.
+zip_map = {
+    'Entry': 'MondZIPEntry',
+}
+
 def rewrite(path: Path, mapping: dict[str, str], strip_imports=()):
     text = path.read_text(encoding='utf-8')
     for module in strip_imports:
@@ -136,6 +145,20 @@ for path in sorted((root / 'Mond').glob('*.swift')):
 
 for path in sorted((root / 'PartyUI').glob('*.swift')):
     rewrite(path, party_map)
+
+for path in sorted((root / 'ZIPFoundation').glob('*.swift')):
+    rewrite(path, zip_map)
+
+# Current mond targets iOS 17 and uses the two-argument onChange closure. Filza
+# intentionally remains iOS 16-compatible. The one-argument overload has the
+# same enabled-value behavior and is the only UI API adaptation required here.
+settings = root / 'Mond' / 'views_App_SettingsView.swift'
+settings_text = settings.read_text(encoding='utf-8')
+old_on_change = '.onChange(of: ka_on) { _, enabled in'
+new_on_change = '.onChange(of: ka_on) { enabled in'
+if old_on_change not in settings_text:
+    raise SystemExit('Current mond staging check failed: expected Keep Alive iOS 17 onChange form not found')
+settings.write_text(settings_text.replace(old_on_change, new_on_change, 1), encoding='utf-8')
 
 # Namespace only the exported C API; implementation internals remain exact.
 for name in ('mond_bad_query.c', 'mond_bad_query.h'):
@@ -184,9 +207,22 @@ require_contains "$GEN/Mond/views_App_ContentView.swift" '"HouseArrest"' 'curren
 require_contains "$GEN/Mond/views_App_SettingsView.swift" '"Run Exploit"' 'exploit action'
 require_contains "$GEN/Mond/views_App_SettingsView.swift" '"Generate Token"' 'token action'
 require_contains "$GEN/Mond/views_App_SettingsView.swift" '"Keep Alive"' 'keep-alive setting'
+require_contains "$GEN/Mond/views_App_SettingsView.swift" '.onChange(of: ka_on) { enabled in' 'iOS 16 Keep Alive onChange compatibility'
 require_contains "$GEN/Mond/views_App_SettingsView.swift" '"Respring"' 'respring action'
+require_contains "$GEN/Mond/helpers_sbx.swift" 'func mondCurrentSandboxExtensionConsume' 'namespaced sandbox consume helper'
+require_contains "$GEN/Mond/helpers_sbx.swift" 'func mondCurrentSandboxExtensionIssueFile' 'namespaced sandbox issue helper'
 require_contains "$GEN/Mond/views_Tweaks_SantanderView.swift" 'struct SantanderView' 'current Santander view'
 require_contains "$GEN/mond_bad_query.c" 'mond_bad_query' 'namespaced mond bad_query'
+require_contains "$GEN/ZIPFoundation/Entry.swift" 'public struct MondZIPEntry' 'namespaced ZIPFoundation Entry type'
+
+if grep -Fq '.onChange(of: ka_on) { _, enabled in' "$GEN/Mond/views_App_SettingsView.swift"; then
+  echo "Current mond staging check failed: iOS 17-only Keep Alive onChange form survived adaptation" >&2
+  exit 1
+fi
+if grep -Fq 'public struct Entry' "$GEN/ZIPFoundation/Entry.swift"; then
+  echo "Current mond staging check failed: unnamespaced ZIPFoundation Entry survived adaptation" >&2
+  exit 1
+fi
 
 ZIP_SWIFT_COUNT="$(find "$GEN/ZIPFoundation" -type f -name '*.swift' | wc -l | tr -d ' ')"
 test "$ZIP_SWIFT_COUNT" -ge 20 || {

--- a/scripts/stage-mond-current.sh
+++ b/scripts/stage-mond-current.sh
@@ -82,7 +82,8 @@ import sys
 root = Path(sys.argv[1])
 
 # Host-only namespacing. This avoids collisions with ByeTunes/3105 types while
-# preserving upstream view bodies and behavior.
+# preserving upstream view bodies and behavior. Santander has no collision in
+# Filza, so its current upstream type names are intentionally left untouched.
 mond_map = {
     'ContentView': 'MondCurrentContentView',
     'AppState': 'MondCurrentAppState',
@@ -92,7 +93,6 @@ mond_map = {
     'GestaltView': 'MondCurrentGestaltView',
     'PosterView': 'MondCurrentPosterView',
     'SafariView': 'MondCurrentSafariView',
-    'Santander': 'MondCurrentSantander',
     'AppPaths': 'MondCurrentAppPaths',
     'TweakPaths': 'MondCurrentTweakPaths',
     'RespringView': 'MondCurrentRespringView',
@@ -166,15 +166,32 @@ PartyUI=$PARTYUI_COMMIT
 ZIPFoundation=$ZIPFOUNDATION_COMMIT
 EOF
 
-# Fail closed if the current app graph was not staged.
-grep -Fq 'navigationTitle("mond")' "$GEN/Mond/views_App_ContentView.swift"
-grep -Fq 'MondCurrentTerminalPlatter' "$GEN/Mond/views_App_ContentView.swift"
-grep -Fq 'Text("HouseArrest")' "$GEN/Mond/views_App_ContentView.swift"
-grep -Fq 'Text("Generate Token")' "$GEN/Mond/views_App_SettingsView.swift"
-grep -Fq 'Toggle("Keep Alive"' "$GEN/Mond/views_App_SettingsView.swift"
-grep -Fq 'Text("Respring")' "$GEN/Mond/views_App_SettingsView.swift"
-grep -Fq 'struct MondCurrentSantanderView' "$GEN/Mond/views_Tweaks_SantanderView.swift"
-grep -Fq 'mond_bad_query' "$GEN/mond_bad_query.c"
-test "$(find "$GEN/ZIPFoundation" -type f -name '*.swift' | wc -l | tr -d ' ')" -ge 20
+require_contains() {
+  local path="$1" marker="$2" label="$3"
+  grep -Fq "$marker" "$path" || {
+    echo "Current mond staging check failed: ${label} marker '${marker}' missing from ${path}" >&2
+    exit 1
+  }
+}
+
+# Fail closed on user-visible current-mond behavior rather than one particular
+# SwiftUI constructor spelling.
+require_contains "$GEN/Mond/views_App_ContentView.swift" 'navigationTitle("mond")' 'root title'
+require_contains "$GEN/Mond/views_App_ContentView.swift" 'MondCurrentTerminalPlatter' 'real terminal platter'
+require_contains "$GEN/Mond/views_App_ContentView.swift" '"MobileGestalt"' 'MobileGestalt route'
+require_contains "$GEN/Mond/views_App_ContentView.swift" '"PosterBoard"' 'PosterBoard route'
+require_contains "$GEN/Mond/views_App_ContentView.swift" '"HouseArrest"' 'current HouseArrest route'
+require_contains "$GEN/Mond/views_App_SettingsView.swift" '"Run Exploit"' 'exploit action'
+require_contains "$GEN/Mond/views_App_SettingsView.swift" '"Generate Token"' 'token action'
+require_contains "$GEN/Mond/views_App_SettingsView.swift" '"Keep Alive"' 'keep-alive setting'
+require_contains "$GEN/Mond/views_App_SettingsView.swift" '"Respring"' 'respring action'
+require_contains "$GEN/Mond/views_Tweaks_SantanderView.swift" 'struct SantanderView' 'current Santander view'
+require_contains "$GEN/mond_bad_query.c" 'mond_bad_query' 'namespaced mond bad_query'
+
+ZIP_SWIFT_COUNT="$(find "$GEN/ZIPFoundation" -type f -name '*.swift' | wc -l | tr -d ' ')"
+test "$ZIP_SWIFT_COUNT" -ge 20 || {
+  echo "Current mond staging check failed: expected >=20 ZIPFoundation Swift sources, got $ZIP_SWIFT_COUNT" >&2
+  exit 1
+}
 
 echo "Staged current mond ${MOND_COMMIT} with PartyUI ${PARTYUI_COMMIT} and ZIPFoundation ${ZIPFOUNDATION_COMMIT}"


### PR DESCRIPTION
Replaces the hand-adapted Gestalt-only mond surface with a source-level embed of current `rooootdev/mond` at `4a37bfca5cb4abb2c99891972365d872d700525e`.

The build stages that immutable mond revision plus its pinned PartyUI 1.2.0 (`830eaac8...`) and ZIPFoundation 0.9.20 (`22787ffb...`) sources. Mond types are deterministically namespaced only where necessary to coexist with ByeTunes/3105 in Filza's single Swift module. The upstream root now provides Logs, MobileGestalt, PosterBoard, current Settings, and the new disabled HouseArrest/Santander route.

`FilzaMondBridge` now presents the complete mond root directly instead of pre-resolving MobileGestalt and opening only the Gestalt editor. The legacy `MondGestaltHostFactory` Objective-C ABI remains as a forwarder to the full current root so existing toolbar/quick-action probes do not break.

`main` remains on the last green build until this PR passes the complete arm64/IPA workflow.

## Summary by Sourcery

Embed the current upstream mond application into Filza as a source-level host and present its full SwiftUI root instead of the previous Gestalt-only reconstruction.

New Features:
- Present the full mond interface (logs, settings, tweaks, PosterBoard, Santander route) directly from Filza via a new embedded host factory and SwiftUI root.
- Preserve the legacy MondGestaltHostFactory Objective-C entry point by forwarding it to the new embedded mond root to keep existing integrations working.

Enhancements:
- Update FilzaMondBridge to invoke the new embedded mond host, simplify presentation flow, and align user-facing messaging and diagnostics with the mond namespace.
- Add a dedicated Swift host (FilzaMondCurrentHost) that configures mond’s runtime, stdout capture, and environment while keeping behavior consistent with the standalone app.

Build:
- Introduce a staged, immutable mond-current tree with pinned mond, PartyUI, and ZIPFoundation revisions, wiring their sources into the build via explicit Swift file lists and C headers.
- Extend build flags and include paths for the mond-generated sources, add Compression framework linkage, and ensure pre-build checks validate staged mond components and licensing.
- Add a staging script that fetches, rewrites, and validates mond, PartyUI, ZIPFoundation, and mond’s bad_query snapshot to coexist deterministically with existing Filza dependencies.