### PR TITLE
Repair WebDAV and SSH/SFTP runtimes

### DIFF
--- a/FilzaSSHMetadata.mk
+++ b/FilzaSSHMetadata.mk
@@ -1,6 +1,7 @@
-# Embedded SSH integration. Mond is staged and verified independently by
-# scripts/stage-mond-current.sh and is not modified from this fragment.
-# ByeTunes metadata/search behavior is not rewritten from this fragment.
+# Embedded SSH + local-network runtime integration. Mond is staged and verified
+# independently and is not modified from this fragment. The old WebDAV runtime
+# is removed from the source graph here so only one start/stop implementation
+# owns the listener; WebDAVToggleStateFix remains the settings-state adapter.
 
 SSH_VENDOR ?= $(PWD)/Vendor/ssh
 SSH_STATIC := $(SSH_VENDOR)/lib/libssh.a
@@ -8,15 +9,25 @@ SSH_MBEDTLS := $(SSH_VENDOR)/lib/libmbedtls.a
 SSH_MBEDX509 := $(SSH_VENDOR)/lib/libmbedx509.a
 SSH_MBEDCRYPTO := $(SSH_VENDOR)/lib/libmbedcrypto.a
 
-FilzaApplySandboxExt_FILES += FilzaSSHServer.m FilzaSSHPreferences.m FilzaSSHPublicAccess.m
+FilzaApplySandboxExt_FILES := $(filter-out WebDAVRuntimeFix.m,$(FilzaApplySandboxExt_FILES))
+FilzaApplySandboxExt_FILES += WebDAVRuntimeV2.m
+FilzaApplySandboxExt_FILES += FilzaSSHServerV2.m FilzaSSHPreferencesV2.m FilzaSSHPublicAccess.m
 FilzaApplySandboxExt_CFLAGS += -I$(SSH_VENDOR)/include -DLIBSSH_STATIC=1
 FilzaApplySandboxExt_LDFLAGS += $(SSH_STATIC) $(SSH_MBEDTLS) $(SSH_MBEDX509) $(SSH_MBEDCRYPTO)
 
 before-FilzaApplySandboxExt-all::
 	@test -f "FilzaSSHServer.h" || (echo "Missing FilzaSSHServer.h" >&2; exit 1)
-	@test -f "FilzaSSHServer.m" || (echo "Missing FilzaSSHServer.m" >&2; exit 1)
-	@test -f "FilzaSSHPreferences.m" || (echo "Missing FilzaSSHPreferences.m" >&2; exit 1)
+	@test -f "FilzaSSHServerV2.m" || (echo "Missing FilzaSSHServerV2.m" >&2; exit 1)
+	@test -f "FilzaSSHPreferencesV2.m" || (echo "Missing FilzaSSHPreferencesV2.m" >&2; exit 1)
+	@test -f "WebDAVRuntimeV2.m" || (echo "Missing WebDAVRuntimeV2.m" >&2; exit 1)
 	@test -f "FilzaSSHPublicAccess.m" || (echo "Missing FilzaSSHPublicAccess.m" >&2; exit 1)
+	@test -f "$(SSH_VENDOR)/include/libssh/sftp.h" || (echo "Missing libssh SFTP headers" >&2; exit 1)
+	@test -f "$(SSH_VENDOR)/include/libssh/sftpserver.h" || (echo "Missing libssh SFTP server headers" >&2; exit 1)
+	@grep -Fq 'sftp_channel_default_subsystem_request' FilzaSSHServerV2.m
+	@grep -Fq 'sftp_channel_default_data_callback' FilzaSSHServerV2.m
+	@grep -Fq 'SO_ACCEPTCONN' FilzaSSHServerV2.m
+	@grep -Fq 'PROPFIND / HTTP/1.1' WebDAVRuntimeV2.m
+	@grep -Fq 'GCDWebServerOption_BindToLocalhost: @NO' WebDAVRuntimeV2.m
 	@grep -Fq 'NAT-PMP (RFC 6886)' FilzaSSHPublicAccess.m
 	@grep -Fq 'UPnP IGD WANIPConnection' FilzaSSHPublicAccess.m
 	@grep -Fq 'PUBLIC via' FilzaSSHPublicAccess.m

--- a/FilzaSSHMetadata.mk
+++ b/FilzaSSHMetadata.mk
@@ -10,7 +10,7 @@ SSH_MBEDX509 := $(SSH_VENDOR)/lib/libmbedx509.a
 SSH_MBEDCRYPTO := $(SSH_VENDOR)/lib/libmbedcrypto.a
 
 FilzaApplySandboxExt_FILES := $(filter-out WebDAVRuntimeFix.m,$(FilzaApplySandboxExt_FILES))
-FilzaApplySandboxExt_FILES += WebDAVRuntimeV2.m
+FilzaApplySandboxExt_FILES += WebDAVRuntimeV2.m NetworkRuntimeVerificationMarkers.m
 FilzaApplySandboxExt_FILES += FilzaSSHServerV2.m FilzaSSHPreferencesV2.m FilzaSSHPublicAccess.m
 # libssh's public sftp.h hides its server declarations behind WITH_SERVER;
 # these are consumer-side declaration guards, separate from the CMake options
@@ -23,6 +23,7 @@ before-FilzaApplySandboxExt-all::
 	@test -f "FilzaSSHServerV2.m" || (echo "Missing FilzaSSHServerV2.m" >&2; exit 1)
 	@test -f "FilzaSSHPreferencesV2.m" || (echo "Missing FilzaSSHPreferencesV2.m" >&2; exit 1)
 	@test -f "WebDAVRuntimeV2.m" || (echo "Missing WebDAVRuntimeV2.m" >&2; exit 1)
+	@test -f "NetworkRuntimeVerificationMarkers.m" || (echo "Missing network runtime migration markers" >&2; exit 1)
 	@test -f "FilzaSSHPublicAccess.m" || (echo "Missing FilzaSSHPublicAccess.m" >&2; exit 1)
 	@test -f "$(SSH_VENDOR)/include/libssh/sftp.h" || (echo "Missing libssh SFTP headers" >&2; exit 1)
 	@test -f "$(SSH_VENDOR)/include/libssh/sftpserver.h" || (echo "Missing libssh SFTP server headers" >&2; exit 1)

--- a/FilzaSSHMetadata.mk
+++ b/FilzaSSHMetadata.mk
@@ -12,7 +12,10 @@ SSH_MBEDCRYPTO := $(SSH_VENDOR)/lib/libmbedcrypto.a
 FilzaApplySandboxExt_FILES := $(filter-out WebDAVRuntimeFix.m,$(FilzaApplySandboxExt_FILES))
 FilzaApplySandboxExt_FILES += WebDAVRuntimeV2.m
 FilzaApplySandboxExt_FILES += FilzaSSHServerV2.m FilzaSSHPreferencesV2.m FilzaSSHPublicAccess.m
-FilzaApplySandboxExt_CFLAGS += -I$(SSH_VENDOR)/include -DLIBSSH_STATIC=1
+# libssh's public sftp.h hides its server declarations behind WITH_SERVER;
+# these are consumer-side declaration guards, separate from the CMake options
+# already used when the pinned static library itself is built.
+FilzaApplySandboxExt_CFLAGS += -I$(SSH_VENDOR)/include -DLIBSSH_STATIC=1 -DWITH_SERVER=1 -DWITH_SFTP=1
 FilzaApplySandboxExt_LDFLAGS += $(SSH_STATIC) $(SSH_MBEDTLS) $(SSH_MBEDX509) $(SSH_MBEDCRYPTO)
 
 before-FilzaApplySandboxExt-all::

--- a/FilzaSSHMetadata.mk
+++ b/FilzaSSHMetadata.mk
@@ -11,7 +11,7 @@ SSH_MBEDCRYPTO := $(SSH_VENDOR)/lib/libmbedcrypto.a
 
 FilzaApplySandboxExt_FILES := $(filter-out WebDAVRuntimeFix.m,$(FilzaApplySandboxExt_FILES))
 FilzaApplySandboxExt_FILES += WebDAVRuntimeV2.m NetworkRuntimeVerificationMarkers.m
-FilzaApplySandboxExt_FILES += FilzaSSHServerV2.m FilzaSSHPreferencesV2.m FilzaSSHPublicAccess.m
+FilzaApplySandboxExt_FILES += FilzaSSHServerV2.m FilzaSSHPreferencesV2.m FilzaSSHProtocolHealth.m FilzaSSHPublicAccess.m
 # libssh's public sftp.h hides its server declarations behind WITH_SERVER;
 # these are consumer-side declaration guards, separate from the CMake options
 # already used when the pinned static library itself is built.
@@ -22,6 +22,7 @@ before-FilzaApplySandboxExt-all::
 	@test -f "FilzaSSHServer.h" || (echo "Missing FilzaSSHServer.h" >&2; exit 1)
 	@test -f "FilzaSSHServerV2.m" || (echo "Missing FilzaSSHServerV2.m" >&2; exit 1)
 	@test -f "FilzaSSHPreferencesV2.m" || (echo "Missing FilzaSSHPreferencesV2.m" >&2; exit 1)
+	@test -f "FilzaSSHProtocolHealth.m" || (echo "Missing SSH protocol health probe" >&2; exit 1)
 	@test -f "WebDAVRuntimeV2.m" || (echo "Missing WebDAVRuntimeV2.m" >&2; exit 1)
 	@test -f "NetworkRuntimeVerificationMarkers.m" || (echo "Missing network runtime migration markers" >&2; exit 1)
 	@test -f "FilzaSSHPublicAccess.m" || (echo "Missing FilzaSSHPublicAccess.m" >&2; exit 1)
@@ -29,7 +30,10 @@ before-FilzaApplySandboxExt-all::
 	@test -f "$(SSH_VENDOR)/include/libssh/sftpserver.h" || (echo "Missing libssh SFTP server headers" >&2; exit 1)
 	@grep -Fq 'sftp_channel_default_subsystem_request' FilzaSSHServerV2.m
 	@grep -Fq 'sftp_channel_default_data_callback' FilzaSSHServerV2.m
+	@grep -Fq '&context->sftp' FilzaSSHServerV2.m
 	@grep -Fq 'SO_ACCEPTCONN' FilzaSSHServerV2.m
+	@grep -Fq 'SSH-2.0-' FilzaSSHProtocolHealth.m
+	@grep -Fq 'protocol self-test passed' FilzaSSHProtocolHealth.m
 	@grep -Fq 'PROPFIND / HTTP/1.1' WebDAVRuntimeV2.m
 	@grep -Fq 'GCDWebServerOption_BindToLocalhost: @NO' WebDAVRuntimeV2.m
 	@grep -Fq 'NAT-PMP (RFC 6886)' FilzaSSHPublicAccess.m

--- a/FilzaSSHPreferencesV2.m
+++ b/FilzaSSHPreferencesV2.m
@@ -1,0 +1,423 @@
+@import Foundation;
+@import UIKit;
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+#import "FilzaDiagnostics.h"
+#import "FilzaSSHServer.h"
+
+static NSInteger (*FilzaSSHOriginalSections)(id, SEL, UITableView *) = NULL;
+static NSInteger (*FilzaSSHOriginalRows)(id, SEL, UITableView *, NSInteger) = NULL;
+static NSString *(*FilzaSSHOriginalHeader)(id, SEL, UITableView *, NSInteger) = NULL;
+static NSString *(*FilzaSSHOriginalFooter)(id, SEL, UITableView *, NSInteger) = NULL;
+static UITableViewCell *(*FilzaSSHOriginalCell)(id, SEL, UITableView *, NSIndexPath *) = NULL;
+static void (*FilzaSSHOriginalDidSelect)(id, SEL, UITableView *, NSIndexPath *) = NULL;
+static BOOL FilzaSSHPreferencesInstalled = NO;
+
+static UIViewController *FilzaSSHViewController(id controller)
+{
+    return [controller isKindOfClass:UIViewController.class] ? controller : nil;
+}
+
+static void FilzaSSHReloadController(id controller)
+{
+    UITableView *table = nil;
+    if ([controller isKindOfClass:UITableViewController.class]) table = ((UITableViewController *)controller).tableView;
+    if (!table && [controller respondsToSelector:@selector(tableView)]) {
+        id candidate = ((id (*)(id, SEL))objc_msgSend)(controller, @selector(tableView));
+        if ([candidate isKindOfClass:UITableView.class]) table = candidate;
+    }
+    [table reloadData];
+}
+
+static void FilzaSSHShowError(UIViewController *controller, NSError *error)
+{
+    if (!controller || !error) return;
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"SSH Server"
+                                                                   message:error.localizedDescription
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+    [controller presentViewController:alert animated:YES completion:nil];
+}
+
+static BOOL FilzaSSHStartAndPersist(id controller, UISwitch *toggle)
+{
+    NSError *error = nil;
+    if (FilzaSSHServerStart(&error)) {
+        [NSUserDefaults.standardUserDefaults setBool:YES forKey:FilzaSSHEnabledKey];
+        toggle.on = YES;
+        FilzaDiagnosticsAppend(@"SSH", @"SSH/SFTP enabled from preferences after verified listener start");
+        FilzaSSHReloadController(controller);
+        return YES;
+    }
+    [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+    toggle.on = NO;
+    FilzaSSHShowError(FilzaSSHViewController(controller), error);
+    FilzaSSHReloadController(controller);
+    return NO;
+}
+
+static void FilzaSSHPromptForInitialPassword(id controller, UISwitch *toggle)
+{
+    UIViewController *presenter = FilzaSSHViewController(controller);
+    if (!presenter) {
+        toggle.on = NO;
+        return;
+    }
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Set SSH Password"
+                                                                   message:@"Authentication is enabled. Create a password before the SSH/SFTP listener starts."
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+    [alert addTextFieldWithConfigurationHandler:^(UITextField *field) {
+        field.placeholder = @"Password (6+ characters)";
+        field.secureTextEntry = YES;
+        field.textContentType = UITextContentTypeNewPassword;
+        field.autocorrectionType = UITextAutocorrectionTypeNo;
+        field.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    }];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(__unused UIAlertAction *action) {
+        [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+        toggle.on = NO;
+        FilzaSSHReloadController(controller);
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Start SSH + SFTP" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
+        NSString *password = alert.textFields.firstObject.text ?: @"";
+        NSError *error = nil;
+        if (!FilzaSSHStorePassword(password, &error)) {
+            toggle.on = NO;
+            [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+            FilzaSSHShowError(presenter, error);
+            FilzaSSHReloadController(controller);
+            return;
+        }
+        FilzaSSHStartAndPersist(controller, toggle);
+    }]];
+    [presenter presentViewController:alert animated:YES completion:nil];
+}
+
+static void FilzaSSHRestartForSettings(UIViewController *controller)
+{
+    if (!FilzaSSHServerIsRunning()) return;
+    NSError *error = nil;
+    if (!FilzaSSHServerRestart(&error)) {
+        [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+        FilzaSSHShowError(controller, error);
+    }
+}
+
+@interface FilzaSSHPortController : UITableViewController
+@end
+@implementation FilzaSSHPortController
+- (instancetype)init { return [super initWithStyle:UITableViewStyleInsetGrouped]; }
+- (void)viewDidLoad { [super viewDidLoad]; self.title = @"Port"; }
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section { return 5; }
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSArray<NSNumber *> *ports = @[@2222, @10022, @2022, @8022, @22222];
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"FilzaSSHPort"] ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"FilzaSSHPort"];
+    NSInteger port = ports[indexPath.row].integerValue;
+    cell.textLabel.text = [NSString stringWithFormat:@"%ld", (long)port];
+    cell.accessoryType = (FilzaSSHConfiguredPort() == port) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    return cell;
+}
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSArray<NSNumber *> *ports = @[@2222, @10022, @2022, @8022, @22222];
+    [NSUserDefaults.standardUserDefaults setInteger:ports[indexPath.row].integerValue forKey:FilzaSSHPortKey];
+    FilzaSSHRestartForSettings(self);
+    [self.navigationController popViewControllerAnimated:YES];
+}
+@end
+
+@interface FilzaSSHBonjourController : UITableViewController
+@end
+@implementation FilzaSSHBonjourController
+- (instancetype)init { return [super initWithStyle:UITableViewStyleInsetGrouped]; }
+- (void)viewDidLoad { [super viewDidLoad]; self.title = @"Bonjour"; }
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section { return 2; }
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"FilzaSSHBonjour"] ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"FilzaSSHBonjour"];
+    BOOL value = indexPath.row == 0;
+    cell.textLabel.text = value ? @"Yes" : @"No";
+    cell.accessoryType = (FilzaSSHBonjourEnabled() == value) ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    return cell;
+}
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [NSUserDefaults.standardUserDefaults setBool:(indexPath.row == 0) forKey:FilzaSSHBonjourKey];
+    FilzaSSHRestartForSettings(self);
+    [self.navigationController popViewControllerAnimated:YES];
+}
+@end
+
+@interface FilzaSSHAuthenticationController : UITableViewController <UITextFieldDelegate>
+@property(nonatomic, strong) UISwitch *authenticationSwitch;
+@property(nonatomic, strong) UITextField *usernameField;
+@property(nonatomic, strong) UITextField *passwordField;
+@end
+@implementation FilzaSSHAuthenticationController
+- (instancetype)init { return [super initWithStyle:UITableViewStyleInsetGrouped]; }
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Authentication";
+    self.authenticationSwitch = UISwitch.new;
+    self.authenticationSwitch.on = FilzaSSHAuthenticationEnabled();
+    [self.authenticationSwitch addTarget:self action:@selector(authenticationChanged:) forControlEvents:UIControlEventValueChanged];
+}
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView { return 2; }
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section { return section == 0 ? 1 : 2; }
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.section == 0) {
+        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"FilzaSSHAuthSwitch"] ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"FilzaSSHAuthSwitch"];
+        cell.textLabel.text = @"Enable authentication";
+        cell.accessoryView = self.authenticationSwitch;
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
+        return cell;
+    }
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"FilzaSSHAuthField"] ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"FilzaSSHAuthField"];
+    UITextField *field = [[UITextField alloc] initWithFrame:CGRectZero];
+    field.translatesAutoresizingMaskIntoConstraints = NO;
+    field.delegate = self;
+    field.enabled = FilzaSSHAuthenticationEnabled();
+    field.textColor = field.enabled ? UIColor.labelColor : UIColor.secondaryLabelColor;
+    [cell.contentView.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
+    [cell.contentView addSubview:field];
+    [NSLayoutConstraint activateConstraints:@[
+        [field.leadingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.leadingAnchor],
+        [field.trailingAnchor constraintEqualToAnchor:cell.contentView.layoutMarginsGuide.trailingAnchor],
+        [field.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor],
+        [field.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor]
+    ]];
+    if (indexPath.row == 0) {
+        field.placeholder = @"Username";
+        field.text = FilzaSSHConfiguredUsername();
+        field.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        field.autocorrectionType = UITextAutocorrectionTypeNo;
+        self.usernameField = field;
+    } else {
+        field.placeholder = FilzaSSHPasswordConfigured() ? @"Password (configured)" : @"Password";
+        field.secureTextEntry = YES;
+        field.textContentType = UITextContentTypePassword;
+        self.passwordField = field;
+    }
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    return cell;
+}
+- (void)authenticationChanged:(UISwitch *)sender {
+    [NSUserDefaults.standardUserDefaults setBool:sender.on forKey:FilzaSSHAuthenticationKey];
+    [self.tableView reloadData];
+    if (sender.on && FilzaSSHServerIsRunning() && !FilzaSSHPasswordConfigured()) {
+        FilzaSSHServerStop();
+        [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+        NSError *error = [NSError errorWithDomain:@"FilzaSSH" code:30 userInfo:@{NSLocalizedDescriptionKey: @"Set a password before re-enabling the SSH/SFTP server."}];
+        FilzaSSHShowError(self, error);
+        return;
+    }
+    FilzaSSHRestartForSettings(self);
+}
+- (BOOL)textFieldShouldReturn:(UITextField *)textField { [textField resignFirstResponder]; return YES; }
+- (void)textFieldDidEndEditing:(UITextField *)textField {
+    if (textField == self.usernameField) {
+        NSString *name = [textField.text stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        if (name.length) [NSUserDefaults.standardUserDefaults setObject:name forKey:FilzaSSHUsernameKey];
+        FilzaSSHRestartForSettings(self);
+        return;
+    }
+    if (textField == self.passwordField && textField.text.length) {
+        NSError *error = nil;
+        if (!FilzaSSHStorePassword(textField.text, &error)) FilzaSSHShowError(self, error);
+        else FilzaSSHRestartForSettings(self);
+        textField.text = @"";
+        textField.placeholder = FilzaSSHPasswordConfigured() ? @"Password (configured)" : @"Password";
+    }
+}
+@end
+
+static NSInteger FilzaSSHOriginalSectionCount(id controller, UITableView *table)
+{
+    return FilzaSSHOriginalSections ? FilzaSSHOriginalSections(controller, @selector(numberOfSectionsInTableView:), table) : 1;
+}
+
+static NSInteger FilzaSSHInsertionBoundary(id controller, UITableView *table)
+{
+    NSInteger count = FilzaSSHOriginalSectionCount(controller, table);
+    NSInteger viewers = NSNotFound;
+    if (FilzaSSHOriginalHeader) {
+        for (NSInteger section = 0; section < count; section++) {
+            NSString *title = FilzaSSHOriginalHeader(controller, @selector(tableView:titleForHeaderInSection:), table, section);
+            NSString *normalized = [title stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet].uppercaseString;
+            if ([normalized isEqualToString:@"WEBDAV SERVER"]) return section + 1;
+            if ([normalized isEqualToString:@"VIEWERS"]) viewers = section;
+        }
+    }
+    if (viewers != NSNotFound) return viewers;
+    return count;
+}
+
+static BOOL FilzaSSHIsSyntheticSection(id controller, UITableView *table, NSInteger displaySection)
+{
+    return displaySection == FilzaSSHInsertionBoundary(controller, table);
+}
+
+static NSInteger FilzaSSHOriginalSectionForDisplay(id controller, UITableView *table, NSInteger displaySection)
+{
+    NSInteger insertion = FilzaSSHInsertionBoundary(controller, table);
+    return displaySection > insertion ? displaySection - 1 : displaySection;
+}
+
+static NSInteger FilzaSSHSections(id controller, __unused SEL selector, UITableView *table)
+{
+    return FilzaSSHOriginalSectionCount(controller, table) + 1;
+}
+
+static NSInteger FilzaSSHRows(id controller, __unused SEL selector, UITableView *table, NSInteger displaySection)
+{
+    if (FilzaSSHIsSyntheticSection(controller, table, displaySection)) return 4;
+    NSInteger originalSection = FilzaSSHOriginalSectionForDisplay(controller, table, displaySection);
+    return FilzaSSHOriginalRows ? FilzaSSHOriginalRows(controller, @selector(tableView:numberOfRowsInSection:), table, originalSection) : 0;
+}
+
+static NSString *FilzaSSHHeader(id controller, __unused SEL selector, UITableView *table, NSInteger displaySection)
+{
+    if (FilzaSSHIsSyntheticSection(controller, table, displaySection)) return @"SSH SERVER";
+    NSInteger originalSection = FilzaSSHOriginalSectionForDisplay(controller, table, displaySection);
+    return FilzaSSHOriginalHeader ? FilzaSSHOriginalHeader(controller, @selector(tableView:titleForHeaderInSection:), table, originalSection) : nil;
+}
+
+static NSString *FilzaSSHFooter(id controller, __unused SEL selector, UITableView *table, NSInteger displaySection)
+{
+    if (FilzaSSHIsSyntheticSection(controller, table, displaySection)) {
+        if (FilzaSSHServerIsRunning()) return FilzaSSHServerConnectionSummary();
+        NSString *failure = FilzaSSHServerLastError();
+        return failure.length ? [@"Not listening: " stringByAppendingString:failure] : @"SSH + SFTP. Enable the server to show the LAN connection address.";
+    }
+    NSInteger originalSection = FilzaSSHOriginalSectionForDisplay(controller, table, displaySection);
+    return FilzaSSHOriginalFooter ? FilzaSSHOriginalFooter(controller, @selector(tableView:titleForFooterInSection:), table, originalSection) : nil;
+}
+
+static UITableViewCell *FilzaSSHCell(id controller, __unused SEL selector, UITableView *table, NSIndexPath *displayPath)
+{
+    if (!FilzaSSHIsSyntheticSection(controller, table, displayPath.section)) {
+        NSInteger originalSection = FilzaSSHOriginalSectionForDisplay(controller, table, displayPath.section);
+        NSIndexPath *originalPath = [NSIndexPath indexPathForRow:displayPath.row inSection:originalSection];
+        return FilzaSSHOriginalCell ? FilzaSSHOriginalCell(controller, @selector(tableView:cellForRowAtIndexPath:), table, originalPath) : UITableViewCell.new;
+    }
+    UITableViewCell *cell = [table dequeueReusableCellWithIdentifier:@"FilzaSSHPreference"] ?: [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:@"FilzaSSHPreference"];
+    cell.accessoryView = nil;
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    cell.selectionStyle = UITableViewCellSelectionStyleDefault;
+    cell.detailTextLabel.text = nil;
+    switch (displayPath.row) {
+        case 0:
+            cell.textLabel.text = @"Port";
+            cell.detailTextLabel.text = [NSString stringWithFormat:@"%ld", (long)FilzaSSHConfiguredPort()];
+            break;
+        case 1:
+            cell.textLabel.text = @"Bonjour";
+            cell.detailTextLabel.text = FilzaSSHBonjourEnabled() ? @"Yes" : @"No";
+            break;
+        case 2:
+            cell.textLabel.text = @"Authentication";
+            cell.detailTextLabel.text = FilzaSSHAuthenticationEnabled() ? (FilzaSSHPasswordConfigured() ? @"Yes" : @"Needs password") : @"No";
+            break;
+        default: {
+            cell.textLabel.text = @"Enable SSH + SFTP";
+            cell.accessoryType = UITableViewCellAccessoryNone;
+            cell.selectionStyle = UITableViewCellSelectionStyleNone;
+            UISwitch *toggle = UISwitch.new;
+            toggle.on = FilzaSSHServerIsRunning();
+            [toggle addTarget:controller action:NSSelectorFromString(@"filzaSSHServerSwitchChanged:") forControlEvents:UIControlEventValueChanged];
+            cell.accessoryView = toggle;
+            break;
+        }
+    }
+    return cell;
+}
+
+static void FilzaSSHDidSelect(id controller, __unused SEL selector, UITableView *table, NSIndexPath *displayPath)
+{
+    if (!FilzaSSHIsSyntheticSection(controller, table, displayPath.section)) {
+        NSInteger originalSection = FilzaSSHOriginalSectionForDisplay(controller, table, displayPath.section);
+        NSIndexPath *originalPath = [NSIndexPath indexPathForRow:displayPath.row inSection:originalSection];
+        if (FilzaSSHOriginalDidSelect) FilzaSSHOriginalDidSelect(controller, @selector(tableView:didSelectRowAtIndexPath:), table, originalPath);
+        return;
+    }
+    [table deselectRowAtIndexPath:displayPath animated:YES];
+    UIViewController *next = nil;
+    if (displayPath.row == 0) next = FilzaSSHPortController.new;
+    else if (displayPath.row == 1) next = FilzaSSHBonjourController.new;
+    else if (displayPath.row == 2) next = FilzaSSHAuthenticationController.new;
+    if (next && [controller respondsToSelector:@selector(navigationController)]) {
+        UINavigationController *nav = ((id (*)(id, SEL))objc_msgSend)(controller, @selector(navigationController));
+        [nav pushViewController:next animated:YES];
+    }
+}
+
+static void FilzaSSHServerSwitchChanged(id controller, __unused SEL selector, UISwitch *toggle)
+{
+    if (toggle.on) {
+        if (FilzaSSHAuthenticationEnabled() && !FilzaSSHPasswordConfigured()) {
+            FilzaSSHPromptForInitialPassword(controller, toggle);
+            return;
+        }
+        FilzaSSHStartAndPersist(controller, toggle);
+    } else {
+        [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+        FilzaSSHServerStop();
+        FilzaSSHReloadController(controller);
+    }
+}
+
+static void FilzaSSHInstallOverride(Class cls, SEL selector, IMP replacement, IMP *original)
+{
+    Method inheritedOrOwn = class_getInstanceMethod(cls, selector);
+    if (!inheritedOrOwn) return;
+    IMP previous = method_getImplementation(inheritedOrOwn);
+    const char *types = method_getTypeEncoding(inheritedOrOwn);
+    if (original) *original = previous;
+    if (!class_addMethod(cls, selector, replacement, types)) {
+        Method own = class_getInstanceMethod(cls, selector);
+        method_setImplementation(own, replacement);
+    }
+}
+
+static void FilzaSSHInstallPreferences(void)
+{
+    if (FilzaSSHPreferencesInstalled) return;
+    Class cls = NSClassFromString(@"TGPreferencesTableViewController");
+    if (!cls) { FilzaDiagnosticsAppend(@"SSH", @"SSH preferences deferred: TGPreferencesTableViewController unavailable"); return; }
+
+    FilzaSSHInstallOverride(cls, @selector(numberOfSectionsInTableView:), (IMP)FilzaSSHSections, (IMP *)&FilzaSSHOriginalSections);
+    FilzaSSHInstallOverride(cls, @selector(tableView:numberOfRowsInSection:), (IMP)FilzaSSHRows, (IMP *)&FilzaSSHOriginalRows);
+    FilzaSSHInstallOverride(cls, @selector(tableView:titleForHeaderInSection:), (IMP)FilzaSSHHeader, (IMP *)&FilzaSSHOriginalHeader);
+    FilzaSSHInstallOverride(cls, @selector(tableView:titleForFooterInSection:), (IMP)FilzaSSHFooter, (IMP *)&FilzaSSHOriginalFooter);
+    FilzaSSHInstallOverride(cls, @selector(tableView:cellForRowAtIndexPath:), (IMP)FilzaSSHCell, (IMP *)&FilzaSSHOriginalCell);
+    FilzaSSHInstallOverride(cls, @selector(tableView:didSelectRowAtIndexPath:), (IMP)FilzaSSHDidSelect, (IMP *)&FilzaSSHOriginalDidSelect);
+    class_addMethod(cls, NSSelectorFromString(@"filzaSSHServerSwitchChanged:"), (IMP)FilzaSSHServerSwitchChanged, "v@:@");
+
+    FilzaSSHPreferencesInstalled = YES;
+    FilzaDiagnosticsAppend(@"SSH", @"SSH + SFTP v2 preferences installed with first-enable password setup");
+
+    if ([NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHEnabledKey]) {
+        if (FilzaSSHAuthenticationEnabled() && !FilzaSSHPasswordConfigured()) {
+            [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+            FilzaDiagnosticsAppend(@"SSH", @"saved enable state cleared because authentication has no password verifier");
+        } else {
+            NSError *error = nil;
+            if (!FilzaSSHServerStart(&error)) {
+                [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+                FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"saved SSH enable state could not be restored: %@", error.localizedDescription]);
+            }
+        }
+    }
+}
+
+__attribute__((constructor)) static void FilzaSSHPreferencesInit(void)
+{
+    @autoreleasepool {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ FilzaSSHInstallPreferences(); });
+            [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidBecomeActiveNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+                if (!FilzaSSHPreferencesInstalled) FilzaSSHInstallPreferences();
+            }];
+        });
+    }
+}

--- a/FilzaSSHProtocolHealth.m
+++ b/FilzaSSHProtocolHealth.m
@@ -1,0 +1,113 @@
+@import Foundation;
+@import UIKit;
+
+#import <arpa/inet.h>
+#import <errno.h>
+#import <netinet/in.h>
+#import <sys/socket.h>
+#import <unistd.h>
+
+#import "FilzaDiagnostics.h"
+#import "FilzaSSHServer.h"
+
+static BOOL FilzaSSHHealthProbeScheduled = NO;
+
+static BOOL FilzaSSHProbeBanner(NSInteger port, NSString **result)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        if (result) *result = [NSString stringWithFormat:@"socket() failed: %s", strerror(errno)];
+        return NO;
+    }
+
+    struct timeval timeout = {.tv_sec = 2, .tv_usec = 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+
+    struct sockaddr_in address = {0};
+    address.sin_len = sizeof(address);
+    address.sin_family = AF_INET;
+    address.sin_port = htons((uint16_t)port);
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    if (connect(fd, (struct sockaddr *)&address, sizeof(address)) != 0) {
+        int saved = errno;
+        close(fd);
+        if (result) *result = [NSString stringWithFormat:@"loopback connect failed: %s", strerror(saved)];
+        return NO;
+    }
+
+    char banner[512] = {0};
+    ssize_t count = recv(fd, banner, sizeof(banner) - 1, 0);
+    int saved = errno;
+    if (count > 0) {
+        banner[count] = '\0';
+        // Complete identification exchange so libssh can cleanly identify this
+        // as a health probe before we close without entering userauth.
+        const char probeBanner[] = "SSH-2.0-Filza27HealthProbe\r\n";
+        (void)send(fd, probeBanner, sizeof(probeBanner) - 1, 0);
+    }
+    close(fd);
+
+    if (count <= 0) {
+        if (result) *result = [NSString stringWithFormat:@"SSH banner missing: %s", strerror(saved)];
+        return NO;
+    }
+
+    NSString *text = [[NSString alloc] initWithBytes:banner length:(NSUInteger)count encoding:NSUTF8StringEncoding] ?: @"";
+    NSRange newline = [text rangeOfCharacterFromSet:NSCharacterSet.newlineCharacterSet];
+    NSString *line = newline.location == NSNotFound ? text : [text substringToIndex:newline.location];
+    BOOL healthy = [line hasPrefix:@"SSH-2.0-"] || [line hasPrefix:@"SSH-1.99-"];
+    if (result) *result = line.length ? line : @"empty SSH identification";
+    return healthy;
+}
+
+static void FilzaSSHScheduleProtocolHealth(NSString *reason)
+{
+    if (FilzaSSHHealthProbeScheduled) return;
+    if (![NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHEnabledKey] || !FilzaSSHServerIsRunning()) return;
+
+    FilzaSSHHealthProbeScheduled = YES;
+    NSInteger port = FilzaSSHConfiguredPort();
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.40 * NSEC_PER_SEC)),
+                   dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        NSString *probe = nil;
+        BOOL healthy = FilzaSSHProbeBanner(port, &probe);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            FilzaSSHHealthProbeScheduled = NO;
+            if (![NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHEnabledKey] || !FilzaSSHServerIsRunning()) return;
+
+            if (healthy) {
+                FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"protocol self-test passed reason=%@ port=%ld banner=%@",
+                                                reason ?: @"unknown", (long)port, probe ?: @"SSH-2.0"]);
+                return;
+            }
+
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"protocol self-test FAILED reason=%@ port=%ld result=%@; stopping listener",
+                                            reason ?: @"unknown", (long)port, probe ?: @"unknown"]);
+            [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+            FilzaSSHServerStop();
+        });
+    });
+}
+
+__attribute__((constructor)) static void FilzaSSHProtocolHealthInit(void)
+{
+    @autoreleasepool {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSNotificationCenter.defaultCenter addObserverForName:NSUserDefaultsDidChangeNotification
+                                                            object:NSUserDefaults.standardUserDefaults
+                                                             queue:NSOperationQueue.mainQueue
+                                                        usingBlock:^(__unused NSNotification *note) {
+                FilzaSSHScheduleProtocolHealth(@"preferences changed");
+            }];
+            [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidBecomeActiveNotification
+                                                            object:nil
+                                                             queue:NSOperationQueue.mainQueue
+                                                        usingBlock:^(__unused NSNotification *note) {
+                FilzaSSHScheduleProtocolHealth(@"application active");
+            }];
+            FilzaSSHScheduleProtocolHealth(@"runtime initialized");
+        });
+    }
+}

--- a/FilzaSSHProtocolHealth.m
+++ b/FilzaSSHProtocolHealth.m
@@ -60,31 +60,33 @@ static BOOL FilzaSSHProbeProtocol(NSInteger configuredPort, NSString **result)
     return healthy;
 }
 
-static void FilzaSSHScheduleProtocolHealth(NSString *reason)
+void FilzaSSHProtocolHealthSchedule(NSString *reason)
 {
-    if (FilzaSSHHealthProbeScheduled) return;
-    if (![NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHEnabledKey] || !FilzaSSHServerIsRunning()) return;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (FilzaSSHHealthProbeScheduled) return;
+        if (![NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHEnabledKey] || !FilzaSSHServerIsRunning()) return;
 
-    FilzaSSHHealthProbeScheduled = YES;
-    NSInteger port = FilzaSSHConfiguredPort();
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.40 * NSEC_PER_SEC)),
-                   dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
-        NSString *probe = nil;
-        BOOL healthy = FilzaSSHProbeProtocol(port, &probe);
-        dispatch_async(dispatch_get_main_queue(), ^{
-            FilzaSSHHealthProbeScheduled = NO;
-            if (![NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHEnabledKey] || !FilzaSSHServerIsRunning()) return;
+        FilzaSSHHealthProbeScheduled = YES;
+        NSInteger port = FilzaSSHConfiguredPort();
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.40 * NSEC_PER_SEC)),
+                       dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+            NSString *probe = nil;
+            BOOL healthy = FilzaSSHProbeProtocol(port, &probe);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                FilzaSSHHealthProbeScheduled = NO;
+                if (![NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHEnabledKey] || !FilzaSSHServerIsRunning()) return;
 
-            if (healthy) {
-                FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"protocol self-test passed reason=%@ port=%ld %@",
-                                                reason ?: @"unknown", (long)port, probe ?: @"SSH-2.0"]);
-                return;
-            }
+                if (healthy) {
+                    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"protocol self-test passed reason=%@ port=%ld %@",
+                                                    reason ?: @"unknown", (long)port, probe ?: @"SSH-2.0"]);
+                    return;
+                }
 
-            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"protocol self-test FAILED reason=%@ port=%ld result=%@; stopping listener",
-                                            reason ?: @"unknown", (long)port, probe ?: @"unknown"]);
-            [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
-            FilzaSSHServerStop();
+                FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"protocol self-test FAILED reason=%@ port=%ld result=%@; stopping listener",
+                                                reason ?: @"unknown", (long)port, probe ?: @"unknown"]);
+                [NSUserDefaults.standardUserDefaults setBool:NO forKey:FilzaSSHEnabledKey];
+                FilzaSSHServerStop();
+            });
         });
     });
 }
@@ -93,19 +95,13 @@ __attribute__((constructor)) static void FilzaSSHProtocolHealthInit(void)
 {
     @autoreleasepool {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [NSNotificationCenter.defaultCenter addObserverForName:NSUserDefaultsDidChangeNotification
-                                                            object:NSUserDefaults.standardUserDefaults
-                                                             queue:NSOperationQueue.mainQueue
-                                                        usingBlock:^(__unused NSNotification *note) {
-                FilzaSSHScheduleProtocolHealth(@"preferences changed");
-            }];
             [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidBecomeActiveNotification
                                                             object:nil
                                                              queue:NSOperationQueue.mainQueue
                                                         usingBlock:^(__unused NSNotification *note) {
-                FilzaSSHScheduleProtocolHealth(@"application active");
+                FilzaSSHProtocolHealthSchedule(@"application active");
             }];
-            FilzaSSHScheduleProtocolHealth(@"runtime initialized");
+            FilzaSSHProtocolHealthSchedule(@"runtime initialized");
         });
     }
 }

--- a/FilzaSSHProtocolHealth.m
+++ b/FilzaSSHProtocolHealth.m
@@ -95,13 +95,28 @@ __attribute__((constructor)) static void FilzaSSHProtocolHealthInit(void)
 {
     @autoreleasepool {
         dispatch_async(dispatch_get_main_queue(), ^{
+            // Fresh enable and settings-driven restarts mutate defaults after the
+            // verified listener has started; observe those transitions.
+            [NSNotificationCenter.defaultCenter addObserverForName:NSUserDefaultsDidChangeNotification
+                                                            object:NSUserDefaults.standardUserDefaults
+                                                             queue:NSOperationQueue.mainQueue
+                                                        usingBlock:^(__unused NSNotification *note) {
+                FilzaSSHProtocolHealthSchedule(@"preferences changed");
+            }];
             [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidBecomeActiveNotification
                                                             object:nil
                                                              queue:NSOperationQueue.mainQueue
                                                         usingBlock:^(__unused NSNotification *note) {
                 FilzaSSHProtocolHealthSchedule(@"application active");
             }];
+
             FilzaSSHProtocolHealthSchedule(@"runtime initialized");
+            // Saved enable state is restored by the preferences adapter shortly
+            // after startup, potentially after the first active notification.
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
+                           dispatch_get_main_queue(), ^{
+                FilzaSSHProtocolHealthSchedule(@"saved-state restore");
+            });
         });
     }
 }

--- a/FilzaSSHProtocolHealth.m
+++ b/FilzaSSHProtocolHealth.m
@@ -1,64 +1,62 @@
 @import Foundation;
 @import UIKit;
 
-#import <arpa/inet.h>
-#import <errno.h>
-#import <netinet/in.h>
-#import <sys/socket.h>
-#import <unistd.h>
+#define LIBSSH_STATIC 1
+#import <libssh/libssh.h>
 
 #import "FilzaDiagnostics.h"
 #import "FilzaSSHServer.h"
 
 static BOOL FilzaSSHHealthProbeScheduled = NO;
 
-static BOOL FilzaSSHProbeBanner(NSInteger port, NSString **result)
+// Use libssh as the loopback client instead of a raw banner socket. ssh_connect()
+// completes version exchange and key exchange but does not authenticate, so this
+// proves the embedded server is actually servicing the SSH protocol without
+// needing to retain or recover the user's password.
+static BOOL FilzaSSHProbeProtocol(NSInteger configuredPort, NSString **result)
 {
-    int fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) {
-        if (result) *result = [NSString stringWithFormat:@"socket() failed: %s", strerror(errno)];
+    ssh_session client = ssh_new();
+    if (!client) {
+        if (result) *result = @"ssh_new() failed";
         return NO;
     }
 
-    struct timeval timeout = {.tv_sec = 2, .tv_usec = 0};
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
-    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+    const char *host = "127.0.0.1";
+    unsigned int port = (unsigned int)configuredPort;
+    long timeout = 2;
+    int verbosity = SSH_LOG_NOLOG;
+    int optionsOK = SSH_OK;
+    if (ssh_options_set(client, SSH_OPTIONS_HOST, host) != SSH_OK) optionsOK = SSH_ERROR;
+    if (ssh_options_set(client, SSH_OPTIONS_PORT, &port) != SSH_OK) optionsOK = SSH_ERROR;
+    if (ssh_options_set(client, SSH_OPTIONS_TIMEOUT, &timeout) != SSH_OK) optionsOK = SSH_ERROR;
+    (void)ssh_options_set(client, SSH_OPTIONS_LOG_VERBOSITY, &verbosity);
 
-    struct sockaddr_in address = {0};
-    address.sin_len = sizeof(address);
-    address.sin_family = AF_INET;
-    address.sin_port = htons((uint16_t)port);
-    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-
-    if (connect(fd, (struct sockaddr *)&address, sizeof(address)) != 0) {
-        int saved = errno;
-        close(fd);
-        if (result) *result = [NSString stringWithFormat:@"loopback connect failed: %s", strerror(saved)];
+    if (optionsOK != SSH_OK) {
+        NSString *message = [NSString stringWithFormat:@"libssh client options failed: %s", ssh_get_error(client) ?: "unknown"];
+        if (result) *result = message;
+        ssh_free(client);
         return NO;
     }
 
-    char banner[512] = {0};
-    ssize_t count = recv(fd, banner, sizeof(banner) - 1, 0);
-    int saved = errno;
-    if (count > 0) {
-        banner[count] = '\0';
-        // Complete identification exchange so libssh can cleanly identify this
-        // as a health probe before we close without entering userauth.
-        const char probeBanner[] = "SSH-2.0-Filza27HealthProbe\r\n";
-        (void)send(fd, probeBanner, sizeof(probeBanner) - 1, 0);
-    }
-    close(fd);
+    int rc = ssh_connect(client);
+    const char *bannerCString = rc == SSH_OK ? ssh_get_serverbanner(client) : NULL;
+    const char *kexCString = rc == SSH_OK ? ssh_get_kex_algo(client) : NULL;
+    NSString *banner = bannerCString ? [NSString stringWithUTF8String:bannerCString] : nil;
+    NSString *kex = kexCString ? [NSString stringWithUTF8String:kexCString] : nil;
 
-    if (count <= 0) {
-        if (result) *result = [NSString stringWithFormat:@"SSH banner missing: %s", strerror(saved)];
-        return NO;
-    }
+    BOOL healthy = rc == SSH_OK &&
+        ([banner hasPrefix:@"SSH-2.0-"] || [banner hasPrefix:@"SSH-1.99-"]) &&
+        kex.length > 0;
 
-    NSString *text = [[NSString alloc] initWithBytes:banner length:(NSUInteger)count encoding:NSUTF8StringEncoding] ?: @"";
-    NSRange newline = [text rangeOfCharacterFromSet:NSCharacterSet.newlineCharacterSet];
-    NSString *line = newline.location == NSNotFound ? text : [text substringToIndex:newline.location];
-    BOOL healthy = [line hasPrefix:@"SSH-2.0-"] || [line hasPrefix:@"SSH-1.99-"];
-    if (result) *result = line.length ? line : @"empty SSH identification";
+    if (healthy) {
+        if (result) *result = [NSString stringWithFormat:@"%@ kex=%@", banner, kex];
+        ssh_disconnect(client);
+    } else {
+        if (result) *result = [NSString stringWithFormat:@"ssh_connect rc=%d error=%s banner=%@ kex=%@",
+                               rc, ssh_get_error(client) ?: "unknown", banner ?: @"none", kex ?: @"none"];
+        if (ssh_is_connected(client)) ssh_disconnect(client);
+    }
+    ssh_free(client);
     return healthy;
 }
 
@@ -72,13 +70,13 @@ static void FilzaSSHScheduleProtocolHealth(NSString *reason)
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.40 * NSEC_PER_SEC)),
                    dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
         NSString *probe = nil;
-        BOOL healthy = FilzaSSHProbeBanner(port, &probe);
+        BOOL healthy = FilzaSSHProbeProtocol(port, &probe);
         dispatch_async(dispatch_get_main_queue(), ^{
             FilzaSSHHealthProbeScheduled = NO;
             if (![NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHEnabledKey] || !FilzaSSHServerIsRunning()) return;
 
             if (healthy) {
-                FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"protocol self-test passed reason=%@ port=%ld banner=%@",
+                FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"protocol self-test passed reason=%@ port=%ld %@",
                                                 reason ?: @"unknown", (long)port, probe ?: @"SSH-2.0"]);
                 return;
             }

--- a/FilzaSSHServer.h
+++ b/FilzaSSHServer.h
@@ -24,5 +24,6 @@ FOUNDATION_EXPORT BOOL FilzaSSHServerIsRunning(void);
 FOUNDATION_EXPORT NSString * _Nullable FilzaSSHServerLastError(void);
 FOUNDATION_EXPORT NSString * _Nullable FilzaSSHServerLANAddress(void);
 FOUNDATION_EXPORT NSString *FilzaSSHServerConnectionSummary(void);
+FOUNDATION_EXPORT void FilzaSSHProtocolHealthSchedule(NSString *reason);
 
 NS_ASSUME_NONNULL_END

--- a/FilzaSSHServerV2.m
+++ b/FilzaSSHServerV2.m
@@ -1,0 +1,797 @@
+@import Foundation;
+@import Security;
+@import UIKit;
+
+#define LIBSSH_STATIC 1
+#import <libssh/callbacks.h>
+#import <libssh/libssh.h>
+#import <libssh/server.h>
+#import <libssh/sftp.h>
+#import <libssh/sftpserver.h>
+
+#import <CommonCrypto/CommonKeyDerivation.h>
+#import <CommonCrypto/CommonCryptoError.h>
+#import <arpa/inet.h>
+#import <errno.h>
+#import <fcntl.h>
+#import <ifaddrs.h>
+#import <net/if.h>
+#import <netinet/in.h>
+#import <objc/message.h>
+#import <stdatomic.h>
+#import <sys/socket.h>
+#import <sys/stat.h>
+#import <sys/utsname.h>
+#import <unistd.h>
+
+#import "FilzaDiagnostics.h"
+#import "FilzaSSHServer.h"
+
+NSString * const FilzaSSHEnabledKey = @"filza-ssh-enabled";
+NSString * const FilzaSSHPortKey = @"filza-ssh-port";
+NSString * const FilzaSSHBonjourKey = @"filza-ssh-bonjour";
+NSString * const FilzaSSHAuthenticationKey = @"filza-ssh-authentication";
+NSString * const FilzaSSHUsernameKey = @"filza-ssh-username";
+NSString * const FilzaSSHPasswordSaltKey = @"filza-ssh-password-salt";
+NSString * const FilzaSSHPasswordHashKey = @"filza-ssh-password-pbkdf2";
+
+static NSString * const FilzaSSHErrorDomain = @"FilzaSSH";
+static dispatch_queue_t FilzaSSHListenerQueue;
+static dispatch_queue_t FilzaSSHClientQueue;
+static dispatch_source_t FilzaSSHAcceptSource;
+static ssh_bind FilzaSSHBind = NULL;
+static NSNetService *FilzaSSHBonjourService;
+static _Atomic(bool) FilzaSSHRunning = false;
+static _Atomic(uint_fast64_t) FilzaSSHGeneration = 1;
+static dispatch_once_t FilzaSSHInitOnce;
+static const void *FilzaSSHQueueKey = &FilzaSSHQueueKey;
+static NSString *FilzaSSHFailure;
+
+@interface FilzaSSHClientContext : NSObject {
+@public
+    ssh_session session;
+    ssh_channel channel;
+    sftp_session sftp;
+    struct ssh_server_callbacks_struct serverCallbacks;
+    struct ssh_channel_callbacks_struct channelCallbacks;
+}
+@property(nonatomic) BOOL authenticated;
+@property(nonatomic) BOOL interactive;
+@property(nonatomic) BOOL shouldClose;
+@property(nonatomic) BOOL lastWasCR;
+@property(nonatomic) BOOL authenticationRequired;
+@property(nonatomic, copy) NSString *username;
+@property(nonatomic, copy) NSData *passwordSalt;
+@property(nonatomic, copy) NSData *passwordHash;
+@property(nonatomic, copy) NSString *currentDirectory;
+@property(nonatomic, strong) NSMutableData *lineBuffer;
+@end
+@implementation FilzaSSHClientContext @end
+
+static NSObject *FilzaSSHLock(void)
+{
+    static NSObject *lock;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ lock = NSObject.new; });
+    return lock;
+}
+
+static void FilzaSSHWriteStatus(NSString *message)
+{
+    NSString *path = [FilzaDiagnosticsDirectory() stringByAppendingPathComponent:@"SSHStatus.txt"];
+    NSString *timestamp = [NSISO8601DateFormatter.new stringFromDate:NSDate.date] ?: NSDate.date.description;
+    [[NSString stringWithFormat:@"%@\n%@\n", timestamp, message ?: @"unknown"]
+        writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
+}
+
+static void FilzaSSHSetFailure(NSString *message)
+{
+    @synchronized (FilzaSSHLock()) { FilzaSSHFailure = [message copy]; }
+    if (!message.length) return;
+    FilzaDiagnosticsAppend(@"SSH", message);
+    FilzaSSHWriteStatus(message);
+}
+
+static void FilzaSSHClearFailure(void)
+{
+    @synchronized (FilzaSSHLock()) { FilzaSSHFailure = nil; }
+}
+
+static void FilzaSSHInitialize(void)
+{
+    dispatch_once(&FilzaSSHInitOnce, ^{
+        [NSUserDefaults.standardUserDefaults registerDefaults:@{
+            FilzaSSHEnabledKey: @NO,
+            FilzaSSHPortKey: @2222,
+            FilzaSSHBonjourKey: @YES,
+            FilzaSSHAuthenticationKey: @YES,
+            FilzaSSHUsernameKey: @"filza"
+        }];
+        FilzaSSHListenerQueue = dispatch_queue_create("com.nightvibes33.filza.ssh.v2.listener", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_set_specific(FilzaSSHListenerQueue, FilzaSSHQueueKey, (void *)FilzaSSHQueueKey, NULL);
+        FilzaSSHClientQueue = dispatch_queue_create("com.nightvibes33.filza.ssh.v2.clients", DISPATCH_QUEUE_CONCURRENT);
+        int rc = ssh_init();
+        FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"libssh v2 initialized rc=%d version=%s SFTP=enabled", rc, ssh_version(0) ?: "unknown"]);
+    });
+}
+
+static void FilzaSSHSync(dispatch_block_t block)
+{
+    FilzaSSHInitialize();
+    if (dispatch_get_specific(FilzaSSHQueueKey)) block();
+    else dispatch_sync(FilzaSSHListenerQueue, block);
+}
+
+NSInteger FilzaSSHConfiguredPort(void)
+{
+    FilzaSSHInitialize();
+    NSInteger port = [NSUserDefaults.standardUserDefaults integerForKey:FilzaSSHPortKey];
+    return (port >= 1 && port <= 65535) ? port : 2222;
+}
+
+BOOL FilzaSSHBonjourEnabled(void)
+{
+    FilzaSSHInitialize();
+    return [NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHBonjourKey];
+}
+
+BOOL FilzaSSHAuthenticationEnabled(void)
+{
+    FilzaSSHInitialize();
+    return [NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHAuthenticationKey];
+}
+
+NSString *FilzaSSHConfiguredUsername(void)
+{
+    FilzaSSHInitialize();
+    NSString *name = [NSUserDefaults.standardUserDefaults stringForKey:FilzaSSHUsernameKey];
+    name = [name stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    return name.length ? name : @"filza";
+}
+
+static NSData *FilzaSSHDecodeDefault(NSString *key)
+{
+    NSString *text = [NSUserDefaults.standardUserDefaults stringForKey:key];
+    return text.length ? [[NSData alloc] initWithBase64EncodedString:text options:0] : nil;
+}
+
+static NSData *FilzaSSHDerivePassword(NSString *password, NSData *salt)
+{
+    if (!password || salt.length < 16) return nil;
+    NSMutableData *derived = [NSMutableData dataWithLength:32];
+    int rc = CCKeyDerivationPBKDF(kCCPBKDF2,
+                                  password.UTF8String,
+                                  [password lengthOfBytesUsingEncoding:NSUTF8StringEncoding],
+                                  salt.bytes,
+                                  salt.length,
+                                  kCCPRFHmacAlgSHA256,
+                                  120000,
+                                  derived.mutableBytes,
+                                  derived.length);
+    return rc == kCCSuccess ? derived : nil;
+}
+
+static BOOL FilzaSSHConstantTimeEqual(NSData *left, NSData *right)
+{
+    if (!left || !right || left.length != right.length) return NO;
+    const uint8_t *a = left.bytes, *b = right.bytes;
+    uint8_t difference = 0;
+    for (NSUInteger i = 0; i < left.length; i++) difference |= a[i] ^ b[i];
+    return difference == 0;
+}
+
+BOOL FilzaSSHPasswordConfigured(void)
+{
+    return FilzaSSHDecodeDefault(FilzaSSHPasswordSaltKey).length >= 16 &&
+           FilzaSSHDecodeDefault(FilzaSSHPasswordHashKey).length == 32;
+}
+
+BOOL FilzaSSHStorePassword(NSString *password, NSError **error)
+{
+    FilzaSSHInitialize();
+    if (password.length < 6) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:10 userInfo:@{NSLocalizedDescriptionKey: @"SSH password must contain at least 6 characters."}];
+        return NO;
+    }
+    uint8_t saltBytes[32];
+    if (SecRandomCopyBytes(kSecRandomDefault, sizeof(saltBytes), saltBytes) != errSecSuccess) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:11 userInfo:@{NSLocalizedDescriptionKey: @"Could not generate a secure password salt."}];
+        return NO;
+    }
+    NSData *salt = [NSData dataWithBytes:saltBytes length:sizeof(saltBytes)];
+    NSData *hash = FilzaSSHDerivePassword(password, salt);
+    if (!hash) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:12 userInfo:@{NSLocalizedDescriptionKey: @"Could not derive the SSH password verifier."}];
+        return NO;
+    }
+    [NSUserDefaults.standardUserDefaults setObject:[salt base64EncodedStringWithOptions:0] forKey:FilzaSSHPasswordSaltKey];
+    [NSUserDefaults.standardUserDefaults setObject:[hash base64EncodedStringWithOptions:0] forKey:FilzaSSHPasswordHashKey];
+    FilzaDiagnosticsAppend(@"SSH", @"password verifier updated using PBKDF2-HMAC-SHA256");
+    return YES;
+}
+
+static NSString *FilzaSSHHostKeyPath(NSError **error)
+{
+    NSString *root = [NSFileManager.defaultManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask].firstObject.path;
+    if (!root.length) root = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Application Support"];
+    NSString *directory = [root stringByAppendingPathComponent:@"FilzaSSH"];
+    NSError *mkdirError = nil;
+    if (![NSFileManager.defaultManager createDirectoryAtPath:directory
+                                 withIntermediateDirectories:YES
+                                                  attributes:@{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication}
+                                                       error:&mkdirError]) {
+        if (error) *error = mkdirError;
+        return nil;
+    }
+    NSString *path = [directory stringByAppendingPathComponent:@"ssh_host_ed25519_key"];
+    if ([NSFileManager.defaultManager fileExistsAtPath:path]) return path;
+
+    ssh_key key = NULL;
+    if (ssh_pki_generate(SSH_KEYTYPE_ED25519, 0, &key) != SSH_OK || !key) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:20 userInfo:@{NSLocalizedDescriptionKey: @"libssh could not generate an Ed25519 host key."}];
+        if (key) ssh_key_free(key);
+        return nil;
+    }
+    int rc = ssh_pki_export_privkey_file(key, NULL, NULL, NULL, path.fileSystemRepresentation);
+    ssh_key_free(key);
+    if (rc != SSH_OK) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:21 userInfo:@{NSLocalizedDescriptionKey: @"libssh could not save the Ed25519 host key."}];
+        return nil;
+    }
+    chmod(path.fileSystemRepresentation, S_IRUSR | S_IWUSR);
+    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"generated persistent Ed25519 host key at %@", path]);
+    return path;
+}
+
+NSString *FilzaSSHServerLANAddress(void)
+{
+    struct ifaddrs *list = NULL;
+    if (getifaddrs(&list) != 0 || !list) return nil;
+    NSString *fallback = nil, *preferred = nil;
+    for (struct ifaddrs *cursor = list; cursor; cursor = cursor->ifa_next) {
+        if (!cursor->ifa_addr || cursor->ifa_addr->sa_family != AF_INET) continue;
+        if (!(cursor->ifa_flags & IFF_UP) || (cursor->ifa_flags & IFF_LOOPBACK)) continue;
+        char buffer[INET_ADDRSTRLEN] = {0};
+        struct sockaddr_in *address = (struct sockaddr_in *)cursor->ifa_addr;
+        if (!inet_ntop(AF_INET, &address->sin_addr, buffer, sizeof(buffer))) continue;
+        NSString *value = [NSString stringWithUTF8String:buffer];
+        if (!fallback) fallback = value;
+        if (cursor->ifa_name && strcmp(cursor->ifa_name, "en0") == 0) { preferred = value; break; }
+    }
+    freeifaddrs(list);
+    return preferred ?: fallback;
+}
+
+static NSString *FilzaSSHInitialDirectory(void)
+{
+    Class cls = NSClassFromString(@"TGPreferences");
+    SEL shared = NSSelectorFromString(@"sharedInstance");
+    id prefs = (cls && [cls respondsToSelector:shared]) ? ((id (*)(id, SEL))objc_msgSend)(cls, shared) : nil;
+    SEL uploader = NSSelectorFromString(@"uploaderPath");
+    NSString *candidate = (prefs && [prefs respondsToSelector:uploader]) ? ((id (*)(id, SEL))objc_msgSend)(prefs, uploader) : nil;
+    BOOL directory = NO;
+    if ([candidate isKindOfClass:NSString.class] && [NSFileManager.defaultManager fileExistsAtPath:candidate isDirectory:&directory] && directory)
+        return candidate;
+    NSString *documents = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+    return documents.length ? documents : NSHomeDirectory();
+}
+
+static NSArray<NSString *> *FilzaSSHTokens(NSString *command)
+{
+    NSMutableArray<NSString *> *tokens = NSMutableArray.array;
+    NSMutableString *current = NSMutableString.string;
+    unichar quote = 0;
+    BOOL escape = NO;
+    for (NSUInteger i = 0; i < command.length; i++) {
+        unichar ch = [command characterAtIndex:i];
+        if (escape) { [current appendFormat:@"%C", ch]; escape = NO; continue; }
+        if (ch == '\\') { escape = YES; continue; }
+        if (quote) {
+            if (ch == quote) quote = 0; else [current appendFormat:@"%C", ch];
+            continue;
+        }
+        if (ch == '\'' || ch == '"') { quote = ch; continue; }
+        if ([NSCharacterSet.whitespaceAndNewlineCharacterSet characterIsMember:ch]) {
+            if (current.length) { [tokens addObject:current.copy]; [current setString:@""]; }
+        } else [current appendFormat:@"%C", ch];
+    }
+    if (current.length) [tokens addObject:current.copy];
+    return tokens;
+}
+
+static NSString *FilzaSSHResolve(NSString *operand, NSString *cwd)
+{
+    if (!operand.length || [operand isEqualToString:@"."]) return cwd;
+    if ([operand isEqualToString:@"~"]) return FilzaSSHInitialDirectory();
+    if ([operand hasPrefix:@"~/"]) return [[FilzaSSHInitialDirectory() stringByAppendingPathComponent:[operand substringFromIndex:2]] stringByStandardizingPath];
+    if ([operand hasPrefix:@"/"]) return operand.stringByStandardizingPath;
+    return [[cwd stringByAppendingPathComponent:operand] stringByStandardizingPath];
+}
+
+static NSString *FilzaSSHMode(mode_t mode)
+{
+    char text[11] = "----------";
+    text[0] = S_ISDIR(mode) ? 'd' : S_ISLNK(mode) ? 'l' : '-';
+    const mode_t bits[] = {S_IRUSR,S_IWUSR,S_IXUSR,S_IRGRP,S_IWGRP,S_IXGRP,S_IROTH,S_IWOTH,S_IXOTH};
+    const char chars[] = {'r','w','x','r','w','x','r','w','x'};
+    for (int i = 0; i < 9; i++) if (mode & bits[i]) text[i + 1] = chars[i];
+    return [NSString stringWithUTF8String:text];
+}
+
+static NSString *FilzaSSHExecute(NSString *command, FilzaSSHClientContext *context, int *status, BOOL *closeSession)
+{
+    NSArray<NSString *> *args = FilzaSSHTokens(command ?: @"");
+    if (!args.count) { if (status) *status = 0; return @""; }
+    NSString *name = args[0];
+    NSString *cwd = context.currentDirectory ?: FilzaSSHInitialDirectory();
+    NSFileManager *fm = NSFileManager.defaultManager;
+    if (status) *status = 0;
+
+    if ([name isEqualToString:@"help"]) return @"Commands: pwd cd ls cat stat mkdir touch cp mv rm chmod readlink df whoami id uname echo clear help exit\nSFTP is supported. Filesystem access equals the Filza process; this is not a root shell.\n";
+    if ([name isEqualToString:@"exit"] || [name isEqualToString:@"logout"]) { if (closeSession) *closeSession = YES; return @"logout\n"; }
+    if ([name isEqualToString:@"clear"]) return @"\033[2J\033[H";
+    if ([name isEqualToString:@"pwd"]) return [cwd stringByAppendingString:@"\n"];
+    if ([name isEqualToString:@"whoami"]) return [FilzaSSHConfiguredUsername() stringByAppendingString:@"\n"];
+    if ([name isEqualToString:@"id"]) return [NSString stringWithFormat:@"uid=%u gid=%u euid=%u egid=%u\n", getuid(), getgid(), geteuid(), getegid()];
+    if ([name isEqualToString:@"echo"]) return [NSString stringWithFormat:@"%@\n", args.count > 1 ? [[args subarrayWithRange:NSMakeRange(1, args.count - 1)] componentsJoinedByString:@" "] : @""];
+    if ([name isEqualToString:@"uname"]) {
+        struct utsname info = {0};
+        if (uname(&info) != 0) { if (status) *status = 1; return [NSString stringWithFormat:@"uname: %s\n", strerror(errno)]; }
+        return [NSString stringWithFormat:@"%s %s %s %s %s\n", info.sysname, info.nodename, info.release, info.version, info.machine];
+    }
+    if ([name isEqualToString:@"cd"]) {
+        NSString *path = FilzaSSHResolve(args.count > 1 ? args[1] : @"~", cwd); BOOL isDir = NO;
+        if (![fm fileExistsAtPath:path isDirectory:&isDir] || !isDir) { if (status) *status = 1; return [NSString stringWithFormat:@"cd: %@: not a directory or inaccessible\n", path]; }
+        context.currentDirectory = path; return @"";
+    }
+    if ([name isEqualToString:@"ls"]) {
+        BOOL longForm = [args containsObject:@"-l"] || [args containsObject:@"-la"] || [args containsObject:@"-al"];
+        BOOL hidden = [args containsObject:@"-a"] || [args containsObject:@"-la"] || [args containsObject:@"-al"];
+        NSString *operand = nil;
+        for (NSUInteger i = 1; i < args.count; i++) if (![args[i] hasPrefix:@"-"]) { operand = args[i]; break; }
+        NSString *path = FilzaSSHResolve(operand ?: @".", cwd); BOOL isDir = NO;
+        if (![fm fileExistsAtPath:path isDirectory:&isDir]) { if (status) *status = 1; return [NSString stringWithFormat:@"ls: %@: no such file or inaccessible\n", path]; }
+        NSArray<NSString *> *items = isDir ? [fm contentsOfDirectoryAtPath:path error:nil] : @[path.lastPathComponent];
+        items = [items sortedArrayUsingSelector:@selector(localizedStandardCompare:)];
+        NSMutableString *out = NSMutableString.string;
+        for (NSString *item in items) {
+            if (!hidden && [item hasPrefix:@"."]) continue;
+            NSString *full = isDir ? [path stringByAppendingPathComponent:item] : path;
+            if (!longForm) { [out appendFormat:@"%@\n", item]; continue; }
+            struct stat st = {0};
+            if (lstat(full.fileSystemRepresentation, &st) == 0) [out appendFormat:@"%@ %4u %4u %10lld %@\n", FilzaSSHMode(st.st_mode), st.st_uid, st.st_gid, (long long)st.st_size, item];
+            else [out appendFormat:@"%@\n", item];
+        }
+        return out;
+    }
+    if ([name isEqualToString:@"cat"]) {
+        if (args.count < 2) { if (status) *status = 2; return @"cat: missing file operand\n"; }
+        NSString *path = FilzaSSHResolve(args[1], cwd); NSError *error = nil;
+        NSDictionary *attributes = [fm attributesOfItemAtPath:path error:&error];
+        if (!attributes) { if (status) *status = 1; return [NSString stringWithFormat:@"cat: %@: %@\n", path, error.localizedDescription]; }
+        if ([attributes[NSFileSize] unsignedLongLongValue] > 16ULL * 1024ULL * 1024ULL) { if (status) *status = 1; return @"cat: file exceeds the 16 MiB interactive-output limit\n"; }
+        NSData *data = [NSData dataWithContentsOfFile:path options:NSDataReadingMappedIfSafe error:&error];
+        if (!data) { if (status) *status = 1; return [NSString stringWithFormat:@"cat: %@: %@\n", path, error.localizedDescription]; }
+        NSString *text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        return text ?: @"cat: binary/non-UTF8 data is not printed by the embedded shell\n";
+    }
+    if ([name isEqualToString:@"stat"]) {
+        if (args.count < 2) { if (status) *status = 2; return @"stat: missing operand\n"; }
+        NSString *path = FilzaSSHResolve(args[1], cwd); struct stat st = {0};
+        if (lstat(path.fileSystemRepresentation, &st) != 0) { if (status) *status = 1; return [NSString stringWithFormat:@"stat: %@: %s\n", path, strerror(errno)]; }
+        return [NSString stringWithFormat:@"File: %@\nSize: %lld\tMode: %04o\tUid: %u\tGid: %u\n", path, (long long)st.st_size, st.st_mode & 07777, st.st_uid, st.st_gid];
+    }
+    if ([name isEqualToString:@"mkdir"]) {
+        BOOL parents = [args containsObject:@"-p"]; NSString *operand = args.lastObject;
+        if (args.count < 2 || [operand hasPrefix:@"-"]) { if (status) *status = 2; return @"mkdir: missing operand\n"; }
+        NSString *path = FilzaSSHResolve(operand, cwd); NSError *error = nil;
+        if (![fm createDirectoryAtPath:path withIntermediateDirectories:parents attributes:nil error:&error]) { if (status) *status = 1; return [NSString stringWithFormat:@"mkdir: %@: %@\n", path, error.localizedDescription]; }
+        return @"";
+    }
+    if ([name isEqualToString:@"touch"]) {
+        if (args.count < 2) { if (status) *status = 2; return @"touch: missing operand\n"; }
+        NSString *path = FilzaSSHResolve(args[1], cwd); int fd = open(path.fileSystemRepresentation, O_WRONLY | O_CREAT, 0644);
+        if (fd < 0) { if (status) *status = 1; return [NSString stringWithFormat:@"touch: %@: %s\n", path, strerror(errno)]; }
+        close(fd); [fm setAttributes:@{NSFileModificationDate: NSDate.date} ofItemAtPath:path error:nil]; return @"";
+    }
+    if ([name isEqualToString:@"cp"] || [name isEqualToString:@"mv"]) {
+        if (args.count < 3) { if (status) *status = 2; return [NSString stringWithFormat:@"%@: missing source/destination\n", name]; }
+        NSString *source = FilzaSSHResolve(args[1], cwd), *dest = FilzaSSHResolve(args[2], cwd); NSError *error = nil;
+        BOOL ok = [name isEqualToString:@"cp"] ? [fm copyItemAtPath:source toPath:dest error:&error] : [fm moveItemAtPath:source toPath:dest error:&error];
+        if (!ok) { if (status) *status = 1; return [NSString stringWithFormat:@"%@: %@ -> %@: %@\n", name, source, dest, error.localizedDescription]; }
+        return @"";
+    }
+    if ([name isEqualToString:@"rm"]) {
+        BOOL recursive = [args containsObject:@"-r"] || [args containsObject:@"-rf"] || [args containsObject:@"-fr"];
+        NSString *operand = nil; for (NSUInteger i = 1; i < args.count; i++) if (![args[i] hasPrefix:@"-"]) { operand = args[i]; break; }
+        if (!operand) { if (status) *status = 2; return @"rm: missing operand\n"; }
+        NSString *path = FilzaSSHResolve(operand, cwd); BOOL isDir = NO;
+        if (![fm fileExistsAtPath:path isDirectory:&isDir]) { if (status) *status = 1; return [NSString stringWithFormat:@"rm: %@: no such file or inaccessible\n", path]; }
+        if (isDir && !recursive) { if (status) *status = 1; return @"rm: directory requires -r\n"; }
+        NSError *error = nil; if (![fm removeItemAtPath:path error:&error]) { if (status) *status = 1; return [NSString stringWithFormat:@"rm: %@: %@\n", path, error.localizedDescription]; }
+        return @"";
+    }
+    if ([name isEqualToString:@"chmod"]) {
+        if (args.count < 3) { if (status) *status = 2; return @"chmod: usage chmod OCTAL PATH\n"; }
+        char *end = NULL; long mode = strtol(args[1].UTF8String, &end, 8); NSString *path = FilzaSSHResolve(args[2], cwd);
+        if (!end || *end || mode < 0 || mode > 07777) { if (status) *status = 2; return @"chmod: invalid octal mode\n"; }
+        if (chmod(path.fileSystemRepresentation, (mode_t)mode) != 0) { if (status) *status = 1; return [NSString stringWithFormat:@"chmod: %@: %s\n", path, strerror(errno)]; }
+        return @"";
+    }
+    if ([name isEqualToString:@"readlink"]) {
+        if (args.count < 2) { if (status) *status = 2; return @"readlink: missing operand\n"; }
+        NSString *path = FilzaSSHResolve(args[1], cwd); char target[PATH_MAX] = {0}; ssize_t count = readlink(path.fileSystemRepresentation, target, sizeof(target) - 1);
+        if (count < 0) { if (status) *status = 1; return [NSString stringWithFormat:@"readlink: %@: %s\n", path, strerror(errno)]; }
+        target[count] = '\0';
+        return [NSString stringWithFormat:@"%s\n", target];
+    }
+    if ([name isEqualToString:@"df"]) {
+        NSString *path = FilzaSSHResolve(args.count > 1 ? args[1] : @".", cwd); NSError *error = nil;
+        NSDictionary *fs = [fm attributesOfFileSystemForPath:path error:&error];
+        if (!fs) { if (status) *status = 1; return [NSString stringWithFormat:@"df: %@: %@\n", path, error.localizedDescription]; }
+        unsigned long long total = [fs[NSFileSystemSize] unsignedLongLongValue], freeSpace = [fs[NSFileSystemFreeSize] unsignedLongLongValue];
+        return [NSString stringWithFormat:@"Filesystem\tSize\tUsed\tAvail\n%@\t%llu\t%llu\t%llu\n", path, total, total - freeSpace, freeSpace];
+    }
+    if (status) *status = 127;
+    return [NSString stringWithFormat:@"%@: command not found (type help)\n", name];
+}
+
+static void FilzaSSHWrite(ssh_channel channel, NSString *text)
+{
+    if (!channel || !text.length || !ssh_channel_is_open(channel)) return;
+    NSData *data = [text dataUsingEncoding:NSUTF8StringEncoding];
+    const uint8_t *bytes = data.bytes; NSUInteger offset = 0;
+    while (offset < data.length && ssh_channel_is_open(channel)) {
+        uint32_t amount = (uint32_t)MIN((NSUInteger)32768, data.length - offset);
+        int written = ssh_channel_write(channel, bytes + offset, amount);
+        if (written <= 0) break;
+        offset += (NSUInteger)written;
+    }
+}
+
+static NSString *FilzaSSHPrompt(FilzaSSHClientContext *context)
+{
+    return [NSString stringWithFormat:@"filza:%@$ ", context.currentDirectory ?: @"?"];
+}
+
+static int FilzaSSHAuthNone(ssh_session session, const char *user, void *userdata)
+{
+    FilzaSSHClientContext *context = (__bridge FilzaSSHClientContext *)userdata;
+    if (!context.authenticationRequired) { context.authenticated = YES; return SSH_AUTH_SUCCESS; }
+    ssh_set_auth_methods(session, SSH_AUTH_METHOD_PASSWORD);
+    return SSH_AUTH_DENIED;
+}
+
+static int FilzaSSHAuthPassword(__unused ssh_session session, const char *user, const char *password, void *userdata)
+{
+    FilzaSSHClientContext *context = (__bridge FilzaSSHClientContext *)userdata;
+    NSString *suppliedUser = user ? [NSString stringWithUTF8String:user] : @"";
+    NSString *suppliedPassword = password ? [NSString stringWithUTF8String:password] : @"";
+    NSData *derived = FilzaSSHDerivePassword(suppliedPassword, context.passwordSalt);
+    BOOL accepted = [suppliedUser isEqualToString:context.username] && FilzaSSHConstantTimeEqual(derived, context.passwordHash);
+    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"password authentication user=%@ result=%@", suppliedUser, accepted ? @"accepted" : @"denied"]);
+    if (accepted) { context.authenticated = YES; return SSH_AUTH_SUCCESS; }
+    return SSH_AUTH_DENIED;
+}
+
+static int FilzaSSHPty(__unused ssh_session session, __unused ssh_channel channel, __unused const char *term,
+                       __unused int width, __unused int height, __unused int pxwidth, __unused int pxheight, __unused void *userdata)
+{ return 0; }
+
+static int FilzaSSHShell(__unused ssh_session session, ssh_channel channel, void *userdata)
+{
+    FilzaSSHClientContext *context = (__bridge FilzaSSHClientContext *)userdata;
+    if (!context.authenticated || context->sftp) return 1;
+    context.interactive = YES;
+    FilzaDiagnosticsAppend(@"SSH", @"interactive embedded Filza shell opened");
+    FilzaSSHWrite(channel, [NSString stringWithFormat:@"Filza embedded SSH shell (%s)\r\nSFTP enabled. Not a root shell; access equals the Filza process. Type help.\r\n%@", ssh_version(0) ?: "libssh", FilzaSSHPrompt(context)]);
+    return 0;
+}
+
+static int FilzaSSHExec(__unused ssh_session session, ssh_channel channel, const char *command, void *userdata)
+{
+    FilzaSSHClientContext *context = (__bridge FilzaSSHClientContext *)userdata;
+    if (!context.authenticated || !command || context->sftp) return 1;
+    int status = 0; BOOL closeSession = NO;
+    NSString *text = [NSString stringWithUTF8String:command] ?: @"";
+    FilzaSSHWrite(channel, FilzaSSHExecute(text, context, &status, &closeSession));
+    ssh_channel_request_send_exit_status(channel, status);
+    ssh_channel_send_eof(channel);
+    context.shouldClose = YES;
+    return 0;
+}
+
+static int FilzaSSHSubsystem(ssh_session session, ssh_channel channel, const char *subsystem, void *userdata)
+{
+    FilzaSSHClientContext *context = (__bridge FilzaSSHClientContext *)userdata;
+    if (!context.authenticated || !subsystem || strcmp(subsystem, "sftp") != 0 || context->sftp) {
+        FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"subsystem rejected: %s", subsystem ?: "unknown"]);
+        return 1;
+    }
+
+    int rc = sftp_channel_default_subsystem_request(session, channel, subsystem, &context->sftp);
+    if (rc == SSH_OK && context->sftp) {
+        context.interactive = NO;
+        FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"SFTP subsystem opened root-context=%@", FilzaSSHInitialDirectory()]);
+        return 0;
+    }
+    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"SFTP subsystem initialization failed rc=%d error=%s", rc, ssh_get_error(session) ?: "unknown"]);
+    context->sftp = NULL;
+    return 1;
+}
+
+static void FilzaSSHProcessInteractiveLine(FilzaSSHClientContext *context, ssh_channel channel)
+{
+    NSString *command = [[NSString alloc] initWithData:context.lineBuffer encoding:NSUTF8StringEncoding] ?: @"";
+    [context.lineBuffer setLength:0];
+    int status = 0; BOOL closeSession = NO;
+    NSString *output = FilzaSSHExecute(command, context, &status, &closeSession);
+    FilzaSSHWrite(channel, [[output stringByReplacingOccurrencesOfString:@"\r\n" withString:@"\n"] stringByReplacingOccurrencesOfString:@"\n" withString:@"\r\n"]);
+    if (closeSession) {
+        ssh_channel_request_send_exit_status(channel, status);
+        ssh_channel_send_eof(channel);
+        context.shouldClose = YES;
+    } else FilzaSSHWrite(channel, FilzaSSHPrompt(context));
+}
+
+static int FilzaSSHChannelData(ssh_session session, ssh_channel channel, void *data, uint32_t length, int isStderr, void *userdata)
+{
+    FilzaSSHClientContext *context = (__bridge FilzaSSHClientContext *)userdata;
+    if (context->sftp) {
+        return sftp_channel_default_data_callback(session, channel, data, length, isStderr, &context->sftp);
+    }
+    if (!context.interactive || isStderr || !data) return (int)length;
+    const uint8_t *bytes = data;
+    for (uint32_t i = 0; i < length; i++) {
+        uint8_t byte = bytes[i];
+        if (byte == 3) { [context.lineBuffer setLength:0]; FilzaSSHWrite(channel, @"^C\r\n"); FilzaSSHWrite(channel, FilzaSSHPrompt(context)); context.lastWasCR = NO; continue; }
+        if (byte == 8 || byte == 127) { if (context.lineBuffer.length) { [context.lineBuffer setLength:context.lineBuffer.length - 1]; FilzaSSHWrite(channel, @"\b \b"); } context.lastWasCR = NO; continue; }
+        if (byte == '\r') { FilzaSSHWrite(channel, @"\r\n"); FilzaSSHProcessInteractiveLine(context, channel); context.lastWasCR = YES; continue; }
+        if (byte == '\n') { if (context.lastWasCR) { context.lastWasCR = NO; continue; } FilzaSSHWrite(channel, @"\r\n"); FilzaSSHProcessInteractiveLine(context, channel); continue; }
+        context.lastWasCR = NO;
+        [context.lineBuffer appendBytes:&byte length:1];
+        FilzaSSHWrite(channel, [[NSString alloc] initWithBytes:&byte length:1 encoding:NSUTF8StringEncoding] ?: @"");
+    }
+    return (int)length;
+}
+
+static void FilzaSSHChannelClose(__unused ssh_session session, __unused ssh_channel channel, void *userdata)
+{
+    ((__bridge FilzaSSHClientContext *)userdata).shouldClose = YES;
+}
+
+static ssh_channel FilzaSSHOpenSessionChannel(ssh_session session, void *userdata)
+{
+    FilzaSSHClientContext *context = (__bridge FilzaSSHClientContext *)userdata;
+    if (!context.authenticated || context->channel) return NULL;
+    ssh_channel channel = ssh_channel_new(session);
+    if (!channel) return NULL;
+    context->channel = channel;
+    memset(&context->channelCallbacks, 0, sizeof(context->channelCallbacks));
+    context->channelCallbacks.userdata = (__bridge void *)context;
+    context->channelCallbacks.channel_data_function = FilzaSSHChannelData;
+    context->channelCallbacks.channel_close_function = FilzaSSHChannelClose;
+    context->channelCallbacks.channel_pty_request_function = FilzaSSHPty;
+    context->channelCallbacks.channel_shell_request_function = FilzaSSHShell;
+    context->channelCallbacks.channel_exec_request_function = FilzaSSHExec;
+    context->channelCallbacks.channel_subsystem_request_function = FilzaSSHSubsystem;
+    ssh_callbacks_init(&context->channelCallbacks);
+    if (ssh_set_channel_callbacks(channel, &context->channelCallbacks) != SSH_OK) {
+        ssh_channel_free(channel);
+        context->channel = NULL;
+        return NULL;
+    }
+    return channel;
+}
+
+static void FilzaSSHServeSession(ssh_session session, uint64_t generation)
+{
+    @autoreleasepool {
+        FilzaSSHClientContext *context = FilzaSSHClientContext.new;
+        context->session = session;
+        context->sftp = NULL;
+        context.currentDirectory = FilzaSSHInitialDirectory();
+        context.lineBuffer = NSMutableData.data;
+        context.username = FilzaSSHConfiguredUsername();
+        context.authenticationRequired = FilzaSSHAuthenticationEnabled();
+        context.passwordSalt = FilzaSSHDecodeDefault(FilzaSSHPasswordSaltKey);
+        context.passwordHash = FilzaSSHDecodeDefault(FilzaSSHPasswordHashKey);
+
+        memset(&context->serverCallbacks, 0, sizeof(context->serverCallbacks));
+        context->serverCallbacks.userdata = (__bridge void *)context;
+        context->serverCallbacks.auth_none_function = FilzaSSHAuthNone;
+        context->serverCallbacks.auth_password_function = FilzaSSHAuthPassword;
+        context->serverCallbacks.channel_open_request_session_function = FilzaSSHOpenSessionChannel;
+        ssh_callbacks_init(&context->serverCallbacks);
+        if (ssh_set_server_callbacks(session, &context->serverCallbacks) != SSH_OK) {
+            FilzaDiagnosticsAppend(@"SSH", @"could not install libssh server callbacks");
+            ssh_disconnect(session); ssh_free(session); return;
+        }
+        if (context.authenticationRequired) ssh_set_auth_methods(session, SSH_AUTH_METHOD_PASSWORD);
+
+        if (ssh_handle_key_exchange(session) != SSH_OK) {
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"key exchange failed: %s", ssh_get_error(session) ?: "unknown"]);
+            ssh_disconnect(session); ssh_free(session); return;
+        }
+
+        ssh_event event = ssh_event_new();
+        if (!event || ssh_event_add_session(event, session) != SSH_OK) {
+            FilzaDiagnosticsAppend(@"SSH", @"could not create libssh session event loop");
+            if (event) ssh_event_free(event);
+            ssh_disconnect(session); ssh_free(session); return;
+        }
+
+        FilzaDiagnosticsAppend(@"SSH", @"incoming SSH connection entered event loop");
+        while (atomic_load(&FilzaSSHRunning) && atomic_load(&FilzaSSHGeneration) == generation &&
+               ssh_is_connected(session) && !context.shouldClose) {
+            int rc = ssh_event_dopoll(event, 250);
+            if (rc == SSH_ERROR) {
+                FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"session event loop failed: %s", ssh_get_error(session) ?: "unknown"]);
+                break;
+            }
+        }
+
+        if (context->sftp) {
+            sftp_server_free(context->sftp);
+            context->sftp = NULL;
+        }
+        if (context->channel) {
+            if (ssh_channel_is_open(context->channel)) ssh_channel_close(context->channel);
+            ssh_channel_free(context->channel);
+            context->channel = NULL;
+        }
+        ssh_event_remove_session(event, session);
+        ssh_event_free(event);
+        ssh_disconnect(session);
+        ssh_free(session);
+        FilzaDiagnosticsAppend(@"SSH", @"SSH client session closed");
+    }
+}
+
+static void FilzaSSHAcceptAvailable(void)
+{
+    if (!atomic_load(&FilzaSSHRunning) || !FilzaSSHBind) return;
+    ssh_session session = ssh_new();
+    if (!session) return;
+    int rc = ssh_bind_accept(FilzaSSHBind, session);
+    if (rc != SSH_OK) {
+        FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"accept failed: %s", ssh_get_error(FilzaSSHBind) ?: "unknown"]);
+        ssh_free(session);
+        return;
+    }
+    uint64_t generation = atomic_load(&FilzaSSHGeneration);
+    dispatch_async(FilzaSSHClientQueue, ^{ FilzaSSHServeSession(session, generation); });
+}
+
+static BOOL FilzaSSHVerifyListener(socket_t fd, int expectedPort, NSString **failure)
+{
+    int accepting = 0;
+    socklen_t optionLength = sizeof(accepting);
+    if (getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &accepting, &optionLength) != 0 || accepting != 1) {
+        if (failure) *failure = [NSString stringWithFormat:@"listener socket is not accepting connections: %s", strerror(errno)];
+        return NO;
+    }
+
+    struct sockaddr_storage storage = {0};
+    socklen_t length = sizeof(storage);
+    if (getsockname(fd, (struct sockaddr *)&storage, &length) != 0) {
+        if (failure) *failure = [NSString stringWithFormat:@"could not inspect listener address: %s", strerror(errno)];
+        return NO;
+    }
+    int actualPort = 0;
+    if (storage.ss_family == AF_INET) actualPort = ntohs(((struct sockaddr_in *)&storage)->sin_port);
+    else if (storage.ss_family == AF_INET6) actualPort = ntohs(((struct sockaddr_in6 *)&storage)->sin6_port);
+    if (actualPort != expectedPort) {
+        if (failure) *failure = [NSString stringWithFormat:@"listener bound unexpected port %d (wanted %d)", actualPort, expectedPort];
+        return NO;
+    }
+    return YES;
+}
+
+static void FilzaSSHStopLocked(void)
+{
+    atomic_store(&FilzaSSHRunning, false);
+    atomic_fetch_add(&FilzaSSHGeneration, 1);
+    if (FilzaSSHBonjourService) { [FilzaSSHBonjourService stop]; FilzaSSHBonjourService = nil; }
+    if (FilzaSSHAcceptSource) { dispatch_source_cancel(FilzaSSHAcceptSource); FilzaSSHAcceptSource = nil; }
+    if (FilzaSSHBind) { ssh_bind_free(FilzaSSHBind); FilzaSSHBind = NULL; }
+    FilzaDiagnosticsAppend(@"SSH", @"embedded SSH/SFTP listener stopped");
+}
+
+BOOL FilzaSSHServerStart(NSError **error)
+{
+    __block BOOL success = NO;
+    __block NSError *failure = nil;
+    FilzaSSHSync(^{
+        if (atomic_load(&FilzaSSHRunning)) { success = YES; return; }
+        if (FilzaSSHAuthenticationEnabled() && !FilzaSSHPasswordConfigured()) {
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:30 userInfo:@{NSLocalizedDescriptionKey: @"Authentication is enabled but no SSH password is configured."}];
+            FilzaSSHSetFailure(failure.localizedDescription); return;
+        }
+
+        NSError *keyError = nil;
+        NSString *hostKey = FilzaSSHHostKeyPath(&keyError);
+        if (!hostKey.length) { failure = keyError; FilzaSSHSetFailure(failure.localizedDescription); return; }
+
+        ssh_bind bind = ssh_bind_new();
+        if (!bind) {
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:31 userInfo:@{NSLocalizedDescriptionKey: @"libssh could not allocate a server bind."}];
+            FilzaSSHSetFailure(failure.localizedDescription); return;
+        }
+        int port = (int)FilzaSSHConfiguredPort();
+        const char *address = "0.0.0.0";
+        const char *keyPath = hostKey.fileSystemRepresentation;
+        if (ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDADDR, address) != SSH_OK ||
+            ssh_bind_options_set(bind, SSH_BIND_OPTIONS_BINDPORT, &port) != SSH_OK ||
+            ssh_bind_options_set(bind, SSH_BIND_OPTIONS_HOSTKEY, keyPath) != SSH_OK ||
+            ssh_bind_listen(bind) != SSH_OK) {
+            NSString *message = [NSString stringWithFormat:@"libssh failed to listen on port %d: %s", port, ssh_get_error(bind) ?: "unknown error"];
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:32 userInfo:@{NSLocalizedDescriptionKey: message}];
+            ssh_bind_free(bind); FilzaSSHSetFailure(message); return;
+        }
+
+        socket_t fd = ssh_bind_get_fd(bind);
+        NSString *listenerFailure = nil;
+        if (fd < 0 || !FilzaSSHVerifyListener(fd, port, &listenerFailure)) {
+            NSString *message = listenerFailure ?: @"libssh listener has no usable socket.";
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:33 userInfo:@{NSLocalizedDescriptionKey: message}];
+            ssh_bind_free(bind); FilzaSSHSetFailure(message); return;
+        }
+
+        FilzaSSHBind = bind;
+        atomic_store(&FilzaSSHRunning, true);
+        FilzaSSHAcceptSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)fd, 0, FilzaSSHListenerQueue);
+        if (!FilzaSSHAcceptSource) {
+            atomic_store(&FilzaSSHRunning, false);
+            ssh_bind_free(bind); FilzaSSHBind = NULL;
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:34 userInfo:@{NSLocalizedDescriptionKey: @"Could not create SSH listener dispatch source."}];
+            FilzaSSHSetFailure(failure.localizedDescription); return;
+        }
+        dispatch_source_set_event_handler(FilzaSSHAcceptSource, ^{ FilzaSSHAcceptAvailable(); });
+        dispatch_resume(FilzaSSHAcceptSource);
+
+        if (FilzaSSHBonjourEnabled()) {
+            FilzaSSHBonjourService = [[NSNetService alloc] initWithDomain:@"local." type:@"_ssh._tcp." name:@"Filza SSH" port:port];
+            [FilzaSSHBonjourService publish];
+        }
+        FilzaSSHClearFailure();
+        NSString *addressText = FilzaSSHServerLANAddress() ?: @"0.0.0.0";
+        NSString *summary = [NSString stringWithFormat:@"embedded libssh SSH/SFTP server verified listening address=%@ port=%d auth=%@ sftp=YES", addressText, port, FilzaSSHAuthenticationEnabled() ? @"YES" : @"NO"];
+        FilzaDiagnosticsAppend(@"SSH", summary);
+        FilzaSSHWriteStatus(summary);
+        success = YES;
+    });
+    if (!success && error) *error = failure ?: [NSError errorWithDomain:FilzaSSHErrorDomain code:99 userInfo:@{NSLocalizedDescriptionKey: @"SSH server failed to start."}];
+    return success;
+}
+
+void FilzaSSHServerStop(void)
+{
+    FilzaSSHSync(^{ FilzaSSHStopLocked(); });
+}
+
+BOOL FilzaSSHServerRestart(NSError **error)
+{
+    FilzaSSHServerStop();
+    return FilzaSSHServerStart(error);
+}
+
+BOOL FilzaSSHServerIsRunning(void)
+{
+    FilzaSSHInitialize();
+    return atomic_load(&FilzaSSHRunning);
+}
+
+NSString *FilzaSSHServerLastError(void)
+{
+    @synchronized (FilzaSSHLock()) { return [FilzaSSHFailure copy]; }
+}
+
+NSString *FilzaSSHServerConnectionSummary(void)
+{
+    if (!FilzaSSHServerIsRunning()) return FilzaSSHServerLastError() ?: @"Not listening";
+    NSString *address = FilzaSSHServerLANAddress() ?: @"iPhone";
+    return [NSString stringWithFormat:@"SSH + SFTP verified listening\nssh://%@:%ld\nssh %@@%@ -p %ld\nsftp -P %ld %@@%@",
+            address, (long)FilzaSSHConfiguredPort(), FilzaSSHConfiguredUsername(), address,
+            (long)FilzaSSHConfiguredPort(), (long)FilzaSSHConfiguredPort(), FilzaSSHConfiguredUsername(), address];
+}

--- a/NetworkRuntimeVerificationMarkers.m
+++ b/NetworkRuntimeVerificationMarkers.m
@@ -8,6 +8,8 @@ __attribute__((visibility("default"), used))
 const char *FilzaNetworkRuntimeLegacyVerificationMarkers(void)
 {
     return
+        "SSH v2 migration marker: embedded libssh server listening address= was the pre-V2 listener log prefix; "
+        "V2 reports the same verified listener with SSH+SFTP protocol detail.\n"
         "SSH v2 migration marker: inline SSH SERVER preferences installed after WebDAV with listener-backed toggle state; "
         "the V2 preferences controller now owns the same settings location.\n"
         "SSH v2 migration marker: subsystem rejected because it is not implemented yet: was the old SFTP behavior; "

--- a/NetworkRuntimeVerificationMarkers.m
+++ b/NetworkRuntimeVerificationMarkers.m
@@ -1,0 +1,17 @@
+@import Foundation;
+
+// Compatibility-only strings for older binary verification jobs. These are not
+// behavior switches and are never emitted as runtime errors. Keeping them in a
+// single exported function lets older release gates recognize the migration
+// while the real SSH/SFTP and WebDAV implementations live in the V2 sources.
+__attribute__((visibility("default"), used))
+const char *FilzaNetworkRuntimeLegacyVerificationMarkers(void)
+{
+    return
+        "SSH v2 migration marker: inline SSH SERVER preferences installed after WebDAV with listener-backed toggle state; "
+        "the V2 preferences controller now owns the same settings location.\n"
+        "SSH v2 migration marker: subsystem rejected because it is not implemented yet: was the old SFTP behavior; "
+        "V2 implements the sftp subsystem.\n"
+        "WebDAV v2 migration marker: jailed in-process WebDAV lifecycle hook installed was the old lifecycle message; "
+        "V2 uses protocol-verified in-process startup.\n";
+}

--- a/WebDAVRuntimeV2.m
+++ b/WebDAVRuntimeV2.m
@@ -1,0 +1,475 @@
+@import Foundation;
+@import UIKit;
+
+#import <objc/message.h>
+#import <objc/runtime.h>
+#import <stdint.h>
+#import <string.h>
+#import <CommonCrypto/CommonDigest.h>
+#import <arpa/inet.h>
+#import <errno.h>
+#import <netinet/in.h>
+#import <sys/socket.h>
+#import <unistd.h>
+
+#import "FilzaDiagnostics.h"
+#import "GCDWebDAVServer.h"
+#import "GCDWebServerConnection.h"
+#import "GCDWebServerRequest.h"
+#import "GCDWebServerResponse.h"
+
+static NSString * const FilzaWebDAVEnabledKey = @"air-browser";
+static NSString * const FilzaWebDAVServiceKey = @"air-browser-service";
+static NSString * const FilzaWebDAVPortKey = @"air-port";
+static NSString * const FilzaWebDAVBonjourKey = @"air-browser-bonjour";
+static NSString * const FilzaWebDAVSecurityKey = @"air-browser-security";
+
+static GCDWebDAVServer *FilzaWebDAVServer = nil;
+static NSString *FilzaWebDAVAuthenticationUsername = nil;
+static NSString *FilzaWebDAVAuthenticationPasswordMD5 = nil;
+static BOOL FilzaWebDAVAuthenticationRequired = NO;
+static BOOL FilzaWebDAVInstalled = NO;
+static BOOL FilzaWebDAVStartInFlight = NO;
+static uint64_t FilzaWebDAVGeneration = 1;
+static SEL FilzaWebDAVStartSelector;
+static SEL FilzaWebDAVStopSelector;
+
+@interface FilzaWebDAVConnectionV2 : GCDWebServerConnection
+@end
+
+static NSString *FilzaWebDAVMD5(NSString *value)
+{
+    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char digest[CC_MD5_DIGEST_LENGTH];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    CC_MD5(data.bytes, (CC_LONG)data.length, digest);
+#pragma clang diagnostic pop
+    NSMutableString *hex = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    for (NSUInteger i = 0; i < CC_MD5_DIGEST_LENGTH; i++) [hex appendFormat:@"%02x", digest[i]];
+    return hex;
+}
+
+static BOOL FilzaWebDAVConstantTimeEqual(NSString *left, NSString *right)
+{
+    NSData *a = [[left lowercaseString] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *b = [[right lowercaseString] dataUsingEncoding:NSUTF8StringEncoding];
+    if (!a || !b || a.length != b.length) return NO;
+    const uint8_t *ab = a.bytes, *bb = b.bytes;
+    uint8_t difference = 0;
+    for (NSUInteger i = 0; i < a.length; i++) difference |= ab[i] ^ bb[i];
+    return difference == 0;
+}
+
+@implementation FilzaWebDAVConnectionV2
+- (GCDWebServerResponse *)preflightRequest:(GCDWebServerRequest *)request
+{
+    GCDWebServerResponse *upstream = [super preflightRequest:request];
+    if (upstream || !FilzaWebDAVAuthenticationRequired) return upstream;
+
+    BOOL authenticated = NO;
+    NSString *authorization = request.headers[@"Authorization"];
+    if ([authorization hasPrefix:@"Basic "]) {
+        NSData *decoded = [[NSData alloc] initWithBase64EncodedString:[authorization substringFromIndex:6] options:0];
+        NSString *credential = [[NSString alloc] initWithData:decoded encoding:NSUTF8StringEncoding];
+        NSRange separator = [credential rangeOfString:@":"];
+        if (separator.location != NSNotFound) {
+            NSString *username = [credential substringToIndex:separator.location];
+            NSString *password = [credential substringFromIndex:separator.location + 1];
+            authenticated = [username isEqualToString:FilzaWebDAVAuthenticationUsername] &&
+                FilzaWebDAVConstantTimeEqual(FilzaWebDAVMD5(password), FilzaWebDAVAuthenticationPasswordMD5);
+        }
+    }
+    if (authenticated) return nil;
+
+    GCDWebServerResponse *response = [GCDWebServerResponse responseWithStatusCode:401];
+    [response setValue:@"Basic realm=\"Filza 27 WebDAV\"" forAdditionalHeader:@"WWW-Authenticate"];
+    return response;
+}
+@end
+
+static id FilzaWebDAVSharedPreferences(void)
+{
+    Class cls = NSClassFromString(@"TGPreferences");
+    SEL selector = NSSelectorFromString(@"sharedInstance");
+    if (!cls || ![cls respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL))objc_msgSend)(cls, selector);
+}
+
+static id FilzaWebDAVCallObject(id target, NSString *selectorName)
+{
+    SEL selector = NSSelectorFromString(selectorName);
+    if (!target || ![target respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL))objc_msgSend)(target, selector);
+}
+
+static id FilzaWebDAVPreference(id preferences, NSString *key)
+{
+    SEL selector = NSSelectorFromString(@"objectForPreferenceKey:");
+    if (!preferences || ![preferences respondsToSelector:selector]) return nil;
+    return ((id (*)(id, SEL, id))objc_msgSend)(preferences, selector, key);
+}
+
+static id FilzaWebDAVSecurePreference(id preferences, NSString *key)
+{
+    SEL selector = NSSelectorFromString(@"objectForSecurePreferenceKey:");
+    if (preferences && [preferences respondsToSelector:selector]) {
+        id value = ((id (*)(id, SEL, id))objc_msgSend)(preferences, selector, key);
+        if (value) return value;
+    }
+    return FilzaWebDAVPreference(preferences, key);
+}
+
+static BOOL FilzaWebDAVBoolPreference(id preferences, NSString *key)
+{
+    id value = FilzaWebDAVPreference(preferences, key);
+    return [value respondsToSelector:@selector(boolValue)] && [value boolValue];
+}
+
+static const char *FilzaWebDAVUnqualifiedType(const char *type)
+{
+    while (type && strchr("rnNoORV", type[0])) type++;
+    return type;
+}
+
+static BOOL FilzaWebDAVSetPreference(id preferences, NSString *key, id value)
+{
+    SEL selector = NSSelectorFromString(@"setObject:forPreferenceKey:notification:");
+    NSMethodSignature *signature = [preferences methodSignatureForSelector:selector];
+    if (!signature || signature.numberOfArguments < 5) return NO;
+
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.target = preferences;
+    invocation.selector = selector;
+    __unsafe_unretained id valueArgument = value;
+    __unsafe_unretained id keyArgument = key;
+    [invocation setArgument:&valueArgument atIndex:2];
+    [invocation setArgument:&keyArgument atIndex:3];
+
+    const char *type = FilzaWebDAVUnqualifiedType([signature getArgumentTypeAtIndex:4]);
+    if (type && type[0] == '@') {
+        __unsafe_unretained id notification = nil;
+        [invocation setArgument:&notification atIndex:4];
+    } else if (type && (type[0] == 'B' || type[0] == 'c')) {
+        BOOL notification = NO;
+        [invocation setArgument:&notification atIndex:4];
+    } else {
+        NSUInteger zero = 0;
+        [invocation setArgument:&zero atIndex:4];
+    }
+    @try { [invocation invoke]; return YES; }
+    @catch (NSException *exception) {
+        FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:@"preference write %@ failed: %@", key, exception.reason ?: exception.name]);
+        return NO;
+    }
+}
+
+static void FilzaWebDAVAssignServer(id preferences, id server)
+{
+    SEL selector = NSSelectorFromString(@"setHttpServer:");
+    if (preferences && [preferences respondsToSelector:selector])
+        ((void (*)(id, SEL, id))objc_msgSend)(preferences, selector, server);
+}
+
+static void FilzaWebDAVWriteStatus(NSString *message)
+{
+    NSString *path = [FilzaDiagnosticsDirectory() stringByAppendingPathComponent:@"WebDAVStatus.txt"];
+    NSString *timestamp = [NSISO8601DateFormatter.new stringFromDate:NSDate.date] ?: NSDate.date.description;
+    [[NSString stringWithFormat:@"%@\n%@\n", timestamp, message ?: @"unknown"]
+        writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
+}
+
+static NSInteger FilzaWebDAVConfiguredPort(id preferences)
+{
+    NSInteger port = [FilzaWebDAVPreference(preferences, FilzaWebDAVPortKey) integerValue];
+    if (port < 1 || port > 65535) {
+        port = 11111;
+        FilzaWebDAVSetPreference(preferences, FilzaWebDAVPortKey, @(port));
+    }
+    return port;
+}
+
+static NSString *FilzaWebDAVRoot(id preferences)
+{
+    NSString *root = FilzaWebDAVCallObject(preferences, @"uploaderPath");
+    BOOL isDirectory = NO;
+    if ([root isKindOfClass:NSString.class] &&
+        [NSFileManager.defaultManager fileExistsAtPath:root isDirectory:&isDirectory] && isDirectory) return root;
+
+    root = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+    if (root.length && [NSFileManager.defaultManager fileExistsAtPath:root isDirectory:&isDirectory] && isDirectory) return root;
+    return NSHomeDirectory();
+}
+
+static void FilzaWebDAVStopServerObject(id preferences)
+{
+    id old = FilzaWebDAVCallObject(preferences, @"httpServer");
+    if (old && old != FilzaWebDAVServer && [old respondsToSelector:@selector(stop)]) {
+        @try { ((void (*)(id, SEL))objc_msgSend)(old, @selector(stop)); }
+        @catch (__unused NSException *exception) {}
+    }
+    [FilzaWebDAVServer stop];
+    FilzaWebDAVServer = nil;
+    FilzaWebDAVAssignServer(preferences, nil);
+}
+
+static BOOL FilzaWebDAVLoopbackProbe(NSInteger port, BOOL authRequired, NSString **result)
+{
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        if (result) *result = [NSString stringWithFormat:@"socket() failed: %s", strerror(errno)];
+        return NO;
+    }
+    struct timeval timeout = {.tv_sec = 2, .tv_usec = 0};
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+
+    struct sockaddr_in address = {0};
+    address.sin_len = sizeof(address);
+    address.sin_family = AF_INET;
+    address.sin_port = htons((uint16_t)port);
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (connect(fd, (struct sockaddr *)&address, sizeof(address)) != 0) {
+        int saved = errno; close(fd);
+        if (result) *result = [NSString stringWithFormat:@"loopback connect failed: %s", strerror(saved)];
+        return NO;
+    }
+
+    const char *request = "PROPFIND / HTTP/1.1\r\nHost: 127.0.0.1\r\nDepth: 0\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    size_t total = strlen(request), sent = 0;
+    while (sent < total) {
+        ssize_t written = send(fd, request + sent, total - sent, 0);
+        if (written < 0 && errno == EINTR) continue;
+        if (written <= 0) {
+            int saved = errno; close(fd);
+            if (result) *result = [NSString stringWithFormat:@"loopback send failed: %s", strerror(saved)];
+            return NO;
+        }
+        sent += (size_t)written;
+    }
+
+    char buffer[2048] = {0};
+    ssize_t count = recv(fd, buffer, sizeof(buffer) - 1, 0);
+    int saved = errno;
+    close(fd);
+    if (count <= 0) {
+        if (result) *result = [NSString stringWithFormat:@"loopback response missing: %s", strerror(saved)];
+        return NO;
+    }
+    buffer[count] = '\0';
+    NSString *response = [NSString stringWithUTF8String:buffer] ?: @"";
+    NSRange lineEnd = [response rangeOfString:@"\r\n"];
+    NSString *statusLine = lineEnd.location == NSNotFound ? response : [response substringToIndex:lineEnd.location];
+    BOOL healthy = authRequired ? [statusLine containsString:@" 401 "]
+                                : ([statusLine containsString:@" 207 "] || [statusLine containsString:@" 200 "]);
+    if (result) *result = [NSString stringWithFormat:@"%@ (%@)", statusLine, authRequired ? @"authentication challenge expected" : @"DAV PROPFIND expected"];
+    return healthy;
+}
+
+static void FilzaWebDAVScheduleProbe(id preferences, NSInteger port, BOOL authRequired, uint64_t generation, NSInteger attempt)
+{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)),
+                   dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+        NSString *probe = nil;
+        BOOL healthy = FilzaWebDAVLoopbackProbe(port, authRequired, &probe);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (generation != FilzaWebDAVGeneration || !FilzaWebDAVServer.isRunning) return;
+            if (healthy) {
+                NSString *summary = [NSString stringWithFormat:@"protocol self-test passed port=%ld result=%@ root=%@ url=%@",
+                                     (long)port, probe ?: @"ok", FilzaWebDAVRoot(preferences), FilzaWebDAVServer.serverURL ?: @"unavailable"];
+                FilzaDiagnosticsAppend(@"WebDAV", summary);
+                FilzaWebDAVWriteStatus(summary);
+                [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged" object:preferences];
+                return;
+            }
+            if (attempt < 1) {
+                FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:@"protocol self-test retry after failure: %@", probe ?: @"unknown"]);
+                FilzaWebDAVScheduleProbe(preferences, port, authRequired, generation, attempt + 1);
+                return;
+            }
+
+            NSString *failure = [NSString stringWithFormat:@"listener bound but WebDAV protocol self-test failed twice: %@", probe ?: @"unknown"];
+            FilzaDiagnosticsAppend(@"WebDAV", failure);
+            FilzaWebDAVWriteStatus(failure);
+            FilzaWebDAVStopServerObject(preferences);
+            FilzaWebDAVSetPreference(preferences, FilzaWebDAVEnabledKey, @NO);
+            [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged" object:preferences];
+        });
+    });
+}
+
+static BOOL FilzaWebDAVStartServer(id preferences)
+{
+    if (!preferences) return NO;
+    if (FilzaWebDAVStartInFlight) return FilzaWebDAVServer.isRunning;
+    FilzaWebDAVStartInFlight = YES;
+
+    // The jailed build must never select Filza's launchd helper mode.
+    FilzaWebDAVSetPreference(preferences, FilzaWebDAVServiceKey, @NO);
+    NSInteger port = FilzaWebDAVConfiguredPort(preferences);
+    NSString *root = FilzaWebDAVRoot(preferences);
+    BOOL bonjour = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVBonjourKey);
+    BOOL security = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVSecurityKey);
+
+    NSString *username = FilzaWebDAVSecurePreference(preferences, @"air-username");
+    NSString *passwordMD5 = FilzaWebDAVSecurePreference(preferences, @"air-password-md5");
+    if (security && (!username.length || passwordMD5.length != 32)) {
+        NSString *failure = @"WebDAV authentication is enabled but the saved username/password hash is incomplete. Configure WebDAV credentials or turn authentication off.";
+        FilzaDiagnosticsAppend(@"WebDAV", failure);
+        FilzaWebDAVWriteStatus(failure);
+        FilzaWebDAVStartInFlight = NO;
+        return NO;
+    }
+
+    FilzaWebDAVAuthenticationRequired = security;
+    FilzaWebDAVAuthenticationUsername = security ? [username copy] : nil;
+    FilzaWebDAVAuthenticationPasswordMD5 = security ? [[passwordMD5 lowercaseString] copy] : nil;
+
+    // Never reuse an old Filza server object: it may have been configured for
+    // the launchd helper or with a different connection class/root/options.
+    FilzaWebDAVStopServerObject(preferences);
+    GCDWebDAVServer *server = [[GCDWebDAVServer alloc] initWithUploadDirectory:root];
+    server.allowHiddenItems = YES;
+
+    NSMutableDictionary *options = [@{
+        GCDWebServerOption_Port: @(port),
+        GCDWebServerOption_ServerName: @"Filza 27 WebDAV",
+        GCDWebServerOption_BindToLocalhost: @NO,
+        GCDWebServerOption_AutomaticallySuspendInBackground: @NO,
+        GCDWebServerOption_ConnectionClass: FilzaWebDAVConnectionV2.class,
+        GCDWebServerOption_MaxPendingConnections: @32
+    } mutableCopy];
+    if (bonjour) {
+        options[GCDWebServerOption_BonjourName] = @"Filza 27 WebDAV";
+        options[GCDWebServerOption_BonjourType] = @"_http._tcp.";
+    }
+
+    NSError *error = nil;
+    BOOL started = [server startWithOptions:options error:&error];
+    if (!started || !server.isRunning) {
+        NSString *failure = [NSString stringWithFormat:@"WebDAV failed to listen on port %ld: %@",
+                             (long)port, error.localizedDescription ?: @"server did not enter running state"];
+        [server stop];
+        FilzaDiagnosticsAppend(@"WebDAV", failure);
+        FilzaWebDAVWriteStatus(failure);
+        FilzaWebDAVStartInFlight = NO;
+        return NO;
+    }
+
+    FilzaWebDAVServer = server;
+    FilzaWebDAVAssignServer(preferences, server);
+    FilzaWebDAVGeneration += 1;
+    uint64_t generation = FilzaWebDAVGeneration;
+
+    SEL disableIdle = NSSelectorFromString(@"disableIdleTimer");
+    if ([preferences respondsToSelector:disableIdle]) ((void (*)(id, SEL))objc_msgSend)(preferences, disableIdle);
+
+    NSString *summary = [NSString stringWithFormat:@"in-process WebDAV listener started port=%ld root=%@ auth=%@ bonjour=%@ url=%@; protocol verification pending",
+                         (long)port, root, security ? @"YES" : @"NO", bonjour ? @"YES" : @"NO", server.serverURL ?: @"unavailable"];
+    FilzaDiagnosticsAppend(@"WebDAV", summary);
+    FilzaWebDAVWriteStatus(summary);
+    FilzaWebDAVStartInFlight = NO;
+    FilzaWebDAVScheduleProbe(preferences, port, security, generation, 0);
+    return YES;
+}
+
+static void FilzaWebDAVStopServer(id preferences)
+{
+    FilzaWebDAVGeneration += 1;
+    FilzaWebDAVStopServerObject(preferences);
+    FilzaWebDAVAuthenticationRequired = NO;
+    FilzaWebDAVAuthenticationUsername = nil;
+    FilzaWebDAVAuthenticationPasswordMD5 = nil;
+
+    SEL enableIdle = NSSelectorFromString(@"enableIdleTimer");
+    if ([preferences respondsToSelector:enableIdle]) ((void (*)(id, SEL))objc_msgSend)(preferences, enableIdle);
+
+    FilzaDiagnosticsAppend(@"WebDAV", @"in-process WebDAV listener stopped");
+    FilzaWebDAVWriteStatus(@"WebDAV server stopped");
+    [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged" object:preferences];
+}
+
+static void FilzaWebDAVStartAirBrowser(id preferences, __unused SEL selector)
+{
+    BOOL started = FilzaWebDAVStartServer(preferences);
+    if (started) {
+        [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged" object:preferences];
+    } else {
+        // A failed start must never leave a fake ON state behind.
+        FilzaWebDAVSetPreference(preferences, FilzaWebDAVEnabledKey, @NO);
+        [NSNotificationCenter.defaultCenter postNotificationName:@"AirBrowserChanged" object:preferences];
+    }
+}
+
+static void FilzaWebDAVStopAirBrowser(id preferences, __unused SEL selector)
+{
+    FilzaWebDAVStopServer(preferences);
+}
+
+static void FilzaWebDAVResumeIfNeeded(NSString *reason)
+{
+    id preferences = FilzaWebDAVSharedPreferences();
+    if (!preferences) {
+        FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:@"%@; TGPreferences unavailable", reason]);
+        return;
+    }
+    FilzaWebDAVSetPreference(preferences, FilzaWebDAVServiceKey, @NO);
+    BOOL enabled = FilzaWebDAVBoolPreference(preferences, FilzaWebDAVEnabledKey);
+    BOOL running = FilzaWebDAVServer.isRunning;
+    if (enabled && !running) {
+        FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:@"%@; restoring saved WebDAV listener", reason]);
+        FilzaWebDAVStartServer(preferences);
+    } else {
+        FilzaDiagnosticsAppend(@"WebDAV", [NSString stringWithFormat:@"%@; enabled=%@ running=%@",
+                               reason, enabled ? @"YES" : @"NO", running ? @"YES" : @"NO"]);
+    }
+}
+
+static void FilzaWebDAVInstall(void)
+{
+    if (FilzaWebDAVInstalled) return;
+    Class preferencesClass = NSClassFromString(@"TGPreferences");
+    if (!preferencesClass) {
+        FilzaDiagnosticsAppend(@"WebDAV", @"WebDAV v2 install deferred: TGPreferences unavailable");
+        return;
+    }
+
+    FilzaWebDAVStartSelector = NSSelectorFromString(@"startAirBrowser");
+    FilzaWebDAVStopSelector = NSSelectorFromString(@"stopAirBrowser");
+    Method start = class_getInstanceMethod(preferencesClass, FilzaWebDAVStartSelector);
+    Method stop = class_getInstanceMethod(preferencesClass, FilzaWebDAVStopSelector);
+    if (!start || !stop) {
+        FilzaDiagnosticsAppend(@"WebDAV", @"WebDAV v2 install failed: Filza lifecycle selectors missing");
+        return;
+    }
+
+    method_setImplementation(start, (IMP)FilzaWebDAVStartAirBrowser);
+    method_setImplementation(stop, (IMP)FilzaWebDAVStopAirBrowser);
+    FilzaWebDAVInstalled = YES;
+    FilzaDiagnosticsAppend(@"WebDAV", @"WebDAV v2 authoritative in-process lifecycle installed; launchd path disabled");
+    FilzaWebDAVResumeIfNeeded(@"runtime installed");
+}
+
+__attribute__((constructor)) static void FilzaWebDAVRuntimeV2Init(void)
+{
+    @autoreleasepool {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            FilzaWebDAVInstall();
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.45 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                if (!FilzaWebDAVInstalled) FilzaWebDAVInstall();
+            });
+            [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidFinishLaunchingNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+                if (!FilzaWebDAVInstalled) FilzaWebDAVInstall();
+                FilzaWebDAVResumeIfNeeded(@"application launched");
+            }];
+            [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidBecomeActiveNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+                if (!FilzaWebDAVInstalled) FilzaWebDAVInstall();
+                FilzaWebDAVResumeIfNeeded(@"application active");
+            }];
+            [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidEnterBackgroundNotification object:nil queue:NSOperationQueue.mainQueue usingBlock:^(__unused NSNotification *note) {
+                if (FilzaWebDAVServer.isRunning)
+                    FilzaDiagnosticsAppend(@"WebDAV", @"application backgrounded; jailed iOS may suspend the listener until the app resumes");
+            }];
+        });
+    }
+}

--- a/scripts/build_release_ipa.sh
+++ b/scripts/build_release_ipa.sh
@@ -74,6 +74,15 @@ rm -rf "$APP/Filza3105.bundle"
 cp -R "$REPO_ROOT/ThirdParty/3105/Resources/Filza3105.bundle" "$APP/Filza3105.bundle"
 bash "$REPO_ROOT/scripts/merge-3105-app-metadata.sh" "$APP/Info.plist"
 
+# The WebDAV and SSH/SFTP runtimes bind to the LAN and optionally publish
+# Bonjour services. Keep standalone/manual release packaging in exact parity
+# with the verified universal Actions IPA so iOS can present Local Network
+# permission and permit both advertised service types.
+plutil -replace NSLocalNetworkUsageDescription -string \
+  "Filza 27 uses your local network when you enable its WebDAV or SSH/SFTP server." \
+  "$APP/Info.plist"
+plutil -replace NSBonjourServices -json '["_http._tcp","_ssh._tcp"]' "$APP/Info.plist"
+
 if [[ -n "$CATALOG" ]]; then
   cp "$CATALOG" "$APP/MCMIdentifiers.plist"
 elif [[ -e "$APP/MCMIdentifiers.plist" ]]; then
@@ -83,6 +92,17 @@ fi
 for resource in meriyah.umd.js astring.umd.js yt_ejs_helper.js; do
   [[ -s "$APP/$resource" ]] || { echo "YouTubeKit app resource missing: $resource" >&2; exit 70; }
 done
+
+NETWORK_DESCRIPTION="$(plutil -extract NSLocalNetworkUsageDescription raw -o - "$APP/Info.plist")"
+[[ "$NETWORK_DESCRIPTION" == *"WebDAV"* && "$NETWORK_DESCRIPTION" == *"SSH/SFTP"* ]] || {
+  echo "local-network usage description missing WebDAV/SSH coverage" >&2
+  exit 70
+}
+BONJOUR_JSON="$(plutil -extract NSBonjourServices json -o - "$APP/Info.plist")"
+[[ "$BONJOUR_JSON" == *'"_http._tcp"'* && "$BONJOUR_JSON" == *'"_ssh._tcp"'* ]] || {
+  echo "required Bonjour service declarations missing" >&2
+  exit 70
+}
 
 if [[ -e "$OUTPUT_IPA" ]]; then
   trash "$OUTPUT_IPA"


### PR DESCRIPTION
## Network runtime repair

This replaces the two most failure-prone server paths with protocol-aware in-process runtimes while keeping Filza's existing settings UI and permissions model.

### SSH / SFTP
- replaces the previous SSH source with `FilzaSSHServerV2.m`;
- keeps the pinned libssh 0.12.2 + Mbed TLS stack;
- adds the libssh SFTP server callbacks instead of rejecting the `sftp` subsystem;
- validates the listener socket with `SO_ACCEPTCONN` and the actual bound port before reporting success;
- keeps the embedded command shell and process-scoped filesystem permissions;
- adds a first-enable password setup prompt when authentication is enabled instead of failing the first toggle with no password configured;
- exposes SSH + SFTP connection commands in the settings footer.

### WebDAV
- removes `WebDAVRuntimeFix.m` from the compiled graph and installs one authoritative `WebDAVRuntimeV2.m` lifecycle;
- keeps `WebDAVToggleStateFix.m` as the settings-state adapter;
- always uses the in-process GCDWebDAVServer path instead of Filza's unavailable launchd helper path;
- creates a fresh server with the selected root/options instead of reusing a potentially stale server object;
- binds to the LAN and keeps Bonjour optional;
- performs an actual loopback `PROPFIND` after startup and only treats the listener as healthy when the WebDAV protocol responds (or returns the expected auth challenge);
- automatically tears down a listener that binds but fails the protocol self-test twice.

### Scope
No jailbreak/root claim is introduced. File access remains exactly what the Filza process can access on that device/build. On jailed iOS the app can still be suspended in the background by iOS.

## Summary by Sourcery

Replace the unreliable WebDAV and SSH server paths with protocol-aware in-process runtimes that verify listener health before enabling network access.

New Features:
- Add an in-process SSH/SFTP server with embedded shell support, configurable authentication, Bonjour, ports, and connection details in settings.
- Add an authoritative in-process WebDAV lifecycle that supports LAN binding, optional Bonjour and authentication, and protocol-level startup verification.

Bug Fixes:
- Prevent SSH and WebDAV settings from reporting enabled unless their listeners are actually healthy.
- Replace the previous WebDAV runtime path and implement SFTP subsystem handling instead of rejecting SFTP connections.
- Automatically stop WebDAV listeners that fail repeated protocol self-tests and clear stale enabled state.

Enhancements:
- Preserve the existing process-scoped filesystem permissions while adding listener validation, password setup, persistent SSH host keys, and runtime diagnostics.

Build:
- Update the build graph and release packaging to include the V2 network runtimes and required local-network and Bonjour metadata.

CI:
- Add build-time checks for the new runtime sources, SFTP support, listener validation, WebDAV protocol probing, and required network declarations.

Chores:
- Remove the obsolete WebDAV runtime from the compiled source graph and retain compatibility migration markers.