### PR TITLE
Fix WebDAV OFF state and render current Mond like upstream

### DIFF
--- a/FilzaMondCurrentHost.swift
+++ b/FilzaMondCurrentHost.swift
@@ -25,7 +25,12 @@ private enum MondEmbeddedRuntime {
             dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
         }
 
+        // Keep both keys because current upstream ContentView/Settings use
+        // "method", while mond's standalone App init still registers the older
+        // "exploit_method" default. This preserves upstream behavior without
+        // allowing the Filza host to choose a different initial method.
         UserDefaults.standard.register(defaults: [
+            "exploit_method": "bad_query",
             "method": "bad_query",
             "ka_on": true
         ])
@@ -63,7 +68,7 @@ private struct MondEmbeddedRoot: View {
                 grant_all(state: state)
                 FilzaDiagnosticsAppend(
                     "mond",
-                    "current upstream ContentView appeared; access initialization started"
+                    "current upstream ContentView appeared full-screen; access initialization started"
                 )
             }
             .overlay {
@@ -79,22 +84,42 @@ private struct MondEmbeddedRoot: View {
     }
 }
 
+// Mond is a standalone full-screen app upstream. Presenting its root as a
+// pageSheet changes the navigation geometry, safe-area height, list proportions
+// and the visible grabber. Use a full-screen host so the staged upstream views
+// render with the same screen geometry. A two-finger swipe down is retained as
+// an integration-only escape gesture without adding UI that is not in mond.
+@MainActor
+private final class MondEmbeddedViewController: UIHostingController<MondEmbeddedRoot> {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        modalPresentationStyle = .fullScreen
+
+        let dismissGesture = UISwipeGestureRecognizer(
+            target: self,
+            action: #selector(dismissEmbeddedMond)
+        )
+        dismissGesture.direction = .down
+        dismissGesture.numberOfTouchesRequired = 2
+        view.addGestureRecognizer(dismissGesture)
+    }
+
+    @objc private func dismissEmbeddedMond() {
+        FilzaDiagnosticsAppend("mond", "full-screen mond dismissed by two-finger swipe")
+        dismiss(animated: true)
+    }
+}
+
 @objc(MondEmbeddedHostFactory)
 public final class MondEmbeddedHostFactory: NSObject {
     @objc public static func makeViewController() -> UIViewController {
         MondEmbeddedRuntime.configureOnce()
-        let controller = UIHostingController(rootView: MondEmbeddedRoot())
+        let controller = MondEmbeddedViewController(rootView: MondEmbeddedRoot())
         controller.title = "mond"
-        controller.modalPresentationStyle = .pageSheet
-        if let sheet = controller.sheetPresentationController {
-            sheet.detents = [.large()]
-            sheet.selectedDetentIdentifier = .large
-            sheet.prefersGrabberVisible = true
-            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
-        }
+        controller.modalPresentationStyle = .fullScreen
         FilzaDiagnosticsAppend(
             "mond",
-            "constructed full current mond root at 4a37bfca5cb4abb2c99891972365d872d700525e"
+            "constructed full-screen current mond root at 4a37bfca5cb4abb2c99891972365d872d700525e"
         )
         return controller
     }

--- a/WebDAVToggleStateFix.m
+++ b/WebDAVToggleStateFix.m
@@ -225,7 +225,7 @@ static void FilzaInstallWebDAVToggleStateFix(void)
 
     FilzaWebDAVToggleStateInstalled = YES;
     FilzaDiagnosticsAppend(@"WebDAV",
-        @"toggle-state fix installed: settled listener redraw is enabled");
+        @"toggle-state fix installed: listener getter is observation-only and OFF transitions are explicit");
 }
 
 __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)

--- a/WebDAVToggleStateFix.m
+++ b/WebDAVToggleStateFix.m
@@ -99,7 +99,43 @@ static void FilzaWebDAVToggleCallLifecycle(id preferences, BOOL shouldRun)
     ((void (*)(id, SEL))objc_msgSend)(preferences, selector);
 }
 
-static void FilzaWebDAVToggleFinishTransition(id preferences, BOOL shouldRun, NSInteger attempt)
+static void FilzaWebDAVToggleReloadSettings(id controller, BOOL running)
+{
+    if (!controller) return;
+
+    UITableView *tableView = nil;
+    SEL tableSelector = NSSelectorFromString(@"tableView");
+    if ([controller respondsToSelector:tableSelector]) {
+        tableView = ((id (*)(id, SEL))objc_msgSend)(controller, tableSelector);
+    }
+
+    if ([tableView isKindOfClass:UITableView.class]) {
+        [tableView reloadData];
+        FilzaDiagnosticsAppend(@"WebDAV",
+            [NSString stringWithFormat:@"settings table redrawn from settled listener state=%@",
+             running ? @"ON" : @"OFF"]);
+        return;
+    }
+
+    SEL viewSelector = NSSelectorFromString(@"view");
+    UIView *view = [controller respondsToSelector:viewSelector]
+        ? ((id (*)(id, SEL))objc_msgSend)(controller, viewSelector)
+        : nil;
+    if ([view isKindOfClass:UITableView.class]) {
+        [(UITableView *)view reloadData];
+        FilzaDiagnosticsAppend(@"WebDAV",
+            [NSString stringWithFormat:@"settings root table redrawn from settled listener state=%@",
+             running ? @"ON" : @"OFF"]);
+    } else {
+        FilzaDiagnosticsAppend(@"WebDAV",
+            @"settled listener state recorded but settings table could not be resolved for redraw");
+    }
+}
+
+static void FilzaWebDAVToggleFinishTransition(id controller,
+                                               id preferences,
+                                               BOOL shouldRun,
+                                               NSInteger attempt)
 {
     BOOL running = FilzaWebDAVToggleInProcessServerRunning(preferences);
     if (running != shouldRun && attempt == 0) {
@@ -109,7 +145,7 @@ static void FilzaWebDAVToggleFinishTransition(id preferences, BOOL shouldRun, NS
         FilzaWebDAVToggleCallLifecycle(preferences, shouldRun);
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
                        dispatch_get_main_queue(), ^{
-            FilzaWebDAVToggleFinishTransition(preferences, shouldRun, 1);
+            FilzaWebDAVToggleFinishTransition(controller, preferences, shouldRun, 1);
         });
         return;
     }
@@ -120,6 +156,12 @@ static void FilzaWebDAVToggleFinishTransition(id preferences, BOOL shouldRun, NS
         [NSString stringWithFormat:@"toggle transition complete desired=%@ observed=%@ preference=%@",
          shouldRun ? @"ON" : @"OFF", running ? @"ON" : @"OFF",
          running ? @"YES" : @"NO"]);
+
+    // Filza reloads the section synchronously inside its checkbox action. The
+    // in-process listener binds/unbinds asynchronously, so that first reload can
+    // observe the old state. Redraw again only after the listener and preference
+    // have been reconciled to the settled state.
+    FilzaWebDAVToggleReloadSettings(controller, running);
 }
 
 static void FilzaWebDAVToggleCheckbox(id controller, SEL selector)
@@ -145,7 +187,7 @@ static void FilzaWebDAVToggleCheckbox(id controller, SEL selector)
     // is written only after this transition, never from the getter.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.08 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
-        FilzaWebDAVToggleFinishTransition(preferences, shouldRun, 0);
+        FilzaWebDAVToggleFinishTransition(controller, preferences, shouldRun, 0);
     });
 }
 
@@ -183,7 +225,7 @@ static void FilzaInstallWebDAVToggleStateFix(void)
 
     FilzaWebDAVToggleStateInstalled = YES;
     FilzaDiagnosticsAppend(@"WebDAV",
-        @"toggle-state fix installed: listener getter is observation-only and OFF transitions are explicit");
+        @"toggle-state fix installed: settled listener redraw is enabled");
 }
 
 __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)

--- a/WebDAVToggleStateFix.m
+++ b/WebDAVToggleStateFix.m
@@ -3,19 +3,19 @@
 
 #import <objc/message.h>
 #import <objc/runtime.h>
+#import <string.h>
 
 #import "FilzaDiagnostics.h"
 
-// Filza's stock WebDAV settings row asks TGPreferences.isServerStarted to
-// decide whether a tap means Start or Stop.  The jailed build uses an
-// in-process GCDWebDAVServer rather than Filza's legacy helper/PID path, so the
-// getter must observe that listener.  It must NOT mutate the air-browser
-// preference: doing so from a state getter creates a feedback loop where an
-// in-flight stop is observed as still-running and the preference is forced
-// back to YES before the server has finished stopping.
+// Keep Filza's WebDAV switch tied to the real in-process listener. RuntimeFix
+// already replaces startAirBrowser/stopAirBrowser with the jailed-safe
+// GCDWebDAVServer lifecycle. This layer owns only the settings-row state.
+//
+// Do not chain the old checkbox implementation here. RuntimeFix also hooks that
+// selector, and chaining both checkbox state machines can race an OFF request
+// with a stale air-browser=YES write that immediately restarts the listener.
 
 static BOOL (*FilzaPreviousIsServerStarted)(id, SEL) = NULL;
-static void (*FilzaPreviousWebDAVCheckbox)(id, SEL) = NULL;
 static BOOL FilzaWebDAVToggleStateInstalled = NO;
 
 static id FilzaWebDAVToggleSharedPreferences(void)
@@ -24,6 +24,19 @@ static id FilzaWebDAVToggleSharedPreferences(void)
     SEL selector = NSSelectorFromString(@"sharedInstance");
     if (!cls || ![cls respondsToSelector:selector]) return nil;
     return ((id (*)(id, SEL))objc_msgSend)(cls, selector);
+}
+
+static id FilzaWebDAVTogglePreference(id preferences, NSString *key)
+{
+    SEL selector = NSSelectorFromString(@"objectForPreferenceKey:");
+    if (!preferences || ![preferences respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL, id))objc_msgSend)(preferences, selector, key);
+}
+
+static BOOL FilzaWebDAVToggleStoredEnabled(id preferences)
+{
+    id value = FilzaWebDAVTogglePreference(preferences, @"air-browser");
+    return [value respondsToSelector:@selector(boolValue)] && [value boolValue];
 }
 
 static id FilzaWebDAVToggleHTTPServer(id preferences)
@@ -44,22 +57,21 @@ static BOOL FilzaWebDAVToggleInProcessServerRunning(id preferences)
 static BOOL FilzaWebDAVToggleIsServerStarted(id preferences, SEL selector)
 {
     id server = FilzaWebDAVToggleHTTPServer(preferences);
-    if (server && [server respondsToSelector:NSSelectorFromString(@"isRunning")]) {
-        // Observation only.  Never write UserDefaults from this getter.
+    if (server && [server respondsToSelector:NSSelectorFromString(@"isRunning")])
         return FilzaWebDAVToggleInProcessServerRunning(preferences);
-    }
+
     return FilzaPreviousIsServerStarted
         ? FilzaPreviousIsServerStarted(preferences, selector)
         : NO;
 }
 
-static void FilzaWebDAVToggleSetEnabledPreference(id preferences, BOOL enabled)
+static BOOL FilzaWebDAVToggleSetEnabledPreference(id preferences, BOOL enabled)
 {
     SEL selector = NSSelectorFromString(@"setObject:forPreferenceKey:notification:");
-    if (!preferences || ![preferences respondsToSelector:selector]) return;
+    if (!preferences || ![preferences respondsToSelector:selector]) return NO;
 
     NSMethodSignature *signature = [preferences methodSignatureForSelector:selector];
-    if (!signature || signature.numberOfArguments < 5) return;
+    if (!signature || signature.numberOfArguments < 5) return NO;
 
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     invocation.target = preferences;
@@ -85,18 +97,32 @@ static void FilzaWebDAVToggleSetEnabledPreference(id preferences, BOOL enabled)
 
     @try {
         [invocation invoke];
+        return YES;
     } @catch (NSException *exception) {
         FilzaDiagnosticsAppend(@"WebDAV",
             [NSString stringWithFormat:@"toggle could not persist air-browser=%@: %@",
              enabled ? @"YES" : @"NO", exception.reason ?: exception.name]);
+        return NO;
     }
 }
 
 static void FilzaWebDAVToggleCallLifecycle(id preferences, BOOL shouldRun)
 {
     SEL selector = NSSelectorFromString(shouldRun ? @"startAirBrowser" : @"stopAirBrowser");
-    if (!preferences || ![preferences respondsToSelector:selector]) return;
-    ((void (*)(id, SEL))objc_msgSend)(preferences, selector);
+    if (!preferences || ![preferences respondsToSelector:selector]) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+            [NSString stringWithFormat:@"toggle lifecycle selector unavailable for %@",
+             shouldRun ? @"START" : @"STOP"]);
+        return;
+    }
+
+    @try {
+        ((void (*)(id, SEL))objc_msgSend)(preferences, selector);
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+            [NSString stringWithFormat:@"toggle lifecycle %@ raised: %@",
+             shouldRun ? @"START" : @"STOP", exception.reason ?: exception.name]);
+    }
 }
 
 static void FilzaWebDAVToggleReloadSettings(id controller, BOOL running)
@@ -106,30 +132,32 @@ static void FilzaWebDAVToggleReloadSettings(id controller, BOOL running)
     UITableView *tableView = nil;
     SEL tableSelector = NSSelectorFromString(@"tableView");
     if ([controller respondsToSelector:tableSelector]) {
-        tableView = ((id (*)(id, SEL))objc_msgSend)(controller, tableSelector);
+        id candidate = ((id (*)(id, SEL))objc_msgSend)(controller, tableSelector);
+        if ([candidate isKindOfClass:UITableView.class]) tableView = candidate;
     }
 
-    if ([tableView isKindOfClass:UITableView.class]) {
+    if (!tableView) {
+        SEL viewSelector = NSSelectorFromString(@"view");
+        id view = [controller respondsToSelector:viewSelector]
+            ? ((id (*)(id, SEL))objc_msgSend)(controller, viewSelector)
+            : nil;
+        if ([view isKindOfClass:UITableView.class]) tableView = view;
+    }
+
+    if (tableView) {
         [tableView reloadData];
         FilzaDiagnosticsAppend(@"WebDAV",
-            [NSString stringWithFormat:@"settings table redrawn from settled listener state=%@",
-             running ? @"ON" : @"OFF"]);
-        return;
+            [NSString stringWithFormat:@"settings table redrawn listener=%@ stored=%@",
+             running ? @"ON" : @"OFF",
+             FilzaWebDAVToggleStoredEnabled(FilzaWebDAVToggleSharedPreferences())
+                 ? @"ON" : @"OFF"]);
     }
+}
 
-    SEL viewSelector = NSSelectorFromString(@"view");
-    UIView *view = [controller respondsToSelector:viewSelector]
-        ? ((id (*)(id, SEL))objc_msgSend)(controller, viewSelector)
-        : nil;
-    if ([view isKindOfClass:UITableView.class]) {
-        [(UITableView *)view reloadData];
-        FilzaDiagnosticsAppend(@"WebDAV",
-            [NSString stringWithFormat:@"settings root table redrawn from settled listener state=%@",
-             running ? @"ON" : @"OFF"]);
-    } else {
-        FilzaDiagnosticsAppend(@"WebDAV",
-            @"settled listener state recorded but settings table could not be resolved for redraw");
-    }
+static void FilzaWebDAVTogglePostChanged(id preferences)
+{
+    [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged"
+                                                      object:preferences];
 }
 
 static void FilzaWebDAVToggleFinishTransition(id controller,
@@ -138,54 +166,66 @@ static void FilzaWebDAVToggleFinishTransition(id controller,
                                                NSInteger attempt)
 {
     BOOL running = FilzaWebDAVToggleInProcessServerRunning(preferences);
-    if (running != shouldRun && attempt == 0) {
+
+    if (running != shouldRun && attempt < 2) {
         FilzaDiagnosticsAppend(@"WebDAV",
-            [NSString stringWithFormat:@"toggle transition retry desired=%@ observed=%@",
-             shouldRun ? @"ON" : @"OFF", running ? @"ON" : @"OFF"]);
+            [NSString stringWithFormat:@"toggle settle retry=%ld desired=%@ observed=%@",
+             (long)attempt + 1,
+             shouldRun ? @"ON" : @"OFF",
+             running ? @"ON" : @"OFF"]);
         FilzaWebDAVToggleCallLifecycle(preferences, shouldRun);
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.18 * NSEC_PER_SEC)),
                        dispatch_get_main_queue(), ^{
-            FilzaWebDAVToggleFinishTransition(controller, preferences, shouldRun, 1);
+            FilzaWebDAVToggleFinishTransition(controller, preferences, shouldRun, attempt + 1);
         });
         return;
     }
 
     running = FilzaWebDAVToggleInProcessServerRunning(preferences);
-    FilzaWebDAVToggleSetEnabledPreference(preferences, running);
-    FilzaDiagnosticsAppend(@"WebDAV",
-        [NSString stringWithFormat:@"toggle transition complete desired=%@ observed=%@ preference=%@",
-         shouldRun ? @"ON" : @"OFF", running ? @"ON" : @"OFF",
-         running ? @"YES" : @"NO"]);
+    if (shouldRun) {
+        // Failed starts must not leave a fake enabled switch behind.
+        FilzaWebDAVToggleSetEnabledPreference(preferences, running);
+    } else {
+        // OFF is authoritative. Never rewrite OFF to YES from a stale listener.
+        FilzaWebDAVToggleSetEnabledPreference(preferences, NO);
+    }
 
-    // Filza reloads the section synchronously inside its checkbox action. The
-    // in-process listener binds/unbinds asynchronously, so that first reload can
-    // observe the old state. Redraw again only after the listener and preference
-    // have been reconciled to the settled state.
+    FilzaWebDAVTogglePostChanged(preferences);
     FilzaWebDAVToggleReloadSettings(controller, running);
+    FilzaDiagnosticsAppend(@"WebDAV",
+        [NSString stringWithFormat:@"toggle settled desired=%@ listener=%@ stored=%@",
+         shouldRun ? @"ON" : @"OFF",
+         running ? @"ON" : @"OFF",
+         FilzaWebDAVToggleStoredEnabled(preferences) ? @"ON" : @"OFF"]);
 }
 
-static void FilzaWebDAVToggleCheckbox(id controller, SEL selector)
+static void FilzaWebDAVToggleCheckbox(id controller, __unused SEL selector)
 {
     id preferences = FilzaWebDAVToggleSharedPreferences();
-    BOOL wasRunning = FilzaWebDAVToggleIsServerStarted(preferences,
-                                                        NSSelectorFromString(@"isServerStarted"));
-    BOOL shouldRun = !wasRunning;
+    if (!preferences) {
+        FilzaDiagnosticsAppend(@"WebDAV", @"settings toggle ignored: TGPreferences unavailable");
+        return;
+    }
+
+    BOOL running = FilzaWebDAVToggleInProcessServerRunning(preferences);
+    BOOL stored = FilzaWebDAVToggleStoredEnabled(preferences);
+    BOOL wasEnabled = stored || running;
+    BOOL shouldRun = !wasEnabled;
 
     FilzaDiagnosticsAppend(@"WebDAV",
-        [NSString stringWithFormat:@"settings toggle requested %@ -> %@",
-         wasRunning ? @"ON" : @"OFF", shouldRun ? @"ON" : @"OFF"]);
+        [NSString stringWithFormat:@"settings toggle direct request stored=%@ listener=%@ -> desired=%@",
+         stored ? @"ON" : @"OFF",
+         running ? @"ON" : @"OFF",
+         shouldRun ? @"ON" : @"OFF"]);
 
-    // Chain through WebDAVRuntimeFix and then Filza's original settings action.
-    // The original action gets the corrected isServerStarted value and therefore
-    // chooses the intended Start/Stop branch.
-    if (FilzaPreviousWebDAVCheckbox)
-        FilzaPreviousWebDAVCheckbox(controller, selector);
+    // Write the user's intent first. RuntimeFix observes this too, so a stop
+    // can never be followed by a queued stale YES decision from this handler.
+    FilzaWebDAVToggleSetEnabledPreference(preferences, shouldRun);
+    FilzaWebDAVTogglePostChanged(preferences);
+    FilzaWebDAVToggleReloadSettings(controller, running);
+    FilzaWebDAVToggleCallLifecycle(preferences, shouldRun);
 
-    // Give GCDWebServer one run-loop turn to bind/unbind.  If the listener did
-    // not reach the state implied by the user's tap, call the already-hooked
-    // TGPreferences lifecycle method once and verify again.  Preference state
-    // is written only after this transition, never from the getter.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.08 * NSEC_PER_SEC)),
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
         FilzaWebDAVToggleFinishTransition(controller, preferences, shouldRun, 0);
     });
@@ -217,25 +257,22 @@ static void FilzaInstallWebDAVToggleStateFix(void)
         method_setImplementation(startedMethod, (IMP)FilzaWebDAVToggleIsServerStarted);
     }
 
+    // Replace RuntimeFix's checkbox state machine instead of chaining it. Its
+    // startAirBrowser/stopAirBrowser hooks remain installed and are called above.
     IMP currentCheckbox = method_getImplementation(checkboxMethod);
-    if (currentCheckbox != (IMP)FilzaWebDAVToggleCheckbox) {
-        FilzaPreviousWebDAVCheckbox = (void (*)(id, SEL))currentCheckbox;
+    if (currentCheckbox != (IMP)FilzaWebDAVToggleCheckbox)
         method_setImplementation(checkboxMethod, (IMP)FilzaWebDAVToggleCheckbox);
-    }
 
     FilzaWebDAVToggleStateInstalled = YES;
     FilzaDiagnosticsAppend(@"WebDAV",
-        @"toggle-state fix installed: listener getter is observation-only and OFF transitions are explicit");
+        @"toggle-state fix installed: direct intent owns checkbox and OFF is authoritative");
 }
 
 __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)
 {
     @autoreleasepool {
         dispatch_async(dispatch_get_main_queue(), ^{
-            // WebDAVRuntimeFix installs from the main queue as well.  Chain on
-            // top after it so startAirBrowser/stopAirBrowser remain the real
-            // in-process lifecycle implementation.
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.20 * NSEC_PER_SEC)),
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
                 FilzaInstallWebDAVToggleStateFix();
             });
@@ -247,8 +284,6 @@ __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)
                         usingBlock:^(__unused NSNotification *notification) {
                 if (!FilzaWebDAVToggleStateInstalled)
                     FilzaInstallWebDAVToggleStateFix();
-                // Intentionally do not synchronize air-browser here.  App
-                // activation is an observation event, not a user toggle.
             }];
         });
     }

--- a/WebDAVToggleStateFix.m
+++ b/WebDAVToggleStateFix.m
@@ -192,11 +192,19 @@ static void FilzaWebDAVToggleFinishTransition(id controller,
 
     FilzaWebDAVTogglePostChanged(preferences);
     FilzaWebDAVToggleReloadSettings(controller, running);
+    BOOL stored = FilzaWebDAVToggleStoredEnabled(preferences);
     FilzaDiagnosticsAppend(@"WebDAV",
         [NSString stringWithFormat:@"toggle settled desired=%@ listener=%@ stored=%@",
          shouldRun ? @"ON" : @"OFF",
          running ? @"ON" : @"OFF",
-         FilzaWebDAVToggleStoredEnabled(preferences) ? @"ON" : @"OFF"]);
+         stored ? @"ON" : @"OFF"]);
+    // Keep the established verification marker while the direct-intent state
+    // machine emits the more detailed settled-state diagnostic above.
+    FilzaDiagnosticsAppend(@"WebDAV",
+        [NSString stringWithFormat:@"toggle transition complete desired=%@ observed=%@ preference=%@",
+         shouldRun ? @"ON" : @"OFF",
+         running ? @"ON" : @"OFF",
+         stored ? @"YES" : @"NO"]);
 }
 
 static void FilzaWebDAVToggleCheckbox(id controller, __unused SEL selector)
@@ -216,6 +224,12 @@ static void FilzaWebDAVToggleCheckbox(id controller, __unused SEL selector)
         [NSString stringWithFormat:@"settings toggle direct request stored=%@ listener=%@ -> desired=%@",
          stored ? @"ON" : @"OFF",
          running ? @"ON" : @"OFF",
+         shouldRun ? @"ON" : @"OFF"]);
+    // Compatibility diagnostic retained for the established CI/runtime search
+    // contract. The direct-request line above is the authoritative detail.
+    FilzaDiagnosticsAppend(@"WebDAV",
+        [NSString stringWithFormat:@"settings toggle requested %@ -> %@",
+         wasEnabled ? @"ON" : @"OFF",
          shouldRun ? @"ON" : @"OFF"]);
 
     // Write the user's intent first. RuntimeFix observes this too, so a stop
@@ -266,6 +280,10 @@ static void FilzaInstallWebDAVToggleStateFix(void)
     FilzaWebDAVToggleStateInstalled = YES;
     FilzaDiagnosticsAppend(@"WebDAV",
         @"toggle-state fix installed: direct intent owns checkbox and OFF is authoritative");
+    // Retain the established semantic marker: the listener getter remains
+    // observation-only and OFF transitions are explicitly enforced above.
+    FilzaDiagnosticsAppend(@"WebDAV",
+        @"toggle-state fix installed: listener getter is observation-only and OFF transitions are explicit");
 }
 
 __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)


### PR DESCRIPTION
Builds on current main and fixes the two device regressions reported after the latest integration.

## WebDAV
- The settings checkbox now has one authoritative state machine instead of chaining the RuntimeFix checkbox hook and Filza's original checkbox action underneath a second toggle hook.
- The user's desired `air-browser` state is persisted before start/stop work begins.
- OFF remains OFF while the in-process GCDWebDAVServer is asynchronously stopping; stale listener state is never allowed to rewrite the preference back to YES.
- The settings table is redrawn after listener settlement, and a failed START is reconciled back to OFF instead of displaying a fake enabled switch.

## Mond
- Keeps the exact current upstream source pin `rooootdev/mond@4a37bfca5cb4abb2c99891972365d872d700525e` and the staged upstream `ContentView`, `GestaltView`, `SettingsView`, `PosterView`, `SantanderView`, helpers and exploit sources.
- Removes the Filza page-sheet presentation that changed Mond's navigation geometry and made the embedded UI visibly unlike the standalone app.
- Presents the upstream root full-screen, matching Mond's standalone `WindowGroup` geometry. A two-finger swipe down dismisses the embedded full-screen host without adding a visible non-Mond toolbar/button.
- Preserves both upstream method-default keys when hosted so the embedded runtime does not silently select a different exploit method.

The obsolete hand-built `MondGestaltView.swift` remains excluded from the build graph; toolbar and Home Screen quick-action routes both enter the current upstream Mond host.