### PR TITLE
Fix Mond fidelity and WebDAV forced-ON toggle on current main

### DIFF
--- a/FilzaMondCurrentHost.swift
+++ b/FilzaMondCurrentHost.swift
@@ -25,7 +25,12 @@ private enum MondEmbeddedRuntime {
             dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
         }
 
+        // Keep both keys because current upstream ContentView/Settings use
+        // "method", while mond's standalone App init still registers the older
+        // "exploit_method" default. This preserves upstream behavior without
+        // allowing the Filza host to choose a different initial method.
         UserDefaults.standard.register(defaults: [
+            "exploit_method": "bad_query",
             "method": "bad_query",
             "ka_on": true
         ])
@@ -63,7 +68,7 @@ private struct MondEmbeddedRoot: View {
                 grant_all(state: state)
                 FilzaDiagnosticsAppend(
                     "mond",
-                    "current upstream ContentView appeared; access initialization started"
+                    "current upstream ContentView appeared full-screen; access initialization started"
                 )
             }
             .overlay {
@@ -79,22 +84,42 @@ private struct MondEmbeddedRoot: View {
     }
 }
 
+// Mond is a standalone full-screen app upstream. Presenting its root as a
+// pageSheet changes the navigation geometry, safe-area height, list proportions
+// and the visible grabber. Use a full-screen host so the staged upstream views
+// render with the same screen geometry. A two-finger swipe down is retained as
+// an integration-only escape gesture without adding UI that is not in mond.
+@MainActor
+private final class MondEmbeddedViewController: UIHostingController<MondEmbeddedRoot> {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        modalPresentationStyle = .fullScreen
+
+        let dismissGesture = UISwipeGestureRecognizer(
+            target: self,
+            action: #selector(dismissEmbeddedMond)
+        )
+        dismissGesture.direction = .down
+        dismissGesture.numberOfTouchesRequired = 2
+        view.addGestureRecognizer(dismissGesture)
+    }
+
+    @objc private func dismissEmbeddedMond() {
+        FilzaDiagnosticsAppend("mond", "full-screen mond dismissed by two-finger swipe")
+        dismiss(animated: true)
+    }
+}
+
 @objc(MondEmbeddedHostFactory)
 public final class MondEmbeddedHostFactory: NSObject {
     @objc public static func makeViewController() -> UIViewController {
         MondEmbeddedRuntime.configureOnce()
-        let controller = UIHostingController(rootView: MondEmbeddedRoot())
+        let controller = MondEmbeddedViewController(rootView: MondEmbeddedRoot())
         controller.title = "mond"
-        controller.modalPresentationStyle = .pageSheet
-        if let sheet = controller.sheetPresentationController {
-            sheet.detents = [.large()]
-            sheet.selectedDetentIdentifier = .large
-            sheet.prefersGrabberVisible = true
-            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
-        }
+        controller.modalPresentationStyle = .fullScreen
         FilzaDiagnosticsAppend(
             "mond",
-            "constructed full current mond root at 4a37bfca5cb4abb2c99891972365d872d700525e"
+            "constructed full-screen current mond root at 4a37bfca5cb4abb2c99891972365d872d700525e"
         )
         return controller
     }

--- a/WebDAVToggleStateFix.m
+++ b/WebDAVToggleStateFix.m
@@ -3,24 +3,19 @@
 
 #import <objc/message.h>
 #import <objc/runtime.h>
+#import <string.h>
 
 #import "FilzaDiagnostics.h"
 
-// Filza's stock WebDAV settings row asks TGPreferences.isServerStarted to
-// decide whether a tap means Start or Stop.  The jailed build uses an
-// in-process GCDWebDAVServer rather than Filza's legacy helper/PID path, so the
-// getter must observe that listener.  It must NOT mutate the air-browser
-// preference: doing so from a state getter creates a feedback loop where an
-// in-flight stop is observed as still-running and the preference is forced
-// back to YES before the server has finished stopping.
+// Keep Filza's WebDAV switch tied to the real in-process listener. RuntimeFix
+// already replaces startAirBrowser/stopAirBrowser with the jailed-safe
+// GCDWebDAVServer lifecycle. This layer owns only the settings-row state.
 //
-// The stock settings controller can also reload its switch before the
-// in-process listener has finished binding/unbinding.  After a verified
-// transition, explicitly reload the preferences table so the visible switch is
-// rendered from the final listener-backed state instead of a stale cell value.
+// Do not chain the old checkbox implementation here. RuntimeFix also hooks that
+// selector, and chaining both checkbox state machines can race an OFF request
+// with a stale air-browser=YES write that immediately restarts the listener.
 
 static BOOL (*FilzaPreviousIsServerStarted)(id, SEL) = NULL;
-static void (*FilzaPreviousWebDAVCheckbox)(id, SEL) = NULL;
 static BOOL FilzaWebDAVToggleStateInstalled = NO;
 
 static id FilzaWebDAVToggleSharedPreferences(void)
@@ -29,6 +24,19 @@ static id FilzaWebDAVToggleSharedPreferences(void)
     SEL selector = NSSelectorFromString(@"sharedInstance");
     if (!cls || ![cls respondsToSelector:selector]) return nil;
     return ((id (*)(id, SEL))objc_msgSend)(cls, selector);
+}
+
+static id FilzaWebDAVTogglePreference(id preferences, NSString *key)
+{
+    SEL selector = NSSelectorFromString(@"objectForPreferenceKey:");
+    if (!preferences || ![preferences respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL, id))objc_msgSend)(preferences, selector, key);
+}
+
+static BOOL FilzaWebDAVToggleStoredEnabled(id preferences)
+{
+    id value = FilzaWebDAVTogglePreference(preferences, @"air-browser");
+    return [value respondsToSelector:@selector(boolValue)] && [value boolValue];
 }
 
 static id FilzaWebDAVToggleHTTPServer(id preferences)
@@ -49,22 +57,21 @@ static BOOL FilzaWebDAVToggleInProcessServerRunning(id preferences)
 static BOOL FilzaWebDAVToggleIsServerStarted(id preferences, SEL selector)
 {
     id server = FilzaWebDAVToggleHTTPServer(preferences);
-    if (server && [server respondsToSelector:NSSelectorFromString(@"isRunning")]) {
-        // Observation only.  Never write UserDefaults from this getter.
+    if (server && [server respondsToSelector:NSSelectorFromString(@"isRunning")])
         return FilzaWebDAVToggleInProcessServerRunning(preferences);
-    }
+
     return FilzaPreviousIsServerStarted
         ? FilzaPreviousIsServerStarted(preferences, selector)
         : NO;
 }
 
-static void FilzaWebDAVToggleSetEnabledPreference(id preferences, BOOL enabled)
+static BOOL FilzaWebDAVToggleSetEnabledPreference(id preferences, BOOL enabled)
 {
     SEL selector = NSSelectorFromString(@"setObject:forPreferenceKey:notification:");
-    if (!preferences || ![preferences respondsToSelector:selector]) return;
+    if (!preferences || ![preferences respondsToSelector:selector]) return NO;
 
     NSMethodSignature *signature = [preferences methodSignatureForSelector:selector];
-    if (!signature || signature.numberOfArguments < 5) return;
+    if (!signature || signature.numberOfArguments < 5) return NO;
 
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     invocation.target = preferences;
@@ -90,21 +97,35 @@ static void FilzaWebDAVToggleSetEnabledPreference(id preferences, BOOL enabled)
 
     @try {
         [invocation invoke];
+        return YES;
     } @catch (NSException *exception) {
         FilzaDiagnosticsAppend(@"WebDAV",
             [NSString stringWithFormat:@"toggle could not persist air-browser=%@: %@",
              enabled ? @"YES" : @"NO", exception.reason ?: exception.name]);
+        return NO;
     }
 }
 
 static void FilzaWebDAVToggleCallLifecycle(id preferences, BOOL shouldRun)
 {
     SEL selector = NSSelectorFromString(shouldRun ? @"startAirBrowser" : @"stopAirBrowser");
-    if (!preferences || ![preferences respondsToSelector:selector]) return;
-    ((void (*)(id, SEL))objc_msgSend)(preferences, selector);
+    if (!preferences || ![preferences respondsToSelector:selector]) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+            [NSString stringWithFormat:@"toggle lifecycle selector unavailable for %@",
+             shouldRun ? @"START" : @"STOP"]);
+        return;
+    }
+
+    @try {
+        ((void (*)(id, SEL))objc_msgSend)(preferences, selector);
+    } @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"WebDAV",
+            [NSString stringWithFormat:@"toggle lifecycle %@ raised: %@",
+             shouldRun ? @"START" : @"STOP", exception.reason ?: exception.name]);
+    }
 }
 
-static void FilzaWebDAVToggleRefreshVisibleSettings(id controller, BOOL running)
+static void FilzaWebDAVToggleReloadSettings(id controller, BOOL running)
 {
     if (!controller) return;
 
@@ -112,11 +133,19 @@ static void FilzaWebDAVToggleRefreshVisibleSettings(id controller, BOOL running)
     if ([controller isKindOfClass:UITableViewController.class]) {
         tableView = ((UITableViewController *)controller).tableView;
     } else {
-        SEL tableViewSelector = NSSelectorFromString(@"tableView");
-        if ([controller respondsToSelector:tableViewSelector]) {
-            id candidate = ((id (*)(id, SEL))objc_msgSend)(controller, tableViewSelector);
+        SEL tableSelector = NSSelectorFromString(@"tableView");
+        if ([controller respondsToSelector:tableSelector]) {
+            id candidate = ((id (*)(id, SEL))objc_msgSend)(controller, tableSelector);
             if ([candidate isKindOfClass:UITableView.class]) tableView = candidate;
         }
+    }
+
+    if (!tableView) {
+        SEL viewSelector = NSSelectorFromString(@"view");
+        id view = [controller respondsToSelector:viewSelector]
+            ? ((id (*)(id, SEL))objc_msgSend)(controller, viewSelector)
+            : nil;
+        if ([view isKindOfClass:UITableView.class]) tableView = view;
     }
 
     if (!tableView) {
@@ -128,62 +157,100 @@ static void FilzaWebDAVToggleRefreshVisibleSettings(id controller, BOOL running)
     [tableView reloadData];
     [tableView setNeedsLayout];
     [tableView layoutIfNeeded];
+
+    BOOL stored = FilzaWebDAVToggleStoredEnabled(FilzaWebDAVToggleSharedPreferences());
+    FilzaDiagnosticsAppend(@"WebDAV",
+        [NSString stringWithFormat:@"settings table redrawn listener=%@ stored=%@",
+         running ? @"ON" : @"OFF", stored ? @"ON" : @"OFF"]);
     FilzaDiagnosticsAppend(@"WebDAV",
         [NSString stringWithFormat:@"settings UI refreshed from listener state=%@",
          running ? @"ON" : @"OFF"]);
 }
 
-static void FilzaWebDAVToggleFinishTransition(id preferences,
-                                               id controller,
+static void FilzaWebDAVTogglePostChanged(id preferences)
+{
+    [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged"
+                                                      object:preferences];
+}
+
+static void FilzaWebDAVToggleFinishTransition(id controller,
+                                               id preferences,
                                                BOOL shouldRun,
                                                NSInteger attempt)
 {
     BOOL running = FilzaWebDAVToggleInProcessServerRunning(preferences);
-    if (running != shouldRun && attempt == 0) {
+
+    if (running != shouldRun && attempt < 2) {
         FilzaDiagnosticsAppend(@"WebDAV",
-            [NSString stringWithFormat:@"toggle transition retry desired=%@ observed=%@",
-             shouldRun ? @"ON" : @"OFF", running ? @"ON" : @"OFF"]);
+            [NSString stringWithFormat:@"toggle settle retry=%ld desired=%@ observed=%@",
+             (long)attempt + 1,
+             shouldRun ? @"ON" : @"OFF",
+             running ? @"ON" : @"OFF"]);
         FilzaWebDAVToggleCallLifecycle(preferences, shouldRun);
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)),
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.18 * NSEC_PER_SEC)),
                        dispatch_get_main_queue(), ^{
-            FilzaWebDAVToggleFinishTransition(preferences, controller, shouldRun, 1);
+            FilzaWebDAVToggleFinishTransition(controller, preferences, shouldRun, attempt + 1);
         });
         return;
     }
 
     running = FilzaWebDAVToggleInProcessServerRunning(preferences);
-    FilzaWebDAVToggleSetEnabledPreference(preferences, running);
-    FilzaWebDAVToggleRefreshVisibleSettings(controller, running);
+    if (shouldRun) {
+        // Failed starts must not leave a fake enabled switch behind.
+        FilzaWebDAVToggleSetEnabledPreference(preferences, running);
+    } else {
+        // OFF is authoritative. Never rewrite OFF to YES from a stale listener.
+        FilzaWebDAVToggleSetEnabledPreference(preferences, NO);
+    }
+
+    FilzaWebDAVTogglePostChanged(preferences);
+    FilzaWebDAVToggleReloadSettings(controller, running);
+    BOOL stored = FilzaWebDAVToggleStoredEnabled(preferences);
+    FilzaDiagnosticsAppend(@"WebDAV",
+        [NSString stringWithFormat:@"toggle settled desired=%@ listener=%@ stored=%@",
+         shouldRun ? @"ON" : @"OFF",
+         running ? @"ON" : @"OFF",
+         stored ? @"ON" : @"OFF"]);
     FilzaDiagnosticsAppend(@"WebDAV",
         [NSString stringWithFormat:@"toggle transition complete desired=%@ observed=%@ preference=%@",
-         shouldRun ? @"ON" : @"OFF", running ? @"ON" : @"OFF",
-         running ? @"YES" : @"NO"]);
+         shouldRun ? @"ON" : @"OFF",
+         running ? @"ON" : @"OFF",
+         stored ? @"YES" : @"NO"]);
 }
 
-static void FilzaWebDAVToggleCheckbox(id controller, SEL selector)
+static void FilzaWebDAVToggleCheckbox(id controller, __unused SEL selector)
 {
     id preferences = FilzaWebDAVToggleSharedPreferences();
-    BOOL wasRunning = FilzaWebDAVToggleIsServerStarted(preferences,
-                                                        NSSelectorFromString(@"isServerStarted"));
-    BOOL shouldRun = !wasRunning;
+    if (!preferences) {
+        FilzaDiagnosticsAppend(@"WebDAV", @"settings toggle ignored: TGPreferences unavailable");
+        return;
+    }
+
+    BOOL running = FilzaWebDAVToggleInProcessServerRunning(preferences);
+    BOOL stored = FilzaWebDAVToggleStoredEnabled(preferences);
+    BOOL wasEnabled = stored || running;
+    BOOL shouldRun = !wasEnabled;
 
     FilzaDiagnosticsAppend(@"WebDAV",
+        [NSString stringWithFormat:@"settings toggle direct request stored=%@ listener=%@ -> desired=%@",
+         stored ? @"ON" : @"OFF",
+         running ? @"ON" : @"OFF",
+         shouldRun ? @"ON" : @"OFF"]);
+    FilzaDiagnosticsAppend(@"WebDAV",
         [NSString stringWithFormat:@"settings toggle requested %@ -> %@",
-         wasRunning ? @"ON" : @"OFF", shouldRun ? @"ON" : @"OFF"]);
+         wasEnabled ? @"ON" : @"OFF",
+         shouldRun ? @"ON" : @"OFF"]);
 
-    // Chain through WebDAVRuntimeFix and then Filza's original settings action.
-    // The original action gets the corrected isServerStarted value and therefore
-    // chooses the intended Start/Stop branch.
-    if (FilzaPreviousWebDAVCheckbox)
-        FilzaPreviousWebDAVCheckbox(controller, selector);
+    // Persist user intent before lifecycle work. RuntimeFix sees OFF before the
+    // listener starts unwinding, so queued stale state cannot restart it.
+    FilzaWebDAVToggleSetEnabledPreference(preferences, shouldRun);
+    FilzaWebDAVTogglePostChanged(preferences);
+    FilzaWebDAVToggleReloadSettings(controller, running);
+    FilzaWebDAVToggleCallLifecycle(preferences, shouldRun);
 
-    // Give GCDWebServer one run-loop turn to bind/unbind.  If the listener did
-    // not reach the state implied by the user's tap, call the already-hooked
-    // TGPreferences lifecycle method once and verify again.  Preference state
-    // and the visible table are synchronized only after this transition.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.08 * NSEC_PER_SEC)),
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.12 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{
-        FilzaWebDAVToggleFinishTransition(preferences, controller, shouldRun, 0);
+        FilzaWebDAVToggleFinishTransition(controller, preferences, shouldRun, 0);
     });
 }
 
@@ -213,14 +280,15 @@ static void FilzaInstallWebDAVToggleStateFix(void)
         method_setImplementation(startedMethod, (IMP)FilzaWebDAVToggleIsServerStarted);
     }
 
+    // Replace RuntimeFix's checkbox state machine instead of chaining it. Its
+    // startAirBrowser/stopAirBrowser hooks remain installed and are called above.
     IMP currentCheckbox = method_getImplementation(checkboxMethod);
-    if (currentCheckbox != (IMP)FilzaWebDAVToggleCheckbox) {
-        FilzaPreviousWebDAVCheckbox = (void (*)(id, SEL))currentCheckbox;
+    if (currentCheckbox != (IMP)FilzaWebDAVToggleCheckbox)
         method_setImplementation(checkboxMethod, (IMP)FilzaWebDAVToggleCheckbox);
-    }
 
     FilzaWebDAVToggleStateInstalled = YES;
-    // Keep the established release-proof marker for existing CI consumers.
+    FilzaDiagnosticsAppend(@"WebDAV",
+        @"toggle-state fix installed: direct intent owns checkbox and OFF is authoritative");
     FilzaDiagnosticsAppend(@"WebDAV",
         @"toggle-state fix installed: listener getter is observation-only and OFF transitions are explicit");
     FilzaDiagnosticsAppend(@"WebDAV",
@@ -231,10 +299,7 @@ __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)
 {
     @autoreleasepool {
         dispatch_async(dispatch_get_main_queue(), ^{
-            // WebDAVRuntimeFix installs from the main queue as well.  Chain on
-            // top after it so startAirBrowser/stopAirBrowser remain the real
-            // in-process lifecycle implementation.
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.20 * NSEC_PER_SEC)),
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
                 FilzaInstallWebDAVToggleStateFix();
             });
@@ -246,8 +311,6 @@ __attribute__((constructor)) static void FilzaWebDAVToggleStateInit(void)
                         usingBlock:^(__unused NSNotification *notification) {
                 if (!FilzaWebDAVToggleStateInstalled)
                     FilzaInstallWebDAVToggleStateFix();
-                // Intentionally do not synchronize air-browser here.  App
-                // activation is an observation event, not a user toggle.
             }];
         });
     }


### PR DESCRIPTION
Replaces the conflicted PR with the same verified Mond/WebDAV fixes rebased cleanly onto current main `bdc26f785715e28e8f91412406b1aa6c06160750`.

## Mond
- Uses the staged current upstream Mond source graph pinned at `rooootdev/mond@4a37bfca5cb4abb2c99891972365d872d700525e`.
- Presents the upstream `ContentView` full-screen instead of wrapping it in a Filza page sheet, restoring standalone Mond navigation/list geometry.
- Keeps upstream runtime defaults for both `method` and legacy `exploit_method`.
- Both toolbar and legacy Gestalt host paths enter the same complete current Mond root; the obsolete hand-built Gestalt reconstruction remains out of the build graph.

## WebDAV
- Removes the double-checkbox state-machine race by directly replacing `swithAirBrowserCheckbox` instead of chaining RuntimeFix + Filza's original action.
- Persists the user's desired `air-browser` state before lifecycle work.
- OFF is authoritative while GCDWebDAVServer stops and is never rewritten to YES from stale `isRunning` state.
- Failed START reconciles back to OFF.
- Retains current-main's post-transition table reload, `setNeedsLayout`, and `layoutIfNeeded` so the visible switch reflects final listener state.
- Preserves established runtime/CI diagnostics markers.

The previous exact implementation compiled, linked, packaged, and uploaded an installable arm64 IPA successfully in Actions run 31866959600. This PR reapplies it to current main plus the newer UI-refresh change.

## Summary by Sourcery

Update Mond integration to use a full-screen upstream host while tightening WebDAV toggle state handling to align the UI switch and persisted preference with the actual in-process server lifecycle.

New Features:
- Present Mond’s current upstream ContentView as a full-screen host within Filza instead of a page sheet, restoring native navigation and layout behavior.

Bug Fixes:
- Prevent WebDAV switch race conditions by owning the checkbox state machine directly instead of chaining multiple toggle implementations.
- Ensure WebDAV OFF requests remain authoritative, avoiding stale isRunning or preference state from re-enabling the server after stop.
- Persist the user’s intended WebDAV air-browser setting before lifecycle changes and reconcile failed starts back to a disabled state so the UI and listener do not diverge.

Enhancements:
- Align Mond embedded runtime defaults with upstream by registering both legacy exploit_method and method keys without allowing Filza to override the chosen method.
- Improve WebDAV diagnostics and settling behavior by adding retries, richer logging, and robust handling when preferences, lifecycle selectors, or tables are unavailable.
- Refresh the WebDAV settings UI more reliably by reloading the appropriate table view or controller view and posting change notifications after state transitions.