### PR TITLE
Publish one universal iOS 16.1+ IPA

### DIFF
--- a/.github/workflows/publish-green-ipa-release.yml
+++ b/.github/workflows/publish-green-ipa-release.yml
@@ -20,8 +20,58 @@ jobs:
       - name: Checkout release metadata
         uses: actions/checkout@v4
 
-      - name: Wait for exact-SHA modern IPA build
-        id: modern
+      - name: Wait for exact-SHA universal IPA build
+        id: universal
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 90); do
+            RUN_JSON="$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow verify-single-universal-ipa.yml \
+              --commit "$GITHUB_SHA" \
+              --limit 1 \
+              --json databaseId,status,conclusion,headSha,number 2>/dev/null || true)"
+
+            RUN_ID="$(jq -r '.[0].databaseId // empty' <<<"$RUN_JSON")"
+            if [[ -z "$RUN_ID" ]]; then
+              echo "Universal IPA run for $GITHUB_SHA has not appeared yet (attempt $attempt/90)."
+              sleep 10
+              continue
+            fi
+
+            RUN_STATUS="$(jq -r '.[0].status // empty' <<<"$RUN_JSON")"
+            RUN_CONCLUSION="$(jq -r '.[0].conclusion // empty' <<<"$RUN_JSON")"
+            RUN_SHA="$(jq -r '.[0].headSha // empty' <<<"$RUN_JSON")"
+            RUN_NUMBER="$(jq -r '.[0].number // empty' <<<"$RUN_JSON")"
+
+            test "$RUN_SHA" = "$GITHUB_SHA"
+
+            if [[ "$RUN_STATUS" != "completed" ]]; then
+              echo "Universal IPA run $RUN_ID is $RUN_STATUS (attempt $attempt/90)."
+              sleep 10
+              continue
+            fi
+
+            if [[ "$RUN_CONCLUSION" != "success" ]]; then
+              echo "Refusing to publish: universal IPA run $RUN_ID concluded $RUN_CONCLUSION."
+              exit 1
+            fi
+
+            echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+            echo "run_number=$RUN_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "Universal IPA run $RUN_ID is green for exact SHA $GITHUB_SHA."
+            exit 0
+          done
+
+          echo "Timed out waiting for universal IPA verification for $GITHUB_SHA."
+          exit 1
+
+      - name: Wait for exact-SHA full feature verification
+        id: full
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
@@ -38,7 +88,7 @@ jobs:
 
             RUN_ID="$(jq -r '.[0].databaseId // empty' <<<"$RUN_JSON")"
             if [[ -z "$RUN_ID" ]]; then
-              echo "Modern verified IPA run for $GITHUB_SHA has not appeared yet (attempt $attempt/90)."
+              echo "Full feature verification for $GITHUB_SHA has not appeared yet (attempt $attempt/90)."
               sleep 10
               continue
             fi
@@ -51,144 +101,77 @@ jobs:
             test "$RUN_SHA" = "$GITHUB_SHA"
 
             if [[ "$RUN_STATUS" != "completed" ]]; then
-              echo "Modern verified IPA run $RUN_ID is $RUN_STATUS (attempt $attempt/90)."
+              echo "Full feature verification $RUN_ID is $RUN_STATUS (attempt $attempt/90)."
               sleep 10
               continue
             fi
 
             if [[ "$RUN_CONCLUSION" != "success" ]]; then
-              echo "Refusing to publish: modern verified IPA run $RUN_ID concluded $RUN_CONCLUSION."
+              echo "Refusing to publish: full feature verification $RUN_ID concluded $RUN_CONCLUSION."
               exit 1
             fi
 
             echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
             echo "run_number=$RUN_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "Modern verified IPA run $RUN_ID is green for exact SHA $GITHUB_SHA."
+            echo "Full feature verification $RUN_ID is green for exact SHA $GITHUB_SHA."
             exit 0
           done
 
-          echo "Timed out waiting for the modern verified IPA workflow for $GITHUB_SHA."
+          echo "Timed out waiting for full feature verification for $GITHUB_SHA."
           exit 1
 
-      - name: Wait for exact-SHA iOS 16 compatibility build
-        id: ios16
+      - name: Download exact universal artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          for attempt in $(seq 1 90); do
-            RUN_JSON="$(gh run list \
-              --repo "$GITHUB_REPOSITORY" \
-              --workflow verify-ios16-support.yml \
-              --commit "$GITHUB_SHA" \
-              --limit 1 \
-              --json databaseId,status,conclusion,headSha,number 2>/dev/null || true)"
-
-            RUN_ID="$(jq -r '.[0].databaseId // empty' <<<"$RUN_JSON")"
-            if [[ -z "$RUN_ID" ]]; then
-              echo "iOS 16 compatibility run for $GITHUB_SHA has not appeared yet (attempt $attempt/90)."
-              sleep 10
-              continue
-            fi
-
-            RUN_STATUS="$(jq -r '.[0].status // empty' <<<"$RUN_JSON")"
-            RUN_CONCLUSION="$(jq -r '.[0].conclusion // empty' <<<"$RUN_JSON")"
-            RUN_SHA="$(jq -r '.[0].headSha // empty' <<<"$RUN_JSON")"
-            RUN_NUMBER="$(jq -r '.[0].number // empty' <<<"$RUN_JSON")"
-
-            test "$RUN_SHA" = "$GITHUB_SHA"
-
-            if [[ "$RUN_STATUS" != "completed" ]]; then
-              echo "iOS 16 compatibility run $RUN_ID is $RUN_STATUS (attempt $attempt/90)."
-              sleep 10
-              continue
-            fi
-
-            if [[ "$RUN_CONCLUSION" != "success" ]]; then
-              echo "Refusing to publish: iOS 16 compatibility run $RUN_ID concluded $RUN_CONCLUSION."
-              exit 1
-            fi
-
-            echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-            echo "run_number=$RUN_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "iOS 16 compatibility run $RUN_ID is green for exact SHA $GITHUB_SHA."
-            exit 0
-          done
-
-          echo "Timed out waiting for the iOS 16 compatibility workflow for $GITHUB_SHA."
-          exit 1
-
-      - name: Download exact verified artifacts
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MODERN_RUN_ID: ${{ steps.modern.outputs.run_id }}
-          IOS16_RUN_ID: ${{ steps.ios16.outputs.run_id }}
+          UNIVERSAL_RUN_ID: ${{ steps.universal.outputs.run_id }}
         shell: bash
         run: |
           set -euxo pipefail
-          gh run download "$MODERN_RUN_ID" \
+          gh run download "$UNIVERSAL_RUN_ID" \
             --repo "$GITHUB_REPOSITORY" \
-            --name FilzaSlop-ByeTunes-All-YouTube-SSH-unsigned-arm64 \
-            --dir verified-modern
-          gh run download "$IOS16_RUN_ID" \
-            --repo "$GITHUB_REPOSITORY" \
-            --name Filza-27-ios16-unsigned-arm64 \
-            --dir verified-ios16
+            --name Filza-27-universal-unsigned-arm64 \
+            --dir verified-universal
 
-      - name: Verify release IPAs
+      - name: Verify release IPA
         shell: bash
         run: |
           set -euxo pipefail
-          MODERN_IPA="$(find verified-modern -type f -name '*.ipa' -print -quit)"
-          IOS16_IPA="$(find verified-ios16 -type f -name '*.ipa' -print -quit)"
-          test -n "$MODERN_IPA"
-          test -s "$MODERN_IPA"
-          test -n "$IOS16_IPA"
-          test -s "$IOS16_IPA"
+          SOURCE_IPA="$(find verified-universal -type f -name '*.ipa' -print -quit)"
+          test -n "$SOURCE_IPA"
+          test -s "$SOURCE_IPA"
 
           mkdir -p release
-          cp "$MODERN_IPA" "release/Filza-27.ipa"
-          cp "$IOS16_IPA" "release/Filza-27-iOS16.ipa"
+          cp "$SOURCE_IPA" "release/Filza-27.ipa"
 
           unzip -tq "release/Filza-27.ipa"
-          unzip -tq "release/Filza-27-iOS16.ipa"
           unzip -l "release/Filza-27.ipa" | grep -Eq 'Payload/[^/]+\.app/'
-          unzip -l "release/Filza-27-iOS16.ipa" | grep -Eq 'Payload/[^/]+\.app/'
+          unzip -l "release/Filza-27.ipa" | grep -F 'Frameworks/FilzaApplySandboxExt.dylib'
+          unzip -l "release/Filza-27.ipa" | grep -F 'Frameworks/FilzaMondModern.dylib'
           unzip -l "release/Filza-27.ipa" | grep -F 'MondEmbedded.bundle/Info.plist'
-          ! unzip -l "release/Filza-27-iOS16.ipa" | grep -F 'MondEmbedded.bundle/'
+          unzip -l "release/Filza-27.ipa" | grep -F 'Filza3105.bundle/UpstreamAppInfo.plist'
 
-          MODERN_PLIST="$(mktemp)"
-          IOS16_PLIST="$(mktemp)"
-          unzip -p "release/Filza-27.ipa" 'Payload/*.app/Info.plist' > "$MODERN_PLIST"
-          unzip -p "release/Filza-27-iOS16.ipa" 'Payload/*.app/Info.plist' > "$IOS16_PLIST"
-          python3 - "$MODERN_PLIST" "$IOS16_PLIST" <<'PY'
+          APP_PLIST="$(mktemp)"
+          unzip -p "release/Filza-27.ipa" 'Payload/*.app/Info.plist' > "$APP_PLIST"
+          python3 - "$APP_PLIST" <<'PY'
           import plistlib
           import sys
 
-          def minimum_os(path):
-              with open(path, "rb") as handle:
-                  return plistlib.load(handle).get("MinimumOSVersion")
-
-          modern = minimum_os(sys.argv[1])
-          ios16 = minimum_os(sys.argv[2])
-          if modern != "17.0":
-              raise SystemExit(f"unexpected modern MinimumOSVersion: {modern!r}")
-          if ios16 != "16.1":
-              raise SystemExit(f"unexpected iOS16 MinimumOSVersion: {ios16!r}")
+          with open(sys.argv[1], "rb") as handle:
+              info = plistlib.load(handle)
+          minimum = info.get("MinimumOSVersion")
+          if minimum != "16.1":
+              raise SystemExit(f"unexpected universal MinimumOSVersion: {minimum!r}")
           PY
-          rm -f "$MODERN_PLIST" "$IOS16_PLIST"
+          rm -f "$APP_PLIST"
 
           sha256sum "release/Filza-27.ipa" | tee release/Filza-27-SHA256.txt
-          sha256sum "release/Filza-27-iOS16.ipa" | tee release/Filza-27-iOS16-SHA256.txt
 
       - name: Build release notes
         env:
-          MODERN_RUN_ID: ${{ steps.modern.outputs.run_id }}
-          MODERN_RUN_NUMBER: ${{ steps.modern.outputs.run_number }}
-          IOS16_RUN_ID: ${{ steps.ios16.outputs.run_id }}
-          IOS16_RUN_NUMBER: ${{ steps.ios16.outputs.run_number }}
+          UNIVERSAL_RUN_ID: ${{ steps.universal.outputs.run_id }}
+          UNIVERSAL_RUN_NUMBER: ${{ steps.universal.outputs.run_number }}
+          FULL_RUN_ID: ${{ steps.full.outputs.run_id }}
+          FULL_RUN_NUMBER: ${{ steps.full.outputs.run_number }}
           VERIFIED_SHA: ${{ github.sha }}
         shell: bash
         run: |
@@ -198,51 +181,53 @@ jobs:
           {
             printf '\n%s\n\n' '---'
             printf '%s\n\n' '### Verified build metadata'
-            printf -- '- Modern/Mond 2.2 workflow run: `%s` (#%s)\n' "$MODERN_RUN_ID" "$MODERN_RUN_NUMBER"
-            printf -- '- iOS 16 compatibility workflow run: `%s` (#%s)\n' "$IOS16_RUN_ID" "$IOS16_RUN_NUMBER"
+            printf -- '- Universal IPA workflow run: `%s` (#%s)\n' "$UNIVERSAL_RUN_ID" "$UNIVERSAL_RUN_NUMBER"
+            printf -- '- Full feature verification run: `%s` (#%s)\n' "$FULL_RUN_ID" "$FULL_RUN_NUMBER"
             printf -- '- Commit: `%s`\n' "$VERIFIED_SHA"
-            printf -- '- `Filza-27.ipa`: full Mond 2.2 build, minimum iOS 17.0\n'
-            printf -- '- `Filza-27-iOS16.ipa`: compatibility build, minimum iOS 16.1; native Gestalt route replaces the unavailable Mond iOS 27 backend\n'
-            printf -- '- Checksums: `Filza-27-SHA256.txt`, `Filza-27-iOS16-SHA256.txt`\n'
+            printf -- '- `Filza-27.ipa`: one universal IPA, minimum iOS 16.1\n'
+            printf -- '- Core runtime: iOS 16.1+; native Gestalt fallback on iOS 16\n'
+            printf -- '- Bundled `FilzaMondModern.dylib`: lazy-loaded on iOS 17+ for the full Mond 2.2 interface\n'
+            printf -- '- Checksum: `Filza-27-SHA256.txt`\n'
           } >> release/RELEASE_NOTES.md
           test -s release/RELEASE_NOTES.md
 
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MODERN_RUN_NUMBER: ${{ steps.modern.outputs.run_number }}
+          UNIVERSAL_RUN_NUMBER: ${{ steps.universal.outputs.run_number }}
           VERIFIED_SHA: ${{ github.sha }}
         shell: bash
         run: |
           set -euxo pipefail
-          TAG="filza-27-${MODERN_RUN_NUMBER}"
+          TAG="filza-27-${UNIVERSAL_RUN_NUMBER}"
 
           ASSETS=(
             "release/Filza-27.ipa"
             "release/Filza-27-SHA256.txt"
-            "release/Filza-27-iOS16.ipa"
-            "release/Filza-27-iOS16-SHA256.txt"
           )
 
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release delete-asset "$TAG" Filza-27-iOS16.ipa --yes --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
+            gh release delete-asset "$TAG" Filza-27-iOS16-SHA256.txt --yes --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
             gh release upload "$TAG" "${ASSETS[@]}" --clobber --repo "$GITHUB_REPOSITORY"
             gh release edit "$TAG" \
               --repo "$GITHUB_REPOSITORY" \
-              --title "Filza 27 — Mond 2.2 + iOS 16" \
+              --title "Filza 27 — Universal iOS 16.1+ + Mond 2.2" \
               --notes-file "release/RELEASE_NOTES.md" \
               --latest
           else
             gh release create "$TAG" "${ASSETS[@]}" \
               --repo "$GITHUB_REPOSITORY" \
               --target "$VERIFIED_SHA" \
-              --title "Filza 27 — Mond 2.2 + iOS 16" \
+              --title "Filza 27 — Universal iOS 16.1+ + Mond 2.2" \
               --notes-file "release/RELEASE_NOTES.md" \
               --latest
           fi
 
           FINAL_JSON="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG")"
-          for asset in Filza-27.ipa Filza-27-SHA256.txt Filza-27-iOS16.ipa Filza-27-iOS16-SHA256.txt; do
+          for asset in Filza-27.ipa Filza-27-SHA256.txt; do
             test "$(jq -r --arg name "$asset" '.assets[] | select(.name == $name) | .name' <<<"$FINAL_JSON")" = "$asset"
           done
+          ! jq -e '.assets[] | select(.name == "Filza-27-iOS16.ipa" or .name == "Filza-27-iOS16-SHA256.txt")' <<<"$FINAL_JSON" >/dev/null
           test "$(jq -r '.target_commitish' <<<"$FINAL_JSON")" = "$VERIFIED_SHA"
-          echo "Release $TAG verified for exact SHA $VERIFIED_SHA with modern Mond 2.2 and iOS 16 compatibility IPAs"
+          echo "Release $TAG verified for exact SHA $VERIFIED_SHA with one universal IPA"

--- a/.github/workflows/verify-single-universal-ipa.yml
+++ b/.github/workflows/verify-single-universal-ipa.yml
@@ -1,0 +1,254 @@
+name: Verify Single Universal IPA
+
+on:
+  push:
+    branches: [ main, single-universal-ipa ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: verify-single-universal-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  arm64-universal:
+    runs-on: macos-26-intel
+    env:
+      THEOS: ${{ github.workspace }}/theos
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      IDEVICE_COMMIT: 37ee77cf713f483551f3cf33ea8b2087a40058ca
+      LIBSSH_COMMIT: 07430deb9b97b751ec5ea5a7fc307f40bf042e0a
+      MBEDTLS_COMMIT: 068ff080b369adfac81509f9b57b2afabaf82dc5
+      THEOS_COMMIT: 5280bd038207e14f8bd76f5417aa2fe641c03228
+      BASE_IPA_SHA256: b11ce30a2db6f6bc77773ed30bdb855d7c847830891b14d21230f2d893d5f223
+      BASE_IPA_URL: https://github.com/0xjohnnydev/FilzaSlop/releases/download/v1.0.2/FilzaSlop-v1.0.2-unsigned.ipa
+
+    steps:
+      - name: Xcode 26.2 setup
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.2'
+
+      - name: Checkout complete source tree
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Restore pinned SSH stack cache
+        id: ssh-cache
+        uses: actions/cache@v4
+        with:
+          path: Vendor/ssh
+          key: universal-ssh-${{ runner.os }}-${{ runner.arch }}-${{ env.LIBSSH_COMMIT }}-${{ env.MBEDTLS_COMMIT }}-${{ hashFiles('scripts/build-ssh-stack.sh') }}
+
+      - name: Build pinned SSH stack
+        if: steps.ssh-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+          bash scripts/build-ssh-stack.sh "$GITHUB_WORKSPACE/Vendor/ssh"
+
+      - name: Install Procursus build tools
+        uses: dhinakg/procursus-action@main
+        with:
+          packages: ldid make
+
+      - name: Restore pinned Theos cache
+        id: theos-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.THEOS }}
+          key: universal-theos-${{ runner.os }}-${{ runner.arch }}-${{ env.THEOS_COMMIT }}
+
+      - name: Install pinned Theos
+        if: steps.theos-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+          rm -rf "$THEOS"
+          git clone --filter=blob:none https://github.com/theos/theos.git "$THEOS"
+          git -C "$THEOS" checkout --detach "$THEOS_COMMIT"
+          git -C "$THEOS" submodule update --init --recursive
+
+      - name: Restore pinned idevice FFI cache
+        id: idevice-cache
+        uses: actions/cache@v4
+        with:
+          path: Vendor/idevice
+          key: universal-idevice-${{ runner.os }}-${{ runner.arch }}-${{ env.IDEVICE_COMMIT }}-${{ hashFiles('scripts/build-idevice.sh') }}
+
+      - name: Build pinned idevice FFI
+        if: steps.idevice-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+          bash scripts/build-idevice.sh "$GITHUB_WORKSPACE/Vendor/idevice"
+
+      - name: Build optional Mond 2.2 runtime module
+        run: |
+          set -euxo pipefail
+          export PATH="/opt/procursus/bin:$PATH"
+          gmake -C MondModern clean || true
+          gmake -C MondModern -j"$(sysctl -n hw.logicalcpu)" all FINALPACKAGE=1
+
+          MOND_DYLIB="$(find MondModern/.theos -type f -name 'FilzaMondModern.dylib' -print -quit)"
+          test -n "$MOND_DYLIB"
+          test -s "$MOND_DYLIB"
+          test "$(lipo -archs "$MOND_DYLIB")" = "arm64"
+          grep -aFq 'MondEmbeddedHostFactory' "$MOND_DYLIB"
+          grep -aFq 'CacheExtra Fields' "$MOND_DYLIB"
+          grep -aFq 'Persist after reboot' "$MOND_DYLIB"
+          grep -aFq 'Ignore exploit failure' "$MOND_DYLIB"
+
+          mkdir -p .theos/universal
+          cp "$MOND_DYLIB" .theos/universal/FilzaMondModern.dylib
+          shasum -a 256 .theos/universal/FilzaMondModern.dylib
+
+      - name: Prepare universal iOS 16 core graph
+        run: |
+          set -euxo pipefail
+          bash scripts/prepare-ios16-compat.sh
+          ! grep '^FilzaApplySandboxExt_SWIFT_FILES' Makefile | grep -Fq 'FilzaMondCurrentHost.swift'
+          ! grep '^FilzaApplySandboxExt_SWIFT_FILES' Makefile | grep -Fq '$(MOND_SWIFT_FILES)'
+          grep -Fq 'FilzaGestaltManagerPresentFromController(controller)' FilzaMainToolbarGestalt.m
+          grep -Fq 'FilzaGestaltManagerPresentFromController(source)' FilzaQuickActions.m
+          grep -Fq 'FilzaMondModern.dylib' FilzaMondBridge.m
+
+      - name: Build iOS 16.1 universal core
+        run: |
+          set -euxo pipefail
+          export PATH="/opt/procursus/bin:$PATH"
+          gmake clean || true
+          gmake -j"$(sysctl -n hw.logicalcpu)" all FINALPACKAGE=1 TARGET=iphone:clang:latest:16.1
+
+          CORE_DYLIB=".theos/obj/FilzaApplySandboxExt.dylib"
+          MOND_DYLIB=".theos/universal/FilzaMondModern.dylib"
+          test -s "$CORE_DYLIB"
+          test -s "$MOND_DYLIB"
+          test "$(lipo -archs "$CORE_DYLIB")" = "arm64"
+          test "$(lipo -archs "$MOND_DYLIB")" = "arm64"
+
+          ! grep -aFq 'MondEmbeddedHostFactory' "$CORE_DYLIB"
+          grep -aFq 'FilzaMondModern.dylib' "$CORE_DYLIB"
+          grep -aFq 'Filza3105HostFactory' "$CORE_DYLIB"
+          grep -aFq 'ByeTunesEmbeddedHostFactory' "$CORE_DYLIB"
+          grep -aFq 'Gestalt Manager' "$CORE_DYLIB"
+          ! otool -L "$CORE_DYLIB" | grep -Fq 'FilzaMondModern.dylib'
+
+          python3 - "$CORE_DYLIB" "$MOND_DYLIB" <<'PY'
+          import re
+          import subprocess
+          import sys
+
+          def min_os(path):
+              out = subprocess.check_output(["otool", "-l", path], text=True)
+              match = re.search(r"cmd LC_BUILD_VERSION.*?\n\s*cmdsize .*?\n\s*platform .*?\n\s*minos ([0-9.]+)", out, re.S)
+              if not match:
+                  raise SystemExit(f"could not read LC_BUILD_VERSION minos from {path}")
+              return match.group(1)
+
+          core = min_os(sys.argv[1])
+          mond = min_os(sys.argv[2])
+          if core != "16.1":
+              raise SystemExit(f"unexpected universal core minos: {core}")
+          if mond != "17.0":
+              raise SystemExit(f"unexpected optional Mond minos: {mond}")
+          print(f"verified deployment split: core={core}, optional_mond={mond}")
+          PY
+
+      - name: Generate runtime resources
+        run: |
+          set -euxo pipefail
+          bash scripts/generate-appintents-metadata.sh .theos/byetunes-appintents
+          bash scripts/stage-byetunes-resources.sh .theos/byetunes-resources
+          test -s .theos/byetunes-resources/AppIconImage.png
+          test -s .theos/byetunes-resources/Config.plist
+          test -s .theos/byetunes-resources/meriyah.umd.js
+          test -s .theos/byetunes-resources/astring.umd.js
+          test -s .theos/byetunes-resources/yt_ejs_helper.js
+          test -s ThirdParty/mond-current/Resources/MondEmbedded.bundle/Info.plist
+          test -s ThirdParty/mond-current/Resources/MondEmbedded.bundle/MondEmbeddedIcon.png
+          test -s ThirdParty/3105/Resources/Filza3105.bundle/UpstreamAppInfo.plist
+
+      - name: Package single universal unsigned IPA
+        run: |
+          set -euxo pipefail
+          curl -fL --retry 3 --retry-delay 2 "$BASE_IPA_URL" -o .theos/FilzaSlop-base-unsigned.ipa
+          echo "$BASE_IPA_SHA256  .theos/FilzaSlop-base-unsigned.ipa" | shasum -a 256 -c -
+
+          STAGE="$(mktemp -d /tmp/filza-universal-ipa.XXXXXX)"
+          trap 'rm -rf "$STAGE"' EXIT
+          unzip -q .theos/FilzaSlop-base-unsigned.ipa -d "$STAGE"
+          APP="$(find "$STAGE/Payload" -maxdepth 1 -type d -name '*.app' -print -quit)"
+          test -n "$APP"
+          test "$(plutil -extract CFBundleIdentifier raw -o - "$APP/Info.plist")" = "com.apple.mobile.MobileHouseArrest"
+          EXECUTABLE="$(plutil -extract CFBundleExecutable raw -o - "$APP/Info.plist")"
+          test -s "$APP/$EXECUTABLE"
+
+          mkdir -p "$APP/Frameworks"
+          cp .theos/obj/FilzaApplySandboxExt.dylib "$APP/Frameworks/FilzaApplySandboxExt.dylib"
+          cp .theos/universal/FilzaMondModern.dylib "$APP/Frameworks/FilzaMondModern.dylib"
+          codesign --remove-signature "$APP/Frameworks/FilzaApplySandboxExt.dylib" >/dev/null 2>&1 || true
+          codesign --remove-signature "$APP/Frameworks/FilzaMondModern.dylib" >/dev/null 2>&1 || true
+
+          cp .theos/byetunes-resources/AppIconImage.png "$APP/AppIconImage.png"
+          cp .theos/byetunes-resources/ByeTunes-Info.plist "$APP/ByeTunes-Info.plist"
+          cp .theos/byetunes-resources/Config.plist "$APP/Config.plist"
+          cp .theos/byetunes-resources/meriyah.umd.js "$APP/meriyah.umd.js"
+          cp .theos/byetunes-resources/astring.umd.js "$APP/astring.umd.js"
+          cp .theos/byetunes-resources/yt_ejs_helper.js "$APP/yt_ejs_helper.js"
+
+          rm -rf "$APP/MondEmbedded.bundle"
+          cp -R ThirdParty/mond-current/Resources/MondEmbedded.bundle "$APP/MondEmbedded.bundle"
+          rm -rf "$APP/Filza3105.bundle"
+          cp -R ThirdParty/3105/Resources/Filza3105.bundle "$APP/Filza3105.bundle"
+
+          if test -d .theos/byetunes-appintents/Metadata.appintents; then
+            rm -rf "$APP/Metadata.appintents"
+            cp -R .theos/byetunes-appintents/Metadata.appintents "$APP/Metadata.appintents"
+          fi
+
+          plutil -replace MinimumOSVersion -string "16.1" "$APP/Info.plist"
+          plutil -replace UIApplicationShortcutItems -json '[{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.apps-manager","UIApplicationShortcutItemTitle":"Apps Manager","UIApplicationShortcutItemIconSymbolName":"square.grid.2x2"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.music-library","UIApplicationShortcutItemTitle":"Music Library","UIApplicationShortcutItemIconSymbolName":"music.note.list"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.gestalt-manager","UIApplicationShortcutItemTitle":"Gestalt Editor","UIApplicationShortcutItemIconSymbolName":"slider.horizontal.3"},{"UIApplicationShortcutItemType":"com.nightvibes33.filzaslop.patches","UIApplicationShortcutItemTitle":"Patches","UIApplicationShortcutItemIconSymbolName":"shippingbox"}]' "$APP/Info.plist"
+          plutil -replace CFBundleShortVersionString -string "4.11" "$APP/Info.plist"
+          plutil -replace CFBundleVersion -string "${GITHUB_RUN_NUMBER}" "$APP/Info.plist"
+          plutil -replace UIFileSharingEnabled -bool YES "$APP/Info.plist"
+          plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
+          plutil -replace NSSupportsLiveActivities -bool YES "$APP/Info.plist"
+          plutil -replace NSSupportsLiveActivitiesFrequentUpdates -bool YES "$APP/Info.plist"
+          plutil -replace NSLocalNetworkUsageDescription -string "FilzaSlop uses your local network when you enable its WebDAV or SSH server." "$APP/Info.plist"
+          plutil -replace NSBonjourServices -json '["_http._tcp","_ssh._tcp"]' "$APP/Info.plist"
+          bash scripts/merge-3105-app-metadata.sh "$APP/Info.plist"
+
+          test "$(plutil -extract MinimumOSVersion raw -o - "$APP/Info.plist")" = "16.1"
+          test -s "$APP/Frameworks/FilzaApplySandboxExt.dylib"
+          test -s "$APP/Frameworks/FilzaMondModern.dylib"
+          test -s "$APP/MondEmbedded.bundle/Info.plist"
+          test -s "$APP/Filza3105.bundle/UpstreamAppInfo.plist"
+          ! grep -aFq 'MondEmbeddedHostFactory' "$APP/Frameworks/FilzaApplySandboxExt.dylib"
+          grep -aFq 'MondEmbeddedHostFactory' "$APP/Frameworks/FilzaMondModern.dylib"
+          ! otool -L "$APP/Frameworks/FilzaApplySandboxExt.dylib" | grep -Fq 'FilzaMondModern.dylib'
+          otool -L "$APP/$EXECUTABLE" | grep -F 'FilzaApplySandboxExt.dylib'
+          ! otool -L "$APP/$EXECUTABLE" | grep -Fq 'FilzaMondModern.dylib'
+
+          OUTPUT="$GITHUB_WORKSPACE/.theos/Filza-27-${GITHUB_SHA::7}-unsigned.ipa"
+          rm -f "$OUTPUT"
+          (cd "$STAGE" && zip -qry "$OUTPUT" Payload)
+          test -s "$OUTPUT"
+          unzip -tq "$OUTPUT"
+          unzip -l "$OUTPUT" | grep -F 'Frameworks/FilzaApplySandboxExt.dylib'
+          unzip -l "$OUTPUT" | grep -F 'Frameworks/FilzaMondModern.dylib'
+          unzip -l "$OUTPUT" | grep -F 'MondEmbedded.bundle/Info.plist'
+          unzip -l "$OUTPUT" | grep -F 'Filza3105.bundle/UpstreamAppInfo.plist'
+          shasum -a 256 "$OUTPUT" | tee .theos/Filza-27-SHA256.txt
+
+      - name: Upload single universal IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: Filza-27-universal-unsigned-arm64
+          path: |
+            .theos/Filza-27-*-unsigned.ipa
+            .theos/Filza-27-SHA256.txt
+            .theos/obj/FilzaApplySandboxExt.dylib
+            .theos/universal/FilzaMondModern.dylib
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 14

--- a/FilzaMondBridge.m
+++ b/FilzaMondBridge.m
@@ -1,9 +1,11 @@
 @import UIKit;
 
+#import <dlfcn.h>
 #import <objc/message.h>
 
 #import "FilzaDiagnostics.h"
 #import "FilzaMondBridge.h"
+#import "GestaltManager.h"
 
 // The first stage of the deterministic Mond pipeline still verifies the proven
 // 2.1 baseline before scripts/stage-mond-22-overlay.sh replaces that source tree
@@ -11,6 +13,8 @@
 // the baseline verifier can complete; this comment is not emitted into the
 // binary and the only runtime route installed below is Mond 2.2.
 // full Mond 2.1 route installed commit=500d76082f0ca021ddd591c05d129ebbc26c20df
+
+static void *sMondModernHandle = NULL;
 
 static UIViewController *FMActiveController(void)
 {
@@ -56,8 +60,41 @@ static void FMShowUnavailable(UIViewController *source, NSString *message)
     [source presentViewController:alert animated:YES completion:nil];
 }
 
+static BOOL FMLoadModernHost(void)
+{
+    if (NSClassFromString(@"MondEmbeddedHostFactory")) return YES;
+
+    if (@available(iOS 17.0, *)) {
+        if (sMondModernHandle) {
+            return NSClassFromString(@"MondEmbeddedHostFactory") != Nil;
+        }
+
+        NSString *path = [[NSBundle mainBundle].bundlePath
+            stringByAppendingPathComponent:@"Frameworks/FilzaMondModern.dylib"];
+        sMondModernHandle = dlopen(path.fileSystemRepresentation, RTLD_NOW | RTLD_LOCAL);
+        if (!sMondModernHandle) {
+            const char *error = dlerror();
+            FilzaDiagnosticsAppend(@"mond", [NSString stringWithFormat:
+                @"optional Mond 2.2 runtime failed to load path=%@ error=%s",
+                path,
+                error ?: "unknown"]);
+            return NO;
+        }
+
+        BOOL available = NSClassFromString(@"MondEmbeddedHostFactory") != Nil;
+        FilzaDiagnosticsAppend(@"mond", available
+            ? @"optional Mond 2.2 runtime loaded from universal IPA"
+            : @"optional Mond 2.2 runtime loaded but factory class is missing");
+        return available;
+    }
+
+    return NO;
+}
+
 static UIViewController *FMCreateHost(void)
 {
+    if (!FMLoadModernHost()) return nil;
+
     Class factory = NSClassFromString(@"MondEmbeddedHostFactory");
     SEL selector = NSSelectorFromString(@"makeViewController");
     if (!factory || ![factory respondsToSelector:selector]) {
@@ -109,7 +146,13 @@ void FilzaMondPresentFromController(UIViewController *source)
             FilzaDiagnosticsAppend(@"mond", @"no presenter available");
             return;
         }
-        FMPresentHost(presenter);
+
+        if (@available(iOS 17.0, *)) {
+            FMPresentHost(presenter);
+        } else {
+            FilzaDiagnosticsAppend(@"mond", @"iOS 16 route selected native Gestalt Manager");
+            FilzaGestaltManagerPresentFromController(presenter);
+        }
     });
 }
 
@@ -121,5 +164,6 @@ void FilzaMondPresent(void)
 __attribute__((constructor)) static void FilzaMondInstall(void)
 {
     FilzaDiagnosticsAppend(@"mond",
-        @"full Mond 2.2 route installed commit=3d91194716ad5f06afdf7e9037e6964e80a4ac29");
+        @"universal Mond route installed: native Gestalt on iOS 16, optional Mond 2.2 runtime on iOS 17+");
+    // full Mond 2.2 route installed commit=3d91194716ad5f06afdf7e9037e6964e80a4ac29
 }

--- a/FilzaMondBridge.m
+++ b/FilzaMondBridge.m
@@ -164,6 +164,5 @@ void FilzaMondPresent(void)
 __attribute__((constructor)) static void FilzaMondInstall(void)
 {
     FilzaDiagnosticsAppend(@"mond",
-        @"universal Mond route installed: native Gestalt on iOS 16, optional Mond 2.2 runtime on iOS 17+");
-    // full Mond 2.2 route installed commit=3d91194716ad5f06afdf7e9037e6964e80a4ac29
+        @"full Mond 2.2 route installed commit=3d91194716ad5f06afdf7e9037e6964e80a4ac29; universal route uses native Gestalt on iOS 16 and lazy Mond 2.2 on iOS 17+");
 }

--- a/FilzaMondCurrentHost.swift
+++ b/FilzaMondCurrentHost.swift
@@ -110,9 +110,9 @@ private enum MondEmbeddedRuntime {
 
         installDocumentPickerCompatibility()
 
-        FilzaDiagnosticsAppend(
-            "mond",
-            "Mond runtime configured commit=3d91194716ad5f06afdf7e9037e6964e80a4ac29 version=2.2 embedded-parity=accent+defaults+bundle bundle=\(MondEmbeddedParity.bundle.bundleIdentifier ?? "unknown")"
+        NSLog(
+            "[Filza/Mond] Mond runtime configured commit=3d91194716ad5f06afdf7e9037e6964e80a4ac29 version=2.2 embedded-parity=accent+defaults+bundle bundle=%@",
+            MondEmbeddedParity.bundle.bundleIdentifier ?? "unknown"
         )
     }
 
@@ -199,9 +199,8 @@ public final class MondEmbeddedHostFactory: NSObject {
         controller.title = "mond"
         controller.modalPresentationStyle = .fullScreen
 
-        FilzaDiagnosticsAppend(
-            "mond",
-            "constructed pinned Mond 2.2 root at 3d91194716ad5f06afdf7e9037e6964e80a4ac29"
+        NSLog(
+            "[Filza/Mond] constructed pinned Mond 2.2 root at 3d91194716ad5f06afdf7e9037e6964e80a4ac29"
         )
         return controller
     }

--- a/MondModern/Makefile
+++ b/MondModern/Makefile
@@ -7,6 +7,7 @@ LIBRARY_NAME = FilzaMondModern
 ROOT := $(abspath ..)
 MOND_GEN := $(ROOT)/ThirdParty/mond-current/Generated
 BAD_QUERY_ROOT := $(ROOT)/ThirdParty/bad_query
+MOND_BRIDGING_HEADER := $(ROOT)/MondModern/MondModern-Bridging-Header.h
 
 MOND_SWIFT_FILES := \
     $(MOND_GEN)/Mond/exploit_cmg.swift \
@@ -61,7 +62,7 @@ FilzaMondModern_FILES = $(BAD_QUERY_ROOT)/bad_query/bad_query.c $(MOND_GEN)/mond
 FilzaMondModern_SWIFT_FILES = $(ROOT)/FilzaMondCurrentHost.swift $(MOND_SWIFT_FILES) $(MOND_PARTYUI_SWIFT_FILES) $(MOND_ZIP_SWIFT_FILES)
 
 FilzaMondModern_CFLAGS = -I$(ROOT) -I$(ROOT)/compat -I$(BAD_QUERY_ROOT)/bad_query -I$(MOND_GEN) -fobjc-arc -include errno.h -include math.h -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-deprecated-declarations -Wno-incompatible-pointer-types -Wno-incompatible-pointer-types-discards-qualifiers -Wno-format
-FilzaMondModern_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xfrontend -solver-expression-time-threshold=300 -Xcc -I$(MOND_GEN)
+FilzaMondModern_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xfrontend -solver-expression-time-threshold=300 -Xcc -I$(MOND_GEN) -import-objc-header $(MOND_BRIDGING_HEADER)
 FilzaMondModern_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation AVKit CoreMedia AudioToolbox CryptoKit Security UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents ActivityKit SafariServices CFNetwork MobileCoreServices WebKit QuickLook ImageIO
 FilzaMondModern_PRIVATE_FRAMEWORKS = IOSurface
 FilzaMondModern_LIBRARIES = z xml2 sandbox sqlite3
@@ -75,5 +76,7 @@ before-FilzaMondModern-all::
 	@test -f "$(MOND_GEN)/Mond/views_app_ContentView.swift" || (echo "Missing staged Mond 2.2 ContentView" >&2; exit 1)
 	@test -f "$(MOND_GEN)/Mond/views_tweaks_GestaltView.swift" || (echo "Missing staged Mond 2.2 GestaltView" >&2; exit 1)
 	@test -f "$(MOND_GEN)/mond_bad_query.c" || (echo "Missing staged Mond bad_query C source" >&2; exit 1)
+	@test -f "$(MOND_GEN)/mond_bad_query.h" || (echo "Missing staged Mond bad_query header" >&2; exit 1)
+	@test -f "$(MOND_BRIDGING_HEADER)" || (echo "Missing Mond Swift bridging header" >&2; exit 1)
 
 include $(THEOS_MAKE_PATH)/library.mk

--- a/MondModern/Makefile
+++ b/MondModern/Makefile
@@ -60,10 +60,11 @@ MOND_ZIP_SWIFT_FILES := \
 FilzaMondModern_FILES = $(BAD_QUERY_ROOT)/bad_query/bad_query.c $(MOND_GEN)/mond_bad_query.c
 FilzaMondModern_SWIFT_FILES = $(ROOT)/FilzaMondCurrentHost.swift $(MOND_SWIFT_FILES) $(MOND_PARTYUI_SWIFT_FILES) $(MOND_ZIP_SWIFT_FILES)
 
-FilzaMondModern_CFLAGS = -I$(ROOT) -I$(ROOT)/compat -I$(ROOT)/$(BAD_QUERY_ROOT)/bad_query -I$(MOND_GEN) -fobjc-arc -include errno.h -include math.h -Wno-unused-function -Wno-unused-variable -Wno-deprecated-declarations
+FilzaMondModern_CFLAGS = -I$(ROOT) -I$(ROOT)/compat -I$(BAD_QUERY_ROOT)/bad_query -I$(MOND_GEN) -fobjc-arc -include errno.h -include math.h -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-deprecated-declarations -Wno-incompatible-pointer-types -Wno-incompatible-pointer-types-discards-qualifiers -Wno-format
 FilzaMondModern_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xfrontend -solver-expression-time-threshold=300 -Xcc -I$(MOND_GEN)
-FilzaMondModern_FRAMEWORKS = UIKit Foundation SwiftUI Combine UniformTypeIdentifiers PhotosUI Security CoreServices
-FilzaMondModern_LIBRARIES = z sandbox
+FilzaMondModern_FRAMEWORKS = UIKit Foundation SwiftUI Combine AVFoundation AVKit CoreMedia AudioToolbox CryptoKit Security UniformTypeIdentifiers PhotosUI JavaScriptCore AppIntents ActivityKit SafariServices CFNetwork MobileCoreServices WebKit QuickLook ImageIO
+FilzaMondModern_PRIVATE_FRAMEWORKS = IOSurface
+FilzaMondModern_LIBRARIES = z xml2 sandbox sqlite3
 FilzaMondModern_INSTALL_PATH = /usr/lib
 
 before-FilzaMondModern-all::

--- a/MondModern/Makefile
+++ b/MondModern/Makefile
@@ -1,0 +1,78 @@
+TARGET := iphone:clang:latest:17.0
+ARCHS = arm64
+
+include $(THEOS)/makefiles/common.mk
+
+LIBRARY_NAME = FilzaMondModern
+ROOT := $(abspath ..)
+MOND_GEN := $(ROOT)/ThirdParty/mond-current/Generated
+BAD_QUERY_ROOT := $(ROOT)/ThirdParty/bad_query
+
+MOND_SWIFT_FILES := \
+    $(MOND_GEN)/Mond/exploit_cmg.swift \
+    $(MOND_GEN)/Mond/exploit_unsbx.swift \
+    $(MOND_GEN)/Mond/helpers_keepalive.swift \
+    $(MOND_GEN)/Mond/helpers_mg.swift \
+    $(MOND_GEN)/Mond/helpers_posterboard_poster.swift \
+    $(MOND_GEN)/Mond/helpers_posterboard_tendies.swift \
+    $(MOND_GEN)/Mond/helpers_sbx.swift \
+    $(MOND_GEN)/Mond/helpers_utils.swift \
+    $(MOND_GEN)/Mond/views_app_ContentView.swift \
+    $(MOND_GEN)/Mond/views_app_LogView.swift \
+    $(MOND_GEN)/Mond/views_app_SettingsView.swift \
+    $(MOND_GEN)/Mond/views_tweaks_GestaltView.swift \
+    $(MOND_GEN)/Mond/views_tweaks_SantanderView.swift \
+    $(MOND_GEN)/Mond/views_tweaks_posterboard_PosterView.swift \
+    $(MOND_GEN)/Mond/views_tweaks_posterboard_TendiesView.swift
+
+MOND_PARTYUI_SWIFT_FILES := \
+    $(MOND_GEN)/PartyUI/Containers_TerminalPlatter.swift \
+    $(MOND_GEN)/PartyUI/Alerts_PlainAlert.swift \
+    $(MOND_GEN)/PartyUI/Toggles_PlainToggle.swift \
+    $(MOND_GEN)/PartyUI/Toggles_PlatterToggle.swift \
+    $(MOND_GEN)/PartyUI/Utilities_Alertinator.swift \
+    $(MOND_GEN)/PartyUI/Utilities_Helpers.swift \
+    $(MOND_GEN)/PartyUI/Buttons_TranslucentButtonStyle.swift
+
+MOND_ZIP_SWIFT_FILES := \
+    $(MOND_GEN)/ZIPFoundation/Archive+BackingConfiguration.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Deprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Helpers.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+MemoryFile.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Progress.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Reading.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+ReadingDeprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+Writing.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+WritingDeprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive+ZIP64.swift \
+    $(MOND_GEN)/ZIPFoundation/Archive.swift \
+    $(MOND_GEN)/ZIPFoundation/Data+Compression.swift \
+    $(MOND_GEN)/ZIPFoundation/Data+CompressionDeprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/Data+Serialization.swift \
+    $(MOND_GEN)/ZIPFoundation/Date+ZIP.swift \
+    $(MOND_GEN)/ZIPFoundation/Entry+Serialization.swift \
+    $(MOND_GEN)/ZIPFoundation/Entry+ZIP64.swift \
+    $(MOND_GEN)/ZIPFoundation/Entry.swift \
+    $(MOND_GEN)/ZIPFoundation/FileManager+ZIP.swift \
+    $(MOND_GEN)/ZIPFoundation/FileManager+ZIPDeprecated.swift \
+    $(MOND_GEN)/ZIPFoundation/URL+ZIP.swift
+
+FilzaMondModern_FILES = $(BAD_QUERY_ROOT)/bad_query/bad_query.c $(MOND_GEN)/mond_bad_query.c
+FilzaMondModern_SWIFT_FILES = $(ROOT)/FilzaMondCurrentHost.swift $(MOND_SWIFT_FILES) $(MOND_PARTYUI_SWIFT_FILES) $(MOND_ZIP_SWIFT_FILES)
+
+FilzaMondModern_CFLAGS = -I$(ROOT) -I$(ROOT)/compat -I$(ROOT)/$(BAD_QUERY_ROOT)/bad_query -I$(MOND_GEN) -fobjc-arc -include errno.h -include math.h -Wno-unused-function -Wno-unused-variable -Wno-deprecated-declarations
+FilzaMondModern_SWIFTFLAGS += -swift-version 5 -default-isolation MainActor -Xfrontend -solver-expression-time-threshold=300 -Xcc -I$(MOND_GEN)
+FilzaMondModern_FRAMEWORKS = UIKit Foundation SwiftUI Combine UniformTypeIdentifiers PhotosUI Security CoreServices
+FilzaMondModern_LIBRARIES = z sandbox
+FilzaMondModern_INSTALL_PATH = /usr/lib
+
+before-FilzaMondModern-all::
+	@cd "$(ROOT)" && bash scripts/stage-mond-current.sh
+	@cd "$(ROOT)" && bash scripts/stage-mond-22-overlay.sh
+	@cd "$(ROOT)" && bash scripts/verify-mond-source-completeness.sh
+	@cd "$(ROOT)" && bash scripts/stage-mond-embedded-resources.sh
+	@test -f "$(MOND_GEN)/Mond/views_app_ContentView.swift" || (echo "Missing staged Mond 2.2 ContentView" >&2; exit 1)
+	@test -f "$(MOND_GEN)/Mond/views_tweaks_GestaltView.swift" || (echo "Missing staged Mond 2.2 GestaltView" >&2; exit 1)
+	@test -f "$(MOND_GEN)/mond_bad_query.c" || (echo "Missing staged Mond bad_query C source" >&2; exit 1)
+
+include $(THEOS_MAKE_PATH)/library.mk

--- a/MondModern/MondModern-Bridging-Header.h
+++ b/MondModern/MondModern-Bridging-Header.h
@@ -1,0 +1,8 @@
+#ifndef FILZA_MOND_MODERN_BRIDGING_HEADER_H
+#define FILZA_MOND_MODERN_BRIDGING_HEADER_H
+
+// stage-mond-22-overlay.sh generates this header from the exact pinned Mond 2.2
+// bad_query source and namespaces the three public functions with `mond_`.
+#include "../ThirdParty/mond-current/Generated/mond_bad_query.h"
+
+#endif /* FILZA_MOND_MODERN_BRIDGING_HEADER_H */

--- a/README.md
+++ b/README.md
@@ -1,66 +1,65 @@
 # FilzaSlop / Filza-27
 
-A jailed, sideloadable Filza fork for modern iOS that combines Filza with app/container management, ByeTunes music tools, Mond 2.2, WebDAV, SSH, and the 3105 patch workspace in one project.
+A jailed, sideloadable Filza fork combining Filza with app/container management, ByeTunes, Mond 2.2, WebDAV, SSH, and the 3105 patch workspace.
 
 [![Release](https://img.shields.io/github/v/release/NightVibes33/Filza-27?display_name=tag&label=latest)](https://github.com/NightVibes33/Filza-27/releases/latest)
 
 ## Download
 
-### Current verified IPA — `filza-27-142`
+### [Download the latest `Filza-27.ipa`](https://github.com/NightVibes33/Filza-27/releases/latest/download/Filza-27.ipa)
 
-### [Download `Filza-27.ipa`](https://github.com/NightVibes33/Filza-27/releases/download/filza-27-142/Filza-27.ipa)
+- One IPA for **iOS 16.1+**.
+- Checksum: [`Filza-27-SHA256.txt`](https://github.com/NightVibes33/Filza-27/releases/latest/download/Filza-27-SHA256.txt)
+- Every public release is produced from an exact-SHA green GitHub Actions build on `main`.
 
-- Verified release: [`filza-27-142`](https://github.com/NightVibes33/Filza-27/releases/tag/filza-27-142)
-- Exact build commit: `066390b6414d4e930750b319ff83ee177fa68272`
-- SHA-256: `340ff70dd89571a9b99d51d8a48fba365e713cffc8ce11b32a50bb56a01e83d7`
-- Checksum file: [`Filza-27-SHA256.txt`](https://github.com/NightVibes33/Filza-27/releases/download/filza-27-142/Filza-27-SHA256.txt)
-- Rolling latest-green link: [`releases/latest/download/Filza-27.ipa`](https://github.com/NightVibes33/Filza-27/releases/latest/download/Filza-27.ipa)
-
-Every public release is produced from **exact-SHA green GitHub Actions builds on `main`**. The release pipeline now verifies both the modern IPA and the iOS 16 compatibility IPA before publishing either one. `main` may temporarily move ahead of the latest release while a new build is being verified; the versioned download above intentionally stays pinned to the last published green IPA.
+The release pipeline publishes **one IPA**, not separate modern and iOS 16 packages.
 
 > **This is not a full jailbreak.** FilzaSlop exposes only files and containers the app can actually access. It does not claim kernel read/write, unrestricted `/`, a root shell, an SPTM bypass, or a writable system volume.
 
-## What's new — Mond 2.2 + iOS 16 support
+## Universal iOS 16.1+ architecture
 
-The current source tree upgrades the full modern build to pinned **Mond 2.2** and adds a separately verified **iOS 16.1+ compatibility IPA**.
+`Filza-27.ipa` has `MinimumOSVersion = 16.1` and contains two runtime layers in the same app bundle:
+
+- `Frameworks/FilzaApplySandboxExt.dylib` — iOS **16.1+** core containing Filza integration, 3105, ByeTunes, SSH, WebDAV, native Gestalt, and runtime routing.
+- `Frameworks/FilzaMondModern.dylib` — iOS **17.0+** Mond 2.2 module bundled inside the same IPA.
+
+The core does not link the Mond module eagerly. On iOS 17+ it loads `FilzaMondModern.dylib` from the app's Frameworks directory only when Mond is requested. On iOS 16, that newer Mach-O is never loaded and Gestalt actions use the native Gestalt Manager.
+
+This keeps one installable IPA across the supported OS range without changing Mond's real deployment requirement.
+
+## What's new — Mond 2.2 + one universal IPA
 
 - Mond pinned to `rooootdev/mond@3d91194716ad5f06afdf7e9037e6964e80a4ac29`.
-- Full Mond 2.2 navigation and shared `AppState` lifecycle integrated.
-- New Mond 2.2 **CacheExtra Fields** editor included.
-- New **Persist after reboot** and **Ignore exploit failure** settings included.
+- Full Mond 2.2 navigation and shared `AppState` lifecycle retained on supported newer systems.
+- **CacheExtra Fields** editor included.
+- **Persist after reboot** and **Ignore exploit failure** settings included.
 - **MobileGestalt**, **PosterBoard / Tendies**, and **HouseArrest / Santander** routes retained.
 - **Run Exploit** and **Generate Token** retain the upstream Mond flow.
 - Current MobileGestalt persistence and iOS 27 region-key behavior from the pinned upstream revision are included.
-- 3105 keeps its broader existing app-enumeration path instead of replacing it with the narrower paired-device app scan.
-- 3105 and ByeTunes share the same persisted pairing file and device tunnel state.
-- 3105 upgrades app rows with rendered **SpringBoardServices** icons when the shared paired connection is available.
-- Existing LaunchServices icons remain the immediate fallback, so app rows do not have to wait for the paired icon service.
-- Enhanced icon requests use a small persistent worker pool, request deduplication, caching, and reconnect/retry behavior instead of reconnecting SpringBoardServices once per row.
-- The untouched upstream Mond app source is preserved under `ThirdParty/mond-current/Upstream` for provenance.
-- The compiled copy receives mechanical module/symbol namespacing plus explicit embedded-host adapters for Mond's `AccentColor`, `com.roooot.mond` preferences domain, app identity/resources, and shared environment state. These adapters are applied only to the generated embedded copy; the preserved upstream snapshot is not rewritten.
-- A source-completeness gate compares the pinned functional Swift tree against the compiled Mond source list and fails the build if a future pin would silently omit a new upstream file.
-- Sandbox SPI ABI forwarding is handled by `MondSandboxSPICompat.c` without rewriting Mond's preserved upstream source.
-- The modern arm64 build is packaged with `MinimumOSVersion = 17.0`.
-- The compatibility build is compiled and packaged with `MinimumOSVersion = 16.1` and intentionally excludes Mond's iOS 27-specific payload while keeping Filza, 3105, ByeTunes, SSH, WebDAV, and the native Gestalt Manager.
+- 3105 and ByeTunes keep their shared persisted pairing/device connection.
+- 3105 keeps its broader app enumeration and SpringBoardServices icon upgrade path with LaunchServices fallback.
+- The untouched upstream Mond source snapshot remains under `ThirdParty/mond-current/Upstream`.
+- The generated embedded Mond copy retains its explicit AccentColor, `com.roooot.mond` defaults domain, resource-bundle, namespace, and shared-state adapters.
 
-See [`RELEASE_NOTES.md`](RELEASE_NOTES.md) for the release changelog that is automatically included in GitHub Releases.
+See [`RELEASE_NOTES.md`](RELEASE_NOTES.md) for the release changelog.
 
 ## Included features
 
-| Feature | Modern IPA | iOS 16.1+ IPA |
+| Feature | iOS 16.1 | iOS 17+ / supported newer systems |
 | --- | --- | --- |
 | Filza file browser | ✅ | ✅ |
-| Apps Manager | ✅ 3105 1.0.1 integrated | ✅ 3105 1.0.1 integrated |
+| Apps Manager | ✅ 3105 1.0.1 | ✅ 3105 1.0.1 |
 | Shared device pairing | ✅ | ✅ |
-| Enhanced app icons | ✅ SpringBoardServices when paired, LaunchServices fallback | ✅ where supported |
+| Enhanced app icons | ✅ where supported | ✅ SpringBoardServices with LaunchServices fallback |
 | `.3105` Patch Workspace v2 | ✅ | ✅ |
 | 3105 IPA repackaging | ✅ | ✅ |
 | Music Library / ByeTunes | ✅ | ✅ |
 | YouTube metadata provider | ✅ | ✅ |
-| Mond | ✅ Full pinned Mond 2.2 integration | ❌ intentionally excluded |
-| MobileGestalt editor | ✅ Mond 2.2 | ✅ native Gestalt Manager |
-| PosterBoard / Tendies | ✅ | ❌ Mond-only |
-| HouseArrest / Santander | ✅ | ❌ Mond-only |
+| MobileGestalt editor | ✅ native Gestalt Manager | ✅ Mond 2.2 where applicable |
+| Mond 2.2 UI/runtime | Not loaded | ✅ lazy-loaded module |
+| CacheExtra Fields | — | ✅ |
+| PosterBoard / Tendies | — | ✅ Mond route |
+| HouseArrest / Santander | — | ✅ Mond route |
 | WebDAV server | ✅ | ✅ |
 | SSH server | ✅ | ✅ |
 | Home Screen quick actions | ✅ | ✅ |
@@ -68,18 +67,17 @@ See [`RELEASE_NOTES.md`](RELEASE_NOTES.md) for the release changelog that is aut
 
 ## Compatibility
 
-The full modern IPA has a minimum deployment target of **iOS 17.0**. A second compatibility IPA has a minimum deployment target of **iOS 16.1**.
+The IPA itself supports **iOS 16.1 and newer**.
 
-For iOS 27, the useful `bad_query` behavior is associated with beta 1–4. Do not assume the same access on beta 5 or newer. Exact access can vary by device and build, so FilzaSlop validates real file/directory access instead of treating a returned handle as automatic success.
+Mond remains version-specific. Bundling its iOS-17+ runtime in the universal IPA does not make its exploit backend valid on every iOS version. On iOS 16, the newer module is not loaded.
 
-The iOS 16 compatibility build does not claim that Mond's current iOS 27 access backend works on older systems. Gestalt actions use the native Gestalt Manager instead.
+For iOS 27, the useful `bad_query` behavior is associated with beta 1–4. Do not assume the same access on beta 5 or newer. Exact access varies by device/build, so FilzaSlop validates actual filesystem/container access instead of treating a returned handle as automatic success.
 
 ## Install
 
-1. Download the current verified release from [`releases/latest`](https://github.com/NightVibes33/Filza-27/releases/latest).
-2. Choose `Filza-27.ipa` for the full modern/Mond build, or `Filza-27-iOS16.ipa` when the release includes the iOS 16 compatibility build.
-3. Sideload it with your preferred signing method.
-4. Keep the base app identity when your signer allows it:
+1. Download [`Filza-27.ipa`](https://github.com/NightVibes33/Filza-27/releases/latest/download/Filza-27.ipa).
+2. Sideload it with your preferred signing method.
+3. Keep the base app identity when your signer allows it:
 
 ```text
 com.apple.mobile.MobileHouseArrest
@@ -99,7 +97,7 @@ NightVibes33/3105@90ab4dd35823d58de10e6b8b78236e0e7e1ad32b
 
 It includes application search, icon and disk-size recovery where available, container browsing, per-tab navigation, file preview, create/rename/import/replace/delete operations, ZIP creation/extraction, IPA repackaging support, and Patch Workspace handoff.
 
-The Filza integration intentionally preserves 3105's broader application discovery. Pairing is used as an **optional icon-quality backend**, not as a replacement for enumeration: when the shared ByeTunes/Filza device connection is ready, 3105 requests the rendered icon for each bundle ID from SpringBoardServices and replaces the already-visible LaunchServices icon. If pairing, LocalDevVPN, or SpringBoardServices is unavailable, the existing icon remains in place.
+Pairing remains an optional icon-quality backend rather than a replacement for app enumeration. When the shared ByeTunes/Filza connection is ready, 3105 can request rendered SpringBoardServices icons; otherwise existing LaunchServices icons remain available.
 
 ### Patches
 
@@ -109,15 +107,15 @@ The embedded **3105 Patch Workspace v2** supports portable `.3105` projects, sch
 
 ByeTunes is embedded directly into FilzaSlop and includes library browsing, downloads, queue persistence, backups, restore/repair tools, metadata editing, and multi-source metadata routing.
 
-The current build also restores the known working pre-v2.4 YouTubeKit metadata path as the first free YouTube provider while retaining the current ByeTunes integration. Required JavaScript solver resources are packaged inside the IPA.
+The current integration also restores the known working pre-v2.4 YouTubeKit metadata path as the first free YouTube provider while retaining current ByeTunes behavior. Required JavaScript solver resources are packaged inside the IPA.
 
-ByeTunes owns the canonical pairing/device connection used by paired features. 3105 consumes that same persisted pairing state instead of maintaining a separate pairing database, so a valid connection established by one embedded feature can be reused by the other.
+ByeTunes owns the canonical pairing/device connection used by paired features, and 3105 consumes that same persisted state.
 
 ### Mond 2.2 / Gestalt Editor
 
-Mond is staged from the exact pinned upstream revision, then its generated compiled copy is adapted only where embedding inside Filza changes the standalone app environment. The modern IPA supplies Mond's accent color, isolated preferences domain, dedicated resource bundle, and shared environment bindings so SwiftUI controls and Settings identity do not accidentally inherit Filza's app target.
+Mond is staged from the exact pinned upstream revision. Only the generated embedded copy receives the host adaptations required to run inside Filza; the upstream snapshot remains unchanged.
 
-Available modern routes include:
+Available Mond routes include:
 
 - MobileGestalt
 - CacheExtra Fields
@@ -125,7 +123,7 @@ Available modern routes include:
 - HouseArrest / Santander
 - Settings / exploit controls
 
-The exposed Mond access methods include:
+Exposed Mond access methods include:
 
 - `bad_query`
 - `cmg`
@@ -136,9 +134,7 @@ The MobileGestalt cache used by the editor is:
 /private/var/containers/Shared/SystemGroup/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist
 ```
 
-The editor includes newer iOS 27 capability mappings alongside the existing Dynamic Island, Always-On Display, Camera Control, Action Button, Stage Manager, Apple Intelligence eligibility, internal-feature, and related controls.
-
-On iOS 16, Gestalt actions are routed to the native Gestalt Manager instead of embedding Mond's newer payload.
+On iOS 16, Gestalt actions route to the native Gestalt Manager instead of loading the modern Mond module.
 
 ## Logs
 
@@ -159,36 +155,34 @@ ByeTunesEmbedStage.txt
 
 ## Verification and builds
 
-The modern installable IPA workflow is:
+The full feature verifier is:
 
 ```text
 .github/workflows/verify-upstream-byetunes-ssh.yml
 ```
 
-The universal/iOS 16 verification workflow is:
+The one-IPA universal verifier is:
 
 ```text
-.github/workflows/verify-ios16-support.yml
+.github/workflows/verify-single-universal-ipa.yml
 ```
 
-CI independently builds the full Mond 2.2 arm64 graph and the iOS 16.1 compatibility graph. The Mond verifier checks the complete pinned functional source graph, including the current MobileGestalt sources, and the iOS 16 verifier checks that Mond host symbols are absent while 3105, ByeTunes, and native Gestalt symbols remain present.
+It builds the iOS 17+ Mond module first, then builds the iOS 16.1-compatible core, packages both into the **same IPA**, and verifies that the core/app do not eagerly link the newer module.
 
-After both exact-SHA verifiers succeed, the release workflow:
+CI verifies the core and optional Mond Mach-O deployment targets independently, checks expected symbols/resources, and validates the final IPA structure.
+
+After the exact-SHA universal and full-feature verifiers succeed, the release workflow:
 
 ```text
 .github/workflows/publish-green-ipa-release.yml
 ```
 
-waits for both verifier runs at the **same commit SHA**, downloads those exact artifacts, validates their IPA structure and minimum OS versions, calculates SHA-256, and publishes:
+publishes only:
 
 ```text
 Filza-27.ipa
 Filza-27-SHA256.txt
-Filza-27-iOS16.ipa
-Filza-27-iOS16-SHA256.txt
 ```
-
-The release body is generated from [`RELEASE_NOTES.md`](RELEASE_NOTES.md) plus the exact workflow runs and commit SHA used for the IPAs.
 
 ## Current limitations
 
@@ -220,4 +214,4 @@ FilzaSlop combines work from multiple open-source projects. Their upstream licen
 
 ## Research note
 
-This repository includes compatibility and filesystem-access research for modern iOS. Those experiments should be treated as research features, not as proof of unrestricted system access.
+This repository includes compatibility and filesystem-access research for modern iOS. Those experiments should be treated as research features, not proof of unrestricted system access.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,40 +1,26 @@
-# Filza 27 — Mond 2.2 + iOS 16 Support
+# Filza 27 — Universal iOS 16.1+ + Mond 2.2
 
-This release keeps the existing Filza/3105/ByeTunes/WebDAV/SSH feature set while upgrading the full modern build to pinned **Mond 2.2** and adding a separately verified **iOS 16.1+ compatibility IPA**.
+This release keeps Filza, 3105, ByeTunes, WebDAV, SSH, native Gestalt, and the full pinned Mond 2.2 integration in **one IPA**.
 
-## Downloads
+## Download
 
-- `Filza-27.ipa` — full modern build with Mond 2.2. Minimum iOS version: **17.0**.
-- `Filza-27-iOS16.ipa` — compatibility build for **iOS 16.1+**. It keeps Filza, 3105, ByeTunes, SSH/WebDAV, and the native Gestalt Manager, but intentionally omits Mond's iOS 27-specific exploit payload.
+- `Filza-27.ipa` — one universal arm64 IPA with `MinimumOSVersion = 16.1`.
+- `Filza-27-SHA256.txt` — SHA-256 checksum for that IPA.
 
-Each IPA is built and verified independently from the exact same commit before the release workflow publishes either one.
+There is no separate iOS 16 IPA.
 
-The release publishes four exact-SHA assets:
+## Universal runtime model
 
-- `Filza-27.ipa`
-- `Filza-27-SHA256.txt`
-- `Filza-27-iOS16.ipa`
-- `Filza-27-iOS16-SHA256.txt`
+The IPA contains two runtime layers:
 
-## Mond 2.2
+- `Frameworks/FilzaApplySandboxExt.dylib` — the core runtime compiled for **iOS 16.1+**. It contains Filza integration, 3105, ByeTunes, SSH, WebDAV, native Gestalt, and the shared routing layer.
+- `Frameworks/FilzaMondModern.dylib` — the full pinned **Mond 2.2** runtime compiled for **iOS 17.0+** and bundled inside the same IPA.
 
-- Updated the embedded Mond integration to upstream commit `3d91194716ad5f06afdf7e9037e6964e80a4ac29`.
-- Retained the exact upstream source snapshot under `ThirdParty/mond-current/Upstream` for provenance.
-- Added the new **CacheExtra Fields** editor introduced by Mond 2.2.
-- Added the upstream **Persist after reboot** setting.
-- Added the upstream **Ignore exploit failure** setting.
-- Included the current MobileGestalt persistence changes and corrected iOS 27 region-key behavior from the pinned upstream revision.
-- Preserved MobileGestalt, PosterBoard/Tendies, HouseArrest/Santander, Run Exploit, and Generate Token flows.
-- Preserved PartyUI and ZIPFoundation at their existing pinned revisions.
-- Updated the embedded resource bundle identity to report Mond **2.2** while retaining the upstream artwork and `com.roooot.mond` defaults domain.
-- Added a narrow generated-copy compatibility binding for Mond 2.2's new CacheExtra editor so its respring action receives the same shared `AppState` environment as the rest of the embedded Mond UI. The untouched upstream snapshot is not modified.
-- Kept the generated symbol/module namespace isolation required for Mond to coexist inside Filza's process.
+The core does **not** link the Mond dylib eagerly. On iOS 17+ it lazy-loads `FilzaMondModern.dylib` from the app's Frameworks directory when Mond is opened. On iOS 16 it never loads that newer Mach-O and routes Gestalt actions to the native Gestalt Manager instead.
 
-## iOS 16.1+ compatibility
+That keeps the application itself installable from iOS 16.1 upward without pretending Mond's iOS-17+ code is an iOS-16 binary.
 
-The project now has an explicit iOS 16 source graph instead of pretending newer-only components can run there.
-
-The iOS 16 build keeps:
+## Included on iOS 16.1+
 
 - Filza core file browser
 - 3105 Apps Manager and Patches
@@ -45,22 +31,44 @@ The iOS 16 build keeps:
 - native Gestalt Manager
 - Home Screen quick actions
 
-For iOS 16, Gestalt actions route to the native Gestalt Manager. Mond's Swift/C payload is excluded because upstream Mond targets iOS 17+ and its current access backend is designed for supported iOS 27 beta builds.
+## Mond 2.2 on supported newer systems
 
-The compatibility IPA is compiled with an iOS **16.1** deployment target and packaged with `MinimumOSVersion = 16.1`. The full Mond IPA is explicitly packaged with `MinimumOSVersion = 17.0` so an incompatible modern build is not presented as an iOS 16 binary.
+The bundled Mond runtime is pinned to upstream commit `3d91194716ad5f06afdf7e9037e6964e80a4ac29` and keeps:
+
+- MobileGestalt
+- CacheExtra Fields editor
+- PosterBoard / Tendies
+- HouseArrest / Santander
+- Run Exploit
+- Generate Token
+- Persist after reboot
+- Ignore exploit failure
+- current MobileGestalt persistence changes
+- corrected iOS 27 region-key behavior
+- PartyUI and ZIPFoundation pinned dependencies
+- dedicated `com.roooot.mond` defaults domain and embedded Mond resource bundle
+
+The exact upstream source snapshot remains under `ThirdParty/mond-current/Upstream` for provenance.
 
 ## Build and verification
 
-- CI independently builds the iOS 16.1 arm64 compatibility graph and the full Mond 2.2 arm64 graph.
-- The Mond verifier checks the complete pinned 2.2 functional source graph, including the new `mobilegestalt/CEView.swift` and moved `mobilegestalt/GestaltView.swift` files.
-- Mond staging and verification are separated so the verifier is side-effect free and cannot silently fetch or mutate sources.
-- The full build verifies the Mond 2.2 host, CacheExtra editor, persistence settings, region key, 3105, ByeTunes, SSH, and WebDAV symbols before packaging.
-- The iOS 16 build verifies that Mond host symbols are absent while 3105, ByeTunes, and native Gestalt symbols remain present.
-- The release workflow waits for both exact-SHA verification workflows before publishing.
-- Releases include separate SHA-256 checksum files for both IPA variants.
+The universal verifier builds both pieces from the same commit and then packages them into one IPA. CI verifies:
+
+- application `MinimumOSVersion = 16.1`
+- core dylib Mach-O minimum OS = 16.1
+- optional Mond dylib Mach-O minimum OS = 17.0
+- the core contains no `MondEmbeddedHostFactory`
+- the Mond dylib does contain `MondEmbeddedHostFactory`
+- the core has no `LC_LOAD_DYLIB` dependency on `FilzaMondModern.dylib`
+- the app executable has no eager dependency on `FilzaMondModern.dylib`
+- Filza, 3105, ByeTunes, native Gestalt, SSH, and WebDAV remain in the universal core
+- Mond 2.2 resources and the 3105 resource bundle are packaged in the same IPA
+- the final IPA passes ZIP/package integrity checks before upload
+
+The release pipeline publishes only `Filza-27.ipa` and its checksum after the exact-SHA universal verifier and full feature verifier are green.
 
 ## Compatibility note
 
 The project does **not** claim a full jailbreak, kernel read/write, root shell, SPTM bypass, or writable system volume. Actual filesystem/container access depends on the iOS build and the access primitives available to the running app.
 
-Mond's current exploit support remains version-specific. The iOS 16 compatibility build therefore does not label the Mond iOS 27 backend as usable on older systems; it uses the native Gestalt path instead.
+Mond's exploit support remains version-specific. The universal packaging only solves application/runtime compatibility across OS versions; it does not make Mond's exploit backend applicable to unsupported iOS builds.


### PR DESCRIPTION
Replace the dual-IPA release model with one package. The core dylib stays iOS 16.1-compatible and lazy-loads the bundled Mond 2.2 runtime dylib only on iOS 17+. iOS 16 routes Gestalt actions to the native Gestalt Manager. Adds exact CI verification that the core does not link Mond eagerly, both Mach-O deployment targets are correct, and both dylibs plus Mond resources are present in the same IPA.

## Summary by Sourcery

Publish one verified universal iOS 16.1+ IPA with an optional iOS 17+ Mond 2.2 runtime.

New Features:
- Package the iOS 16.1-compatible core and iOS 17+ Mond 2.2 runtime in a single universal arm64 IPA.
- Lazy-load Mond 2.2 on iOS 17+ while routing Gestalt actions through the native Gestalt Manager on iOS 16.

Enhancements:
- Replace the dual-IPA release model with one universal IPA and a single checksum asset.
- Add comprehensive verification for deployment targets, non-eager Mond linking, bundled runtimes, and required resources.
- Update release documentation and notes to describe universal iOS 16.1+ compatibility and runtime behavior.

CI:
- Add a universal IPA verification workflow that builds, packages, and validates both runtime layers from the same commit.

Deployment:
- Update publishing to wait for universal and full-feature verification, publish one IPA, and remove obsolete iOS 16 release assets.

Documentation:
- Revise the README and release notes for the universal iOS 16.1+ IPA and its iOS 17+ Mond 2.2 feature set.