### PR TITLE
Replace embedded libssh server with real wolfSSH backend

### DIFF
--- a/.github/workflows/verify-upstream-byetunes-ssh.yml
+++ b/.github/workflows/verify-upstream-byetunes-ssh.yml
@@ -58,6 +58,7 @@ jobs:
           test -f scripts/build-wolfssh-stack.sh
           grep -Fq 'wolfSSH_accept' FilzaWolfSSHServer.m
           grep -Fq 'wolfSSH_SFTP_read' FilzaWolfSSHServer.m
+          grep -Fq 'silent-audio background keepalive active for wolfSSH' FilzaWolfSSHServer.m
           grep -Fq 'FilzaWolfSSHServer.m' FilzaSSHMetadata.mk
           ! grep -Fq 'FilzaSSHServerV2.m FilzaSSHPreferencesV2.m' FilzaSSHMetadata.mk
           test -f ByeTunesMetadataCompat.swift
@@ -222,6 +223,8 @@ jobs:
           plutil -replace LSSupportsOpeningDocumentsInPlace -bool YES "$APP/Info.plist"
           plutil -replace NSSupportsLiveActivities -bool YES "$APP/Info.plist"
           plutil -replace NSSupportsLiveActivitiesFrequentUpdates -bool YES "$APP/Info.plist"
+          plutil -remove UIBackgroundModes "$APP/Info.plist" 2>/dev/null || true
+          plutil -insert UIBackgroundModes -json '["audio"]' "$APP/Info.plist"
           plutil -replace NSLocalNetworkUsageDescription -string "Filza 27 uses your local network when you enable its WebDAV or SSH/SFTP server." "$APP/Info.plist"
           plutil -replace NSBonjourServices -json '["_http._tcp","_ssh._tcp"]' "$APP/Info.plist"
           bash scripts/merge-3105-app-metadata.sh "$APP/Info.plist"
@@ -233,6 +236,7 @@ jobs:
           fi
 
           test "$(plutil -extract MinimumOSVersion raw -o - "$APP/Info.plist")" = "17.0"
+          plutil -extract UIBackgroundModes json -o - "$APP/Info.plist" | grep -Fq '"audio"'
           test ! -e "$APP/Frameworks/FilzaMondModern.dylib"
           test -s "$APP/Frameworks/FilzaApplySandboxExt.dylib"
           test -s "$APP/MondEmbedded.bundle/Info.plist"

--- a/.github/workflows/verify-upstream-byetunes-ssh.yml
+++ b/.github/workflows/verify-upstream-byetunes-ssh.yml
@@ -56,6 +56,10 @@ jobs:
           grep -Fq 'patch-3105-embedded-compat.sh' Makefile
           test -f FilzaWolfSSHServer.m
           test -f scripts/build-wolfssh-stack.sh
+          test -f scripts/wolfssh-allow-multiple-session-channels.patch
+          grep -Fq 'if (ssh->channelListSz >= 1)' scripts/wolfssh-allow-multiple-session-channels.patch
+          grep -Fq 'wolfSSH_CTX_SetChannelOpenCb' FilzaWolfSSHServer.m
+          grep -Fq 'wolfSSH rejected exec channel closed' FilzaWolfSSHServer.m
           grep -Fq 'wolfSSH_accept' FilzaWolfSSHServer.m
           grep -Fq 'wolfSSH_SFTP_read' FilzaWolfSSHServer.m
           grep -Fq 'silent-audio background keepalive active for wolfSSH' FilzaWolfSSHServer.m
@@ -92,7 +96,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: Vendor/wolfssh
-          key: wolfssh-${{ runner.os }}-${{ runner.arch }}-xcode26.2-ios17-${{ env.WOLFSSH_COMMIT }}-${{ env.WOLFSSL_COMMIT }}-${{ hashFiles('scripts/build-wolfssh-stack.sh') }}
+          key: wolfssh-${{ runner.os }}-${{ runner.arch }}-xcode26.2-ios17-${{ env.WOLFSSH_COMMIT }}-${{ env.WOLFSSL_COMMIT }}-${{ hashFiles('scripts/build-wolfssh-stack.sh', 'scripts/wolfssh-allow-multiple-session-channels.patch') }}
 
       - name: Build pinned wolfSSH server stack
         if: steps.wolfssh-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/verify-upstream-byetunes-ssh.yml
+++ b/.github/workflows/verify-upstream-byetunes-ssh.yml
@@ -158,7 +158,8 @@ jobs:
           grep -aFq 'wolfSSH authenticated SFTP subsystem accepted' "$DYLIB"
           grep -aFq 'protocol self-test passed' "$DYLIB"
           grep -aFq 'jailed in-process WebDAV lifecycle hook installed' "$DYLIB"
-          nm -gU "$DYLIB" | grep -q 'wolfSSH_accept\|_wolfSSH_accept'
+          nm -gU "$DYLIB" > .theos/wolfssh-symbols.txt
+          grep -Eq 'wolfSSH_accept|_wolfSSH_accept' .theos/wolfssh-symbols.txt
           ! otool -L "$DYLIB" | grep -Fq 'FilzaMondModern.dylib'
           bash scripts/verify-mond-source-completeness.sh
 

--- a/.github/workflows/verify-upstream-byetunes-ssh.yml
+++ b/.github/workflows/verify-upstream-byetunes-ssh.yml
@@ -22,6 +22,8 @@ jobs:
       IDEVICE_COMMIT: 37ee77cf713f483551f3cf33ea8b2087a40058ca
       LIBSSH_COMMIT: 07430deb9b97b751ec5ea5a7fc307f40bf042e0a
       MBEDTLS_COMMIT: 068ff080b369adfac81509f9b57b2afabaf82dc5
+      WOLFSSH_COMMIT: e7c8dc2c2c54e5f0f2986be592e2243725a4dd33
+      WOLFSSL_COMMIT: 9ab8a4b19debdade06b10d30cf70167de8f9b915
       THEOS_COMMIT: 5280bd038207e14f8bd76f5417aa2fe641c03228
       MOND_COMMIT: 3d91194716ad5f06afdf7e9037e6964e80a4ac29
       BASE_IPA_SHA256: b11ce30a2db6f6bc77773ed30bdb855d7c847830891b14d21230f2d893d5f223
@@ -52,6 +54,12 @@ jobs:
           grep -Fq 'stage-mond-22-overlay.sh' Makefile
           grep -Fq 'stage-3105-v1.sh' Makefile
           grep -Fq 'patch-3105-embedded-compat.sh' Makefile
+          test -f FilzaWolfSSHServer.m
+          test -f scripts/build-wolfssh-stack.sh
+          grep -Fq 'wolfSSH_accept' FilzaWolfSSHServer.m
+          grep -Fq 'wolfSSH_SFTP_read' FilzaWolfSSHServer.m
+          grep -Fq 'FilzaWolfSSHServer.m' FilzaSSHMetadata.mk
+          ! grep -Fq 'FilzaSSHServerV2.m FilzaSSHPreferencesV2.m' FilzaSSHMetadata.mk
           test -f ByeTunesMetadataCompat.swift
           test -f ByeTunesDownloadParityCompat.swift
           test -f scripts/stage-byetunes-youtubekit.sh
@@ -67,16 +75,27 @@ jobs:
           grep -Fq 'FilzaEmbeddedPanel {' FilzaMondCurrentHost.swift
           ! grep -Fq 'ios16Backport' FilzaMondCurrentHost.swift
 
-      - name: Restore pinned SSH stack cache
+      - name: Restore pinned libssh verifier cache
         id: ssh-cache
         uses: actions/cache@v4
         with:
           path: Vendor/ssh
           key: ssh-stack-${{ runner.os }}-${{ runner.arch }}-xcode26.2-ios26.2-${{ env.LIBSSH_COMMIT }}-${{ env.MBEDTLS_COMMIT }}-${{ hashFiles('scripts/build-ssh-stack.sh') }}
 
-      - name: Build pinned SSH stack
+      - name: Build pinned libssh verifier
         if: steps.ssh-cache.outputs.cache-hit != 'true'
         run: bash scripts/build-ssh-stack.sh "$GITHUB_WORKSPACE/Vendor/ssh"
+
+      - name: Restore pinned wolfSSH server cache
+        id: wolfssh-cache
+        uses: actions/cache@v4
+        with:
+          path: Vendor/wolfssh
+          key: wolfssh-${{ runner.os }}-${{ runner.arch }}-xcode26.2-ios17-${{ env.WOLFSSH_COMMIT }}-${{ env.WOLFSSL_COMMIT }}-${{ hashFiles('scripts/build-wolfssh-stack.sh') }}
+
+      - name: Build pinned wolfSSH server stack
+        if: steps.wolfssh-cache.outputs.cache-hit != 'true'
+        run: bash scripts/build-wolfssh-stack.sh "$GITHUB_WORKSPACE/Vendor/wolfssh"
 
       - name: Install Procursus build tools
         uses: dhinakg/procursus-action@main
@@ -117,8 +136,12 @@ jobs:
           set -euxo pipefail
           export PATH="/opt/procursus/bin:$PATH"
           test "$(cat Vendor/idevice/COMMIT)" = "$IDEVICE_COMMIT"
+          test "$(cat Vendor/wolfssh/WOLFSSH_COMMIT)" = "$WOLFSSH_COMMIT"
+          test "$(cat Vendor/wolfssh/WOLFSSL_COMMIT)" = "$WOLFSSL_COMMIT"
           test -s Vendor/idevice/lib/libidevice_ffi.a
           test -s Vendor/ssh/lib/libssh.a
+          test -s Vendor/wolfssh/lib/libwolfssh.a
+          test -s Vendor/wolfssh/lib/libwolfssl.a
           gmake clean || true
           gmake -j"$(sysctl -n hw.logicalcpu)" all FINALPACKAGE=1 TARGET=iphone:clang:latest:17.0
 
@@ -131,8 +154,11 @@ jobs:
           grep -aFq 'ByeTunesEmbeddedHostFactory' "$DYLIB"
           grep -aFq 'All Sources' "$DYLIB"
           grep -aFq 'YouTube' "$DYLIB"
-          grep -aFq 'embedded libssh server listening address=' "$DYLIB"
+          grep -aFq 'wolfSSH SSH/SFTP server listening address=' "$DYLIB"
+          grep -aFq 'wolfSSH authenticated SFTP subsystem accepted' "$DYLIB"
+          grep -aFq 'protocol self-test passed' "$DYLIB"
           grep -aFq 'jailed in-process WebDAV lifecycle hook installed' "$DYLIB"
+          nm -gU "$DYLIB" | grep -q 'wolfSSH_accept\|_wolfSSH_accept'
           ! otool -L "$DYLIB" | grep -Fq 'FilzaMondModern.dylib'
           bash scripts/verify-mond-source-completeness.sh
 
@@ -199,7 +225,6 @@ jobs:
           plutil -replace NSBonjourServices -json '["_http._tcp","_ssh._tcp"]' "$APP/Info.plist"
           bash scripts/merge-3105-app-metadata.sh "$APP/Info.plist"
 
-          # Keep the latest FilzaSlop packaging hardening while using the modern runtime.
           plutil -remove CFBundleURLTypes "$APP/Info.plist" 2>/dev/null || true
           if plutil -extract CFBundleURLTypes json -o - "$APP/Info.plist" >/dev/null 2>&1; then
             echo "CFBundleURLTypes was not stripped" >&2

--- a/.github/workflows/verify-upstream-byetunes-ssh.yml
+++ b/.github/workflows/verify-upstream-byetunes-ssh.yml
@@ -60,6 +60,7 @@ jobs:
           grep -Fq 'if (ssh->channelListSz >= 1)' scripts/wolfssh-allow-multiple-session-channels.patch
           grep -Fq 'wolfSSH_CTX_SetChannelOpenCb' FilzaWolfSSHServer.m
           grep -Fq 'wolfSSH rejected exec channel closed' FilzaWolfSSHServer.m
+          grep -Fq 'consumed stale close acknowledgement after local channel exit' FilzaWolfSSHServer.m
           grep -Fq 'wolfSSH_accept' FilzaWolfSSHServer.m
           grep -Fq 'wolfSSH_SFTP_read' FilzaWolfSSHServer.m
           grep -Fq 'silent-audio background keepalive active for wolfSSH' FilzaWolfSSHServer.m

--- a/FilzaSSHMetadata.mk
+++ b/FilzaSSHMetadata.mk
@@ -1,7 +1,6 @@
-# Embedded SSH + local-network runtime integration. Mond is staged and verified
-# independently and is not modified from this fragment. The old WebDAV runtime
-# is removed from the source graph here so only one start/stop implementation
-# owns the listener; WebDAVToggleStateFix remains the settings-state adapter.
+# Embedded SSH + local-network runtime integration. The production server is
+# wolfSSH; libssh remains only as an independent loopback protocol verifier.
+# Mond is staged and verified independently and is not modified here.
 
 SSH_VENDOR ?= $(PWD)/Vendor/ssh
 SSH_STATIC := $(SSH_VENDOR)/lib/libssh.a
@@ -9,29 +8,37 @@ SSH_MBEDTLS := $(SSH_VENDOR)/lib/libmbedtls.a
 SSH_MBEDX509 := $(SSH_VENDOR)/lib/libmbedx509.a
 SSH_MBEDCRYPTO := $(SSH_VENDOR)/lib/libmbedcrypto.a
 
+WOLFSSH_VENDOR ?= $(PWD)/Vendor/wolfssh
+WOLFSSH_STATIC := $(WOLFSSH_VENDOR)/lib/libwolfssh.a
+WOLFSSL_STATIC := $(WOLFSSH_VENDOR)/lib/libwolfssl.a
+
 FilzaApplySandboxExt_FILES := $(filter-out WebDAVRuntimeFix.m,$(FilzaApplySandboxExt_FILES))
 FilzaApplySandboxExt_FILES += WebDAVRuntimeV2.m NetworkRuntimeVerificationMarkers.m
-FilzaApplySandboxExt_FILES += FilzaSSHServerV2.m FilzaSSHPreferencesV2.m FilzaSSHProtocolHealth.m FilzaSSHPublicAccess.m
-# libssh's public sftp.h hides its server declarations behind WITH_SERVER;
-# these are consumer-side declaration guards, separate from the CMake options
-# already used when the pinned static library itself is built.
-FilzaApplySandboxExt_CFLAGS += -I$(SSH_VENDOR)/include -DLIBSSH_STATIC=1 -DWITH_SERVER=1 -DWITH_SFTP=1
+FilzaApplySandboxExt_FILES += FilzaWolfSSHServer.m FilzaSSHPreferencesV2.m FilzaSSHProtocolHealth.m FilzaSSHPublicAccess.m
+
+# libssh is a client-only health probe now. wolfSSH owns the actual listening
+# socket, authentication, shell transport, and SFTP subsystem.
+FilzaApplySandboxExt_CFLAGS += -I$(SSH_VENDOR)/include -DLIBSSH_STATIC=1
+FilzaApplySandboxExt_CFLAGS += -I$(WOLFSSH_VENDOR)/include -DWOLFSSH_SFTP=1 -DWOLFSSH_SCP=1
+FilzaApplySandboxExt_LDFLAGS += $(WOLFSSH_STATIC) $(WOLFSSL_STATIC)
 FilzaApplySandboxExt_LDFLAGS += $(SSH_STATIC) $(SSH_MBEDTLS) $(SSH_MBEDX509) $(SSH_MBEDCRYPTO)
 
 before-FilzaApplySandboxExt-all::
 	@test -f "FilzaSSHServer.h" || (echo "Missing FilzaSSHServer.h" >&2; exit 1)
-	@test -f "FilzaSSHServerV2.m" || (echo "Missing FilzaSSHServerV2.m" >&2; exit 1)
+	@test -f "FilzaWolfSSHServer.m" || (echo "Missing FilzaWolfSSHServer.m" >&2; exit 1)
 	@test -f "FilzaSSHPreferencesV2.m" || (echo "Missing FilzaSSHPreferencesV2.m" >&2; exit 1)
-	@test -f "FilzaSSHProtocolHealth.m" || (echo "Missing SSH protocol health probe" >&2; exit 1)
+	@test -f "FilzaSSHProtocolHealth.m" || (echo "Missing independent SSH protocol health probe" >&2; exit 1)
 	@test -f "WebDAVRuntimeV2.m" || (echo "Missing WebDAVRuntimeV2.m" >&2; exit 1)
 	@test -f "NetworkRuntimeVerificationMarkers.m" || (echo "Missing network runtime migration markers" >&2; exit 1)
 	@test -f "FilzaSSHPublicAccess.m" || (echo "Missing FilzaSSHPublicAccess.m" >&2; exit 1)
-	@test -f "$(SSH_VENDOR)/include/libssh/sftp.h" || (echo "Missing libssh SFTP headers" >&2; exit 1)
-	@test -f "$(SSH_VENDOR)/include/libssh/sftpserver.h" || (echo "Missing libssh SFTP server headers" >&2; exit 1)
-	@grep -Fq 'sftp_channel_default_subsystem_request' FilzaSSHServerV2.m
-	@grep -Fq 'sftp_channel_default_data_callback' FilzaSSHServerV2.m
-	@grep -Fq '&context->sftp' FilzaSSHServerV2.m
-	@grep -Fq 'SO_ACCEPTCONN' FilzaSSHServerV2.m
+	@test -f "$(SSH_VENDOR)/include/libssh/libssh.h" || (echo "Missing libssh verifier headers" >&2; exit 1)
+	@test -f "$(WOLFSSH_VENDOR)/include/wolfssh/ssh.h" || (echo "Missing wolfSSH headers" >&2; exit 1)
+	@test -f "$(WOLFSSH_VENDOR)/include/wolfssh/wolfsftp.h" || (echo "Missing wolfSSH SFTP headers" >&2; exit 1)
+	@test -f "$(WOLFSSH_VENDOR)/include/wolfssl/wolfcrypt/ecc.h" || (echo "Missing wolfCrypt headers" >&2; exit 1)
+	@grep -Fq 'wolfSSH_accept' FilzaWolfSSHServer.m
+	@grep -Fq 'wolfSSH_SFTP_read' FilzaWolfSSHServer.m
+	@grep -Fq 'wolfSSH_CTX_UsePrivateKey_buffer' FilzaWolfSSHServer.m
+	@grep -Fq 'wolfSSH password verifier updated' FilzaWolfSSHServer.m
 	@grep -Fq 'SSH-2.0-' FilzaSSHProtocolHealth.m
 	@grep -Fq 'protocol self-test passed' FilzaSSHProtocolHealth.m
 	@grep -Fq 'PROPFIND / HTTP/1.1' WebDAVRuntimeV2.m
@@ -39,7 +46,10 @@ before-FilzaApplySandboxExt-all::
 	@grep -Fq 'NAT-PMP (RFC 6886)' FilzaSSHPublicAccess.m
 	@grep -Fq 'UPnP IGD WANIPConnection' FilzaSSHPublicAccess.m
 	@grep -Fq 'PUBLIC via' FilzaSSHPublicAccess.m
-	@test -f "scripts/build-ssh-stack.sh" || (echo "Missing pinned SSH build script" >&2; exit 1)
+	@test -f "scripts/build-ssh-stack.sh" || (echo "Missing pinned libssh verifier build script" >&2; exit 1)
+	@test -f "scripts/build-wolfssh-stack.sh" || (echo "Missing pinned wolfSSH build script" >&2; exit 1)
+	@test -s "$(WOLFSSH_STATIC)" || (echo "Missing $(WOLFSSH_STATIC). Run: bash scripts/build-wolfssh-stack.sh" >&2; exit 1)
+	@test -s "$(WOLFSSL_STATIC)" || (echo "Missing $(WOLFSSL_STATIC). Run: bash scripts/build-wolfssh-stack.sh" >&2; exit 1)
 	@test -s "$(SSH_STATIC)" || (echo "Missing $(SSH_STATIC). Run: bash scripts/build-ssh-stack.sh" >&2; exit 1)
 	@test -s "$(SSH_MBEDTLS)" || (echo "Missing $(SSH_MBEDTLS)" >&2; exit 1)
 	@test -s "$(SSH_MBEDX509)" || (echo "Missing $(SSH_MBEDX509)" >&2; exit 1)

--- a/FilzaSSHMetadata.mk
+++ b/FilzaSSHMetadata.mk
@@ -39,6 +39,7 @@ before-FilzaApplySandboxExt-all::
 	@grep -Fq 'wolfSSH_SFTP_read' FilzaWolfSSHServer.m
 	@grep -Fq 'wolfSSH_CTX_UsePrivateKey_buffer' FilzaWolfSSHServer.m
 	@grep -Fq 'wolfSSH password verifier updated' FilzaWolfSSHServer.m
+	@grep -Fq 'silent-audio background keepalive active for wolfSSH' FilzaWolfSSHServer.m
 	@grep -Fq 'SSH-2.0-' FilzaSSHProtocolHealth.m
 	@grep -Fq 'protocol self-test passed' FilzaSSHProtocolHealth.m
 	@grep -Fq 'PROPFIND / HTTP/1.1' WebDAVRuntimeV2.m

--- a/FilzaSSHServer.h
+++ b/FilzaSSHServer.h
@@ -1,6 +1,4 @@
 #import <Foundation/Foundation.h>
-#import <errno.h>
-#import <sys/socket.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,39 +9,6 @@ FOUNDATION_EXPORT NSString * const FilzaSSHAuthenticationKey;
 FOUNDATION_EXPORT NSString * const FilzaSSHUsernameKey;
 FOUNDATION_EXPORT NSString * const FilzaSSHPasswordSaltKey;
 FOUNDATION_EXPORT NSString * const FilzaSSHPasswordHashKey;
-
-/*
- * SO_ACCEPTCONN is only a diagnostic in Filza's startup path. On iOS 27 the
- * libssh-owned listener can report ENOPROTOOPT or a false zero for this option
- * even after ssh_bind_listen() succeeds. Do not let that non-authoritative
- * socket option veto a working listener. FilzaSSHServerV2 still validates the
- * bound address/port with getsockname(), and FilzaSSHProtocolHealth performs a
- * real loopback SSH version/key-exchange immediately after startup. That
- * protocol handshake is the authoritative accept-path test.
- */
-static inline int FilzaSSHPortableGetSockOpt(int socketFD,
-                                             int level,
-                                             int optionName,
-                                             void *optionValue,
-                                             socklen_t *optionLength)
-{
-#if defined(__APPLE__) && defined(SO_ACCEPTCONN)
-    if (level == SOL_SOCKET && optionName == SO_ACCEPTCONN) {
-        if (!optionValue || !optionLength || *optionLength < sizeof(int)) {
-            errno = EINVAL;
-            return -1;
-        }
-        *(int *)optionValue = 1;
-        *optionLength = sizeof(int);
-        errno = 0;
-        return 0;
-    }
-#endif
-    return getsockopt(socketFD, level, optionName, optionValue, optionLength);
-}
-
-/* FilzaSSHServerV2 imports this header after <sys/socket.h>. */
-#define getsockopt FilzaSSHPortableGetSockOpt
 
 FOUNDATION_EXPORT NSInteger FilzaSSHConfiguredPort(void);
 FOUNDATION_EXPORT BOOL FilzaSSHBonjourEnabled(void);

--- a/FilzaWolfSSHServer.m
+++ b/FilzaWolfSSHServer.m
@@ -453,16 +453,46 @@ static NSString *FilzaSSHExecute(NSString *command, NSString **cwd, BOOL *should
     return [NSString stringWithFormat:@"%@: command not found (type help)\r\n", name];
 }
 
-static void FilzaWolfSSHSend(WOLFSSH *ssh, NSString *text)
+static BOOL FilzaWolfSSHRetryable(int rc, int error)
+{
+    return rc == WS_WANT_READ || rc == WS_WANT_WRITE ||
+           rc == WS_CHAN_RXD || rc == WS_REKEYING || rc == WS_WINDOW_FULL ||
+           error == WS_WANT_READ || error == WS_WANT_WRITE ||
+           error == WS_CHAN_RXD || error == WS_REKEYING || error == WS_WINDOW_FULL;
+}
+
+/* wolfSSH_accept() can finish authentication before a client has completed its
+ * PTY/shell channel requests. Keep turning wolfSSH's protocol state machine
+ * until the channel can carry the prompt instead of treating that state as EOF. */
+static BOOL FilzaWolfSSHSend(WOLFSSH *ssh, NSString *text)
 {
     NSData *data = [text dataUsingEncoding:NSUTF8StringEncoding];
     const byte *bytes = data.bytes;
     NSUInteger offset = 0;
     while (offset < data.length) {
         int sent = wolfSSH_stream_send(ssh, bytes + offset, (word32)MIN((NSUInteger)32768, data.length - offset));
-        if (sent <= 0) break;
-        offset += (NSUInteger)sent;
+        if (sent > 0) {
+            offset += (NSUInteger)sent;
+            continue;
+        }
+
+        int error = wolfSSH_get_error(ssh);
+        if (!FilzaWolfSSHRetryable(sent, error)) {
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH shell send ended rc=%d error=%d", sent, error]);
+            return NO;
+        }
+
+        /* This is the same channel-driving pattern used by wolfSSH's official
+         * echoserver. It completes pending channel-open, PTY and shell requests. */
+        int worker = wolfSSH_worker(ssh, NULL);
+        int workerError = wolfSSH_get_error(ssh);
+        if (worker == WS_CHANNEL_CLOSED || worker == WS_EOF || workerError == WS_EOF) return NO;
+        if (worker != WS_SUCCESS && !FilzaWolfSSHRetryable(worker, workerError)) {
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH shell channel setup ended rc=%d error=%d", worker, workerError]);
+            return NO;
+        }
     }
+    return YES;
 }
 
 static void FilzaWolfSSHServeSFTP(WOLFSSH *ssh)
@@ -491,13 +521,20 @@ static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
 {
     __block NSString *cwd = FilzaSSHInitialDirectory();
     NSMutableData *line = NSMutableData.data;
-    FilzaWolfSSHSend(ssh, @"Filza 27 wolfSSH\r\n");
-    FilzaWolfSSHSend(ssh, [NSString stringWithFormat:@"filza:%@$ ", cwd]);
+    if (!FilzaWolfSSHSend(ssh, @"Filza 27 wolfSSH\r\n") ||
+        !FilzaWolfSSHSend(ssh, [NSString stringWithFormat:@"filza:%@$ ", cwd])) return;
+    FilzaDiagnosticsAppend(@"SSH", @"wolfSSH interactive shell channel ready");
     byte buffer[4096];
     BOOL closeSession = NO;
     while (!closeSession && atomic_load(&FilzaSSHRunning)) {
         int rc = wolfSSH_stream_read(ssh, buffer, sizeof(buffer));
-        if (rc <= 0) break;
+        if (rc <= 0) {
+            int error = wolfSSH_get_error(ssh);
+            if (rc == WS_EOF || rc == WS_CHANNEL_CLOSED || error == WS_EOF) break;
+            if (FilzaWolfSSHRetryable(rc, error) || rc == WS_SUCCESS) continue;
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH shell read ended rc=%d error=%d", rc, error]);
+            break;
+        }
         for (int i = 0; i < rc; i++) {
             byte ch = buffer[i];
             if (ch == '\r' || ch == '\n') {
@@ -505,9 +542,14 @@ static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
                 NSString *command = [[NSString alloc] initWithData:line encoding:NSUTF8StringEncoding] ?: @"";
                 [line setLength:0];
                 NSString *output = FilzaSSHExecute(command, &cwd, &closeSession);
-                FilzaWolfSSHSend(ssh, @"\r\n");
-                FilzaWolfSSHSend(ssh, output);
-                if (!closeSession) FilzaWolfSSHSend(ssh, [NSString stringWithFormat:@"filza:%@$ ", cwd]);
+                if (!FilzaWolfSSHSend(ssh, @"\r\n") || !FilzaWolfSSHSend(ssh, output)) {
+                    closeSession = YES;
+                    break;
+                }
+                if (!closeSession && !FilzaWolfSSHSend(ssh, [NSString stringWithFormat:@"filza:%@$ ", cwd])) {
+                    closeSession = YES;
+                    break;
+                }
             } else if (ch == 0x7f || ch == 0x08) {
                 if (line.length) [line setLength:line.length - 1];
             } else if (ch >= 0x20 || ch == '\t') {

--- a/FilzaWolfSSHServer.m
+++ b/FilzaWolfSSHServer.m
@@ -470,6 +470,15 @@ static int FilzaWolfSSHChannelRequestShell(WOLFSSH_CHANNEL *channel, void *conte
     return WS_SUCCESS;
 }
 
+static int FilzaWolfSSHChannelOpen(WOLFSSH_CHANNEL *channel, void *context)
+{
+    (void)context;
+    word32 channelID = 0;
+    wolfSSH_ChannelGetId(channel, &channelID, WS_CHANNEL_ID_SELF);
+    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH session channel opened channel=%u", channelID]);
+    return WS_SUCCESS;
+}
+
 /* Clauntty probes and deploys rtach with extra exec channels. This jailed
  * server deliberately has no process-spawning shell, so reject exec requests
  * immediately. Clauntty then follows its built-in plain-SSH fallback instead
@@ -575,7 +584,15 @@ static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
         for (WOLFSSH_CHANNEL *channel = wolfSSH_ChannelNext(ssh, NULL), *next = NULL;
              channel != NULL; channel = next) {
             next = wolfSSH_ChannelNext(ssh, channel);
-            if (wolfSSH_ChannelGetSessionType(channel) != WOLFSSH_SESSION_SHELL) continue;
+            WS_SessionType sessionType = wolfSSH_ChannelGetSessionType(channel);
+            if (sessionType == WOLFSSH_SESSION_EXEC) {
+                word32 execChannelID = 0;
+                wolfSSH_ChannelGetId(channel, &execChannelID, WS_CHANNEL_ID_SELF);
+                FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH rejected exec channel closed channel=%u", execChannelID]);
+                wolfSSH_ChannelExit(channel);
+                continue;
+            }
+            if (sessionType != WOLFSSH_SESSION_SHELL) continue;
             word32 channelID = 0;
             if (wolfSSH_ChannelGetId(channel, &channelID, WS_CHANNEL_ID_SELF) != WS_SUCCESS) continue;
             NSNumber *key = @(channelID);
@@ -647,6 +664,7 @@ static void FilzaWolfSSHServeClient(int clientFD)
         WOLFSSH_CTX *ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
         if (!ctx) { FilzaDiagnosticsAppend(@"SSH", @"wolfSSH_CTX_new failed"); close(clientFD); return; }
         wolfSSH_SetUserAuth(ctx, FilzaWolfSSHUserAuth);
+        wolfSSH_CTX_SetChannelOpenCb(ctx, FilzaWolfSSHChannelOpen);
         wolfSSH_CTX_SetChannelReqShellCb(ctx, FilzaWolfSSHChannelRequestShell);
         wolfSSH_CTX_SetChannelReqExecCb(ctx, FilzaWolfSSHChannelRequestExec);
         wolfSSH_CTX_SetBanner(ctx, "Filza 27 wolfSSH server");

--- a/FilzaWolfSSHServer.m
+++ b/FilzaWolfSSHServer.m
@@ -2,7 +2,7 @@
 @import Security;
 @import UIKit;
 
-#import <CommonCrypto/CommonKeyDerivation.h>
+#import <CommonCrypto/CommonCrypto.h>
 #import <arpa/inet.h>
 #import <errno.h>
 #import <fcntl.h>
@@ -16,6 +16,7 @@
 #import <sys/utsname.h>
 #import <unistd.h>
 
+#include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/random.h>

--- a/FilzaWolfSSHServer.m
+++ b/FilzaWolfSSHServer.m
@@ -461,36 +461,49 @@ static BOOL FilzaWolfSSHRetryable(int rc, int error)
            error == WS_CHAN_RXD || error == WS_REKEYING || error == WS_WINDOW_FULL;
 }
 
-/* wolfSSH_accept() can finish authentication before a client has completed its
- * PTY/shell channel requests. Keep turning wolfSSH's protocol state machine
- * until the channel can carry the prompt instead of treating that state as EOF. */
-static BOOL FilzaWolfSSHSend(WOLFSSH *ssh, NSString *text)
+static int FilzaWolfSSHChannelRequestShell(WOLFSSH_CHANNEL *channel, void *context)
+{
+    (void)context;
+    word32 channelID = 0;
+    wolfSSH_ChannelGetId(channel, &channelID, WS_CHANNEL_ID_SELF);
+    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH shell request accepted channel=%u", channelID]);
+    return WS_SUCCESS;
+}
+
+/* Clauntty probes and deploys rtach with extra exec channels. This jailed
+ * server deliberately has no process-spawning shell, so reject exec requests
+ * immediately. Clauntty then follows its built-in plain-SSH fallback instead
+ * of waiting forever for an exec channel that will never close. */
+static int FilzaWolfSSHChannelRequestExec(WOLFSSH_CHANNEL *channel, void *context)
+{
+    (void)context;
+    word32 channelID = 0;
+    wolfSSH_ChannelGetId(channel, &channelID, WS_CHANNEL_ID_SELF);
+    const char *raw = wolfSSH_ChannelGetSessionCommand(channel);
+    NSString *command = raw ? [NSString stringWithUTF8String:raw] : @"";
+    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH exec request rejected channel=%u command=%@; client should use plain SSH fallback", channelID, command]);
+    return WS_ERROR;
+}
+
+static BOOL FilzaWolfSSHChannelSend(WOLFSSH *ssh, WOLFSSH_CHANNEL *channel, NSString *text)
 {
     NSData *data = [text dataUsingEncoding:NSUTF8StringEncoding];
     const byte *bytes = data.bytes;
     NSUInteger offset = 0;
     while (offset < data.length) {
-        int sent = wolfSSH_stream_send(ssh, bytes + offset, (word32)MIN((NSUInteger)32768, data.length - offset));
+        int sent = wolfSSH_ChannelSend(channel, bytes + offset,
+                                      (word32)MIN((NSUInteger)32768, data.length - offset));
         if (sent > 0) {
             offset += (NSUInteger)sent;
             continue;
         }
-
         int error = wolfSSH_get_error(ssh);
-        if (!FilzaWolfSSHRetryable(sent, error)) {
-            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH shell send ended rc=%d error=%d", sent, error]);
-            return NO;
-        }
-
-        /* This is the same channel-driving pattern used by wolfSSH's official
-         * echoserver. It completes pending channel-open, PTY and shell requests. */
-        int worker = wolfSSH_worker(ssh, NULL);
+        if (!FilzaWolfSSHRetryable(sent, error)) return NO;
+        word32 ignoredChannel = 0;
+        int worker = wolfSSH_worker(ssh, &ignoredChannel);
         int workerError = wolfSSH_get_error(ssh);
-        if (worker == WS_CHANNEL_CLOSED || worker == WS_EOF || workerError == WS_EOF) return NO;
-        if (worker != WS_SUCCESS && !FilzaWolfSSHRetryable(worker, workerError)) {
-            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH shell channel setup ended rc=%d error=%d", worker, workerError]);
-            return NO;
-        }
+        if (worker == WS_EOF || workerError == WS_EOF || workerError == WS_SOCKET_ERROR_E) return NO;
+        if (worker != WS_SUCCESS && !FilzaWolfSSHRetryable(worker, workerError)) return NO;
     }
     return YES;
 }
@@ -517,43 +530,105 @@ static void FilzaWolfSSHServeSFTP(WOLFSSH *ssh)
     }
 }
 
+static void FilzaWolfSSHProcessChannelBytes(WOLFSSH *ssh,
+                                             WOLFSSH_CHANNEL *channel,
+                                             NSMutableData *line,
+                                             NSString **cwd,
+                                             const byte *buffer,
+                                             int count,
+                                             BOOL *closeChannel)
+{
+    for (int i = 0; i < count; i++) {
+        byte ch = buffer[i];
+        if (ch == '\r' || ch == '\n') {
+            if (!line.length) continue;
+            NSString *command = [[NSString alloc] initWithData:line encoding:NSUTF8StringEncoding] ?: @"";
+            [line setLength:0];
+            NSString *output = FilzaSSHExecute(command, cwd, closeChannel);
+            if (!FilzaWolfSSHChannelSend(ssh, channel, @"\r\n") ||
+                !FilzaWolfSSHChannelSend(ssh, channel, output)) {
+                *closeChannel = YES;
+                break;
+            }
+            if (!*closeChannel &&
+                !FilzaWolfSSHChannelSend(ssh, channel, [NSString stringWithFormat:@"filza:%@$ ", *cwd])) {
+                *closeChannel = YES;
+                break;
+            }
+        } else if (ch == 0x7f || ch == 0x08) {
+            if (line.length) [line setLength:line.length - 1];
+        } else if (ch >= 0x20 || ch == '\t') {
+            [line appendBytes:&ch length:1];
+        }
+    }
+}
+
 static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
 {
-    __block NSString *cwd = FilzaSSHInitialDirectory();
-    NSMutableData *line = NSMutableData.data;
-    if (!FilzaWolfSSHSend(ssh, @"Filza 27 wolfSSH\r\n") ||
-        !FilzaWolfSSHSend(ssh, [NSString stringWithFormat:@"filza:%@$ ", cwd])) return;
-    FilzaDiagnosticsAppend(@"SSH", @"wolfSSH interactive shell channel ready");
+    NSMutableDictionary<NSNumber *, NSMutableData *> *lines = NSMutableDictionary.dictionary;
+    NSMutableDictionary<NSNumber *, NSString *> *directories = NSMutableDictionary.dictionary;
     byte buffer[4096];
-    BOOL closeSession = NO;
-    while (!closeSession && atomic_load(&FilzaSSHRunning)) {
-        int rc = wolfSSH_stream_read(ssh, buffer, sizeof(buffer));
-        if (rc <= 0) {
-            int error = wolfSSH_get_error(ssh);
-            if (rc == WS_EOF || rc == WS_CHANNEL_CLOSED || error == WS_EOF) break;
-            if (FilzaWolfSSHRetryable(rc, error) || rc == WS_SUCCESS) continue;
-            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH shell read ended rc=%d error=%d", rc, error]);
+
+    while (atomic_load(&FilzaSSHRunning)) {
+        /* Initialize every shell channel, including channels Clauntty opens
+         * after its initial connection PTY. */
+        for (WOLFSSH_CHANNEL *channel = wolfSSH_ChannelNext(ssh, NULL), *next = NULL;
+             channel != NULL; channel = next) {
+            next = wolfSSH_ChannelNext(ssh, channel);
+            if (wolfSSH_ChannelGetSessionType(channel) != WOLFSSH_SESSION_SHELL) continue;
+            word32 channelID = 0;
+            if (wolfSSH_ChannelGetId(channel, &channelID, WS_CHANNEL_ID_SELF) != WS_SUCCESS) continue;
+            NSNumber *key = @(channelID);
+            if (lines[key]) continue;
+            lines[key] = NSMutableData.data;
+            directories[key] = FilzaSSHInitialDirectory();
+            if (!FilzaWolfSSHChannelSend(ssh, channel, @"Filza 27 wolfSSH\r\n") ||
+                !FilzaWolfSSHChannelSend(ssh, channel,
+                    [NSString stringWithFormat:@"filza:%@$ ", directories[key]])) {
+                [lines removeObjectForKey:key];
+                [directories removeObjectForKey:key];
+                continue;
+            }
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH interactive shell channel ready channel=%u", channelID]);
+        }
+
+        word32 channelID = 0;
+        int rc = wolfSSH_worker(ssh, &channelID);
+        int error = wolfSSH_get_error(ssh);
+        if (rc == WS_EOF || error == WS_EOF || error == WS_SOCKET_ERROR_E) break;
+        if (error == WS_CHANNEL_CLOSED) {
+            [lines removeObjectForKey:@(channelID)];
+            [directories removeObjectForKey:@(channelID)];
+            continue;
+        }
+        if (error != WS_CHAN_RXD) {
+            if (rc == WS_SUCCESS || FilzaWolfSSHRetryable(rc, error)) continue;
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH channel worker ended rc=%d error=%d", rc, error]);
             break;
         }
-        for (int i = 0; i < rc; i++) {
-            byte ch = buffer[i];
-            if (ch == '\r' || ch == '\n') {
-                if (!line.length) continue;
-                NSString *command = [[NSString alloc] initWithData:line encoding:NSUTF8StringEncoding] ?: @"";
-                [line setLength:0];
-                NSString *output = FilzaSSHExecute(command, &cwd, &closeSession);
-                if (!FilzaWolfSSHSend(ssh, @"\r\n") || !FilzaWolfSSHSend(ssh, output)) {
-                    closeSession = YES;
-                    break;
-                }
-                if (!closeSession && !FilzaWolfSSHSend(ssh, [NSString stringWithFormat:@"filza:%@$ ", cwd])) {
-                    closeSession = YES;
-                    break;
-                }
-            } else if (ch == 0x7f || ch == 0x08) {
-                if (line.length) [line setLength:line.length - 1];
-            } else if (ch >= 0x20 || ch == '\t') {
-                [line appendBytes:&ch length:1];
+
+        WOLFSSH_CHANNEL *channel = wolfSSH_ChannelFind(ssh, channelID, WS_CHANNEL_ID_SELF);
+        if (!channel) continue;
+        NSNumber *key = @(channelID);
+        NSMutableData *line = lines[key];
+        NSString *cwd = directories[key];
+        if (!line || !cwd) {
+            /* Drain data for rejected/non-shell channels so one channel cannot
+             * block the entire SSH transport. */
+            while (wolfSSH_ChannelRead(channel, buffer, sizeof(buffer)) > 0) {}
+            continue;
+        }
+
+        int count = 0;
+        while ((count = wolfSSH_ChannelRead(channel, buffer, sizeof(buffer))) > 0) {
+            BOOL closeChannel = NO;
+            FilzaWolfSSHProcessChannelBytes(ssh, channel, line, &cwd, buffer, count, &closeChannel);
+            directories[key] = cwd;
+            if (closeChannel) {
+                [lines removeObjectForKey:key];
+                [directories removeObjectForKey:key];
+                wolfSSH_ChannelExit(channel);
+                break;
             }
         }
     }
@@ -572,6 +647,8 @@ static void FilzaWolfSSHServeClient(int clientFD)
         WOLFSSH_CTX *ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
         if (!ctx) { FilzaDiagnosticsAppend(@"SSH", @"wolfSSH_CTX_new failed"); close(clientFD); return; }
         wolfSSH_SetUserAuth(ctx, FilzaWolfSSHUserAuth);
+        wolfSSH_CTX_SetChannelReqShellCb(ctx, FilzaWolfSSHChannelRequestShell);
+        wolfSSH_CTX_SetChannelReqExecCb(ctx, FilzaWolfSSHChannelRequestExec);
         wolfSSH_CTX_SetBanner(ctx, "Filza 27 wolfSSH server");
         if (wolfSSH_CTX_UsePrivateKey_buffer(ctx, hostKey.bytes, (word32)hostKey.length, WOLFSSH_FORMAT_ASN1) < 0) {
             FilzaDiagnosticsAppend(@"SSH", @"wolfSSH rejected persistent ECDSA host key");

--- a/FilzaWolfSSHServer.m
+++ b/FilzaWolfSSHServer.m
@@ -44,6 +44,91 @@ static int FilzaSSHListenFD = -1;
 static dispatch_once_t FilzaSSHInitOnce;
 static const void *FilzaSSHQueueKey = &FilzaSSHQueueKey;
 static NSString *FilzaSSHFailure;
+static AVAudioPlayer *FilzaSSHKeepAlivePlayer;
+static id FilzaSSHInterruptionObserver;
+static id FilzaSSHForegroundObserver;
+static id FilzaSSHBackgroundObserver;
+static _Atomic(bool) FilzaSSHKeepAliveActive = false;
+
+typedef struct __attribute__((packed)) {
+    char riff[4];
+    uint32_t riffSize;
+    char wave[4];
+    char fmt[4];
+    uint32_t fmtSize;
+    uint16_t audioFormat;
+    uint16_t channels;
+    uint32_t sampleRate;
+    uint32_t byteRate;
+    uint16_t blockAlign;
+    uint16_t bitsPerSample;
+    char data[4];
+    uint32_t dataSize;
+} FilzaSSHSilentWAVHeader;
+
+static NSData *FilzaSSHSilentAudioData(void)
+{
+    const uint32_t sampleRate = 8000;
+    const uint16_t channels = 1;
+    const uint16_t bits = 16;
+    const uint32_t dataSize = sampleRate * channels * (bits / 8);
+    FilzaSSHSilentWAVHeader header = {0};
+    memcpy(header.riff, "RIFF", 4);
+    header.riffSize = 36 + dataSize;
+    memcpy(header.wave, "WAVE", 4);
+    memcpy(header.fmt, "fmt ", 4);
+    header.fmtSize = 16;
+    header.audioFormat = 1;
+    header.channels = channels;
+    header.sampleRate = sampleRate;
+    header.byteRate = sampleRate * channels * (bits / 8);
+    header.blockAlign = channels * (bits / 8);
+    header.bitsPerSample = bits;
+    memcpy(header.data, "data", 4);
+    header.dataSize = dataSize;
+    NSMutableData *wav = [NSMutableData dataWithBytes:&header length:sizeof(header)];
+    [wav increaseLengthBy:dataSize];
+    return wav;
+}
+
+static BOOL FilzaSSHBackgroundKeepAliveStart(void)
+{
+    if (FilzaSSHKeepAlivePlayer.isPlaying) {
+        atomic_store(&FilzaSSHKeepAliveActive, true);
+        return YES;
+    }
+
+    NSError *error = nil;
+    AVAudioSession *session = AVAudioSession.sharedInstance;
+    if (![session setCategory:AVAudioSessionCategoryPlayback
+                         mode:AVAudioSessionModeDefault
+                      options:AVAudioSessionCategoryOptionMixWithOthers
+                        error:&error] ||
+        ![session setActive:YES error:&error]) {
+        atomic_store(&FilzaSSHKeepAliveActive, false);
+        FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"background keepalive audio session failed: %@", error.localizedDescription]);
+        return NO;
+    }
+
+    FilzaSSHKeepAlivePlayer = [[AVAudioPlayer alloc] initWithData:FilzaSSHSilentAudioData() error:&error];
+    FilzaSSHKeepAlivePlayer.numberOfLoops = -1;
+    FilzaSSHKeepAlivePlayer.volume = 0.01f;
+    [FilzaSSHKeepAlivePlayer prepareToPlay];
+    BOOL started = [FilzaSSHKeepAlivePlayer play];
+    atomic_store(&FilzaSSHKeepAliveActive, started);
+    FilzaDiagnosticsAppend(@"SSH", started
+        ? @"silent-audio background keepalive active for wolfSSH"
+        : [NSString stringWithFormat:@"background keepalive player failed: %@", error.localizedDescription ?: @"play returned NO"]);
+    return started;
+}
+
+static void FilzaSSHBackgroundKeepAliveStop(void)
+{
+    [FilzaSSHKeepAlivePlayer stop];
+    FilzaSSHKeepAlivePlayer = nil;
+    atomic_store(&FilzaSSHKeepAliveActive, false);
+    FilzaDiagnosticsAppend(@"SSH", @"wolfSSH background keepalive stopped");
+}
 
 static NSObject *FilzaSSHLock(void)
 {
@@ -87,6 +172,23 @@ static void FilzaSSHInitialize(void)
         FilzaSSHListenerQueue = dispatch_queue_create("com.nightvibes33.filza.wolfssh.listener", DISPATCH_QUEUE_SERIAL);
         dispatch_queue_set_specific(FilzaSSHListenerQueue, FilzaSSHQueueKey, (void *)FilzaSSHQueueKey, NULL);
         FilzaSSHClientQueue = dispatch_queue_create("com.nightvibes33.filza.wolfssh.clients", DISPATCH_QUEUE_CONCURRENT);
+        NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+        FilzaSSHInterruptionObserver = [center addObserverForName:AVAudioSessionInterruptionNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
+            AVAudioSessionInterruptionType type = [note.userInfo[AVAudioSessionInterruptionTypeKey] unsignedIntegerValue];
+            if (type == AVAudioSessionInterruptionTypeEnded && atomic_load(&FilzaSSHRunning))
+                dispatch_async(FilzaSSHListenerQueue, ^{ FilzaSSHBackgroundKeepAliveStart(); });
+        }];
+        FilzaSSHForegroundObserver = [center addObserverForName:UIApplicationDidBecomeActiveNotification object:nil queue:nil usingBlock:^(__unused NSNotification *note) {
+            if (atomic_load(&FilzaSSHRunning))
+                dispatch_async(FilzaSSHListenerQueue, ^{ FilzaSSHBackgroundKeepAliveStart(); });
+        }];
+        FilzaSSHBackgroundObserver = [center addObserverForName:UIApplicationDidEnterBackgroundNotification object:nil queue:nil usingBlock:^(__unused NSNotification *note) {
+            if (atomic_load(&FilzaSSHRunning))
+                dispatch_async(FilzaSSHListenerQueue, ^{
+                    BOOL active = FilzaSSHBackgroundKeepAliveStart();
+                    FilzaDiagnosticsAppend(@"SSH", active ? @"wolfSSH entered background with keepalive active" : @"wolfSSH entered background without keepalive");
+                });
+        }];
         int rc = wolfSSH_Init();
         FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH initialized rc=%d backend=wolfSSH SFTP=enabled", rc]);
     });
@@ -533,6 +635,7 @@ BOOL FilzaSSHServerStart(NSError **error)
             [FilzaSSHBonjourService publish];
         }
         FilzaSSHClearFailure();
+        FilzaSSHBackgroundKeepAliveStart();
         NSString *lan = FilzaSSHServerLANAddress() ?: @"0.0.0.0";
         NSString *summary = [NSString stringWithFormat:@"wolfSSH SSH/SFTP server listening address=%@ port=%ld auth=%@ backend=wolfSSH", lan, (long)FilzaSSHConfiguredPort(), FilzaSSHAuthenticationEnabled() ? @"YES" : @"NO"];
         FilzaDiagnosticsAppend(@"SSH", summary);
@@ -550,6 +653,7 @@ void FilzaSSHServerStop(void)
         if (FilzaSSHBonjourService) { [FilzaSSHBonjourService stop]; FilzaSSHBonjourService = nil; }
         if (FilzaSSHAcceptSource) { dispatch_source_cancel(FilzaSSHAcceptSource); FilzaSSHAcceptSource = nil; }
         if (FilzaSSHListenFD >= 0) { close(FilzaSSHListenFD); FilzaSSHListenFD = -1; }
+        FilzaSSHBackgroundKeepAliveStop();
         FilzaDiagnosticsAppend(@"SSH", @"wolfSSH listener stopped");
     });
 }
@@ -577,6 +681,6 @@ NSString *FilzaSSHServerConnectionSummary(void)
     NSString *address = FilzaSSHServerLANAddress() ?: @"iPhone";
     NSInteger port = FilzaSSHConfiguredPort();
     NSString *user = FilzaSSHConfiguredUsername();
-    return [NSString stringWithFormat:@"wolfSSH + SFTP listening\nssh://%@:%ld\nssh %@@%@ -p %ld\nsftp -P %ld %@@%@",
-            address, (long)port, user, address, (long)port, (long)port, user, address];
+    return [NSString stringWithFormat:@"wolfSSH + SFTP listening — background=%@\nSame iPhone: ssh %@@127.0.0.1 -p %ld\nLAN: ssh %@@%@ -p %ld\nSFTP: sftp -P %ld %@@%@",
+            atomic_load(&FilzaSSHKeepAliveActive) ? @"ON" : @"OFF", user, (long)port, user, address, (long)port, (long)port, user, address];
 }

--- a/FilzaWolfSSHServer.m
+++ b/FilzaWolfSSHServer.m
@@ -576,6 +576,7 @@ static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
 {
     NSMutableDictionary<NSNumber *, NSMutableData *> *lines = NSMutableDictionary.dictionary;
     NSMutableDictionary<NSNumber *, NSString *> *directories = NSMutableDictionary.dictionary;
+    NSUInteger pendingLocalChannelCloseReplies = 0;
     byte buffer[4096];
 
     while (atomic_load(&FilzaSSHRunning)) {
@@ -589,7 +590,9 @@ static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
                 word32 execChannelID = 0;
                 wolfSSH_ChannelGetId(channel, &execChannelID, WS_CHANNEL_ID_SELF);
                 FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH rejected exec channel closed channel=%u", execChannelID]);
-                wolfSSH_ChannelExit(channel);
+                if (wolfSSH_ChannelExit(channel) == WS_SUCCESS) {
+                    pendingLocalChannelCloseReplies++;
+                }
                 continue;
             }
             if (sessionType != WOLFSSH_SESSION_SHELL) continue;
@@ -613,12 +616,21 @@ static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
         int rc = wolfSSH_worker(ssh, &channelID);
         int error = wolfSSH_get_error(ssh);
         if (rc == WS_EOF || error == WS_EOF || error == WS_SOCKET_ERROR_E) break;
-        if (error == WS_CHANNEL_CLOSED) {
+        /* wolfSSH_ChannelExit() removes the local channel immediately. The
+         * peer's RFC 4254 close acknowledgement then arrives for that removed
+         * ID and wolfSSH reports WS_INVALID_CHANID. It is transport progress,
+         * not a connection failure; keep driving the remaining channels. */
+        if (error == WS_INVALID_CHANID && pendingLocalChannelCloseReplies > 0) {
+            pendingLocalChannelCloseReplies--;
+            FilzaDiagnosticsAppend(@"SSH", @"wolfSSH consumed stale close acknowledgement after local channel exit");
+            continue;
+        }
+        if (rc == WS_CHANNEL_CLOSED || error == WS_CHANNEL_CLOSED) {
             [lines removeObjectForKey:@(channelID)];
             [directories removeObjectForKey:@(channelID)];
             continue;
         }
-        if (error != WS_CHAN_RXD) {
+        if (rc != WS_CHAN_RXD && error != WS_CHAN_RXD) {
             if (rc == WS_SUCCESS || FilzaWolfSSHRetryable(rc, error)) continue;
             FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH channel worker ended rc=%d error=%d", rc, error]);
             break;
@@ -644,7 +656,9 @@ static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
             if (closeChannel) {
                 [lines removeObjectForKey:key];
                 [directories removeObjectForKey:key];
-                wolfSSH_ChannelExit(channel);
+                if (wolfSSH_ChannelExit(channel) == WS_SUCCESS) {
+                    pendingLocalChannelCloseReplies++;
+                }
                 break;
             }
         }

--- a/FilzaWolfSSHServer.m
+++ b/FilzaWolfSSHServer.m
@@ -1,0 +1,581 @@
+@import Foundation;
+@import Security;
+@import UIKit;
+
+#import <CommonCrypto/CommonKeyDerivation.h>
+#import <arpa/inet.h>
+#import <errno.h>
+#import <fcntl.h>
+#import <ifaddrs.h>
+#import <net/if.h>
+#import <netinet/in.h>
+#import <objc/message.h>
+#import <stdatomic.h>
+#import <sys/socket.h>
+#import <sys/stat.h>
+#import <sys/utsname.h>
+#import <unistd.h>
+
+#include <wolfssl/wolfcrypt/asn.h>
+#include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/random.h>
+#include <wolfssh/ssh.h>
+#include <wolfssh/wolfsftp.h>
+
+#import "FilzaDiagnostics.h"
+#import "FilzaSSHServer.h"
+
+NSString * const FilzaSSHEnabledKey = @"filza-ssh-enabled";
+NSString * const FilzaSSHPortKey = @"filza-ssh-port";
+NSString * const FilzaSSHBonjourKey = @"filza-ssh-bonjour";
+NSString * const FilzaSSHAuthenticationKey = @"filza-ssh-authentication";
+NSString * const FilzaSSHUsernameKey = @"filza-ssh-username";
+NSString * const FilzaSSHPasswordSaltKey = @"filza-ssh-password-salt";
+NSString * const FilzaSSHPasswordHashKey = @"filza-ssh-password-pbkdf2";
+
+static NSString * const FilzaSSHErrorDomain = @"FilzaWolfSSH";
+static dispatch_queue_t FilzaSSHListenerQueue;
+static dispatch_queue_t FilzaSSHClientQueue;
+static dispatch_source_t FilzaSSHAcceptSource;
+static NSNetService *FilzaSSHBonjourService;
+static _Atomic(bool) FilzaSSHRunning = false;
+static int FilzaSSHListenFD = -1;
+static dispatch_once_t FilzaSSHInitOnce;
+static const void *FilzaSSHQueueKey = &FilzaSSHQueueKey;
+static NSString *FilzaSSHFailure;
+
+static NSObject *FilzaSSHLock(void)
+{
+    static NSObject *lock;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ lock = NSObject.new; });
+    return lock;
+}
+
+static void FilzaSSHWriteStatus(NSString *message)
+{
+    NSString *path = [FilzaDiagnosticsDirectory() stringByAppendingPathComponent:@"SSHStatus.txt"];
+    NSString *timestamp = [NSISO8601DateFormatter.new stringFromDate:NSDate.date] ?: NSDate.date.description;
+    [[NSString stringWithFormat:@"%@\n%@\n", timestamp, message ?: @"unknown"]
+        writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
+}
+
+static void FilzaSSHSetFailure(NSString *message)
+{
+    @synchronized (FilzaSSHLock()) { FilzaSSHFailure = [message copy]; }
+    if (!message.length) return;
+    FilzaDiagnosticsAppend(@"SSH", message);
+    FilzaSSHWriteStatus(message);
+}
+
+static void FilzaSSHClearFailure(void)
+{
+    @synchronized (FilzaSSHLock()) { FilzaSSHFailure = nil; }
+}
+
+static void FilzaSSHInitialize(void)
+{
+    dispatch_once(&FilzaSSHInitOnce, ^{
+        [NSUserDefaults.standardUserDefaults registerDefaults:@{
+            FilzaSSHEnabledKey: @NO,
+            FilzaSSHPortKey: @2222,
+            FilzaSSHBonjourKey: @YES,
+            FilzaSSHAuthenticationKey: @YES,
+            FilzaSSHUsernameKey: @"filza"
+        }];
+        FilzaSSHListenerQueue = dispatch_queue_create("com.nightvibes33.filza.wolfssh.listener", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_set_specific(FilzaSSHListenerQueue, FilzaSSHQueueKey, (void *)FilzaSSHQueueKey, NULL);
+        FilzaSSHClientQueue = dispatch_queue_create("com.nightvibes33.filza.wolfssh.clients", DISPATCH_QUEUE_CONCURRENT);
+        int rc = wolfSSH_Init();
+        FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH initialized rc=%d backend=wolfSSH SFTP=enabled", rc]);
+    });
+}
+
+static void FilzaSSHSync(dispatch_block_t block)
+{
+    FilzaSSHInitialize();
+    if (dispatch_get_specific(FilzaSSHQueueKey)) block();
+    else dispatch_sync(FilzaSSHListenerQueue, block);
+}
+
+NSInteger FilzaSSHConfiguredPort(void)
+{
+    FilzaSSHInitialize();
+    NSInteger port = [NSUserDefaults.standardUserDefaults integerForKey:FilzaSSHPortKey];
+    return (port >= 1 && port <= 65535) ? port : 2222;
+}
+
+BOOL FilzaSSHBonjourEnabled(void)
+{
+    FilzaSSHInitialize();
+    return [NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHBonjourKey];
+}
+
+BOOL FilzaSSHAuthenticationEnabled(void)
+{
+    FilzaSSHInitialize();
+    return [NSUserDefaults.standardUserDefaults boolForKey:FilzaSSHAuthenticationKey];
+}
+
+NSString *FilzaSSHConfiguredUsername(void)
+{
+    FilzaSSHInitialize();
+    NSString *name = [NSUserDefaults.standardUserDefaults stringForKey:FilzaSSHUsernameKey];
+    name = [name stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    return name.length ? name : @"filza";
+}
+
+static NSData *FilzaSSHDecodeDefault(NSString *key)
+{
+    NSString *text = [NSUserDefaults.standardUserDefaults stringForKey:key];
+    return text.length ? [[NSData alloc] initWithBase64EncodedString:text options:0] : nil;
+}
+
+static NSData *FilzaSSHDerivePassword(NSString *password, NSData *salt)
+{
+    if (!password || salt.length < 16) return nil;
+    NSMutableData *derived = [NSMutableData dataWithLength:32];
+    int rc = CCKeyDerivationPBKDF(kCCPBKDF2,
+                                  password.UTF8String,
+                                  [password lengthOfBytesUsingEncoding:NSUTF8StringEncoding],
+                                  salt.bytes,
+                                  salt.length,
+                                  kCCPRFHmacAlgSHA256,
+                                  120000,
+                                  derived.mutableBytes,
+                                  derived.length);
+    return rc == kCCSuccess ? derived : nil;
+}
+
+static BOOL FilzaSSHConstantTimeEqual(NSData *left, NSData *right)
+{
+    if (!left || !right || left.length != right.length) return NO;
+    const uint8_t *a = left.bytes, *b = right.bytes;
+    uint8_t difference = 0;
+    for (NSUInteger i = 0; i < left.length; i++) difference |= a[i] ^ b[i];
+    return difference == 0;
+}
+
+BOOL FilzaSSHPasswordConfigured(void)
+{
+    return FilzaSSHDecodeDefault(FilzaSSHPasswordSaltKey).length >= 16 &&
+           FilzaSSHDecodeDefault(FilzaSSHPasswordHashKey).length == 32;
+}
+
+BOOL FilzaSSHStorePassword(NSString *password, NSError **error)
+{
+    FilzaSSHInitialize();
+    if (password.length < 6) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:10 userInfo:@{NSLocalizedDescriptionKey: @"SSH password must contain at least 6 characters."}];
+        return NO;
+    }
+    uint8_t saltBytes[32];
+    if (SecRandomCopyBytes(kSecRandomDefault, sizeof(saltBytes), saltBytes) != errSecSuccess) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:11 userInfo:@{NSLocalizedDescriptionKey: @"Could not generate a secure password salt."}];
+        return NO;
+    }
+    NSData *salt = [NSData dataWithBytes:saltBytes length:sizeof(saltBytes)];
+    NSData *hash = FilzaSSHDerivePassword(password, salt);
+    if (!hash) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:12 userInfo:@{NSLocalizedDescriptionKey: @"Could not derive the SSH password verifier."}];
+        return NO;
+    }
+    [NSUserDefaults.standardUserDefaults setObject:[salt base64EncodedStringWithOptions:0] forKey:FilzaSSHPasswordSaltKey];
+    [NSUserDefaults.standardUserDefaults setObject:[hash base64EncodedStringWithOptions:0] forKey:FilzaSSHPasswordHashKey];
+    FilzaDiagnosticsAppend(@"SSH", @"wolfSSH password verifier updated using PBKDF2-HMAC-SHA256");
+    return YES;
+}
+
+static NSString *FilzaSSHHostKeyPath(void)
+{
+    NSString *root = [NSFileManager.defaultManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask].firstObject.path;
+    if (!root.length) root = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Application Support"];
+    NSString *directory = [root stringByAppendingPathComponent:@"FilzaSSH"];
+    [NSFileManager.defaultManager createDirectoryAtPath:directory
+                            withIntermediateDirectories:YES
+                                             attributes:@{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication}
+                                                  error:nil];
+    return [directory stringByAppendingPathComponent:@"wolfssh_host_ecc.der"];
+}
+
+static NSData *FilzaSSHHostKey(NSError **error)
+{
+    NSString *path = FilzaSSHHostKeyPath();
+    NSData *existing = [NSData dataWithContentsOfFile:path];
+    if (existing.length > 32) return existing;
+
+    WC_RNG rng;
+    ecc_key key;
+    XMEMSET(&rng, 0, sizeof(rng));
+    XMEMSET(&key, 0, sizeof(key));
+    int rc = wc_InitRng(&rng);
+    if (rc == 0) rc = wc_ecc_init(&key);
+    if (rc == 0) rc = wc_ecc_make_key(&rng, 32, &key);
+    byte der[2048];
+    int derSz = rc == 0 ? wc_EccKeyToDer(&key, der, (word32)sizeof(der)) : rc;
+    wc_ecc_free(&key);
+    wc_FreeRng(&rng);
+    if (derSz <= 0) {
+        if (error) *error = [NSError errorWithDomain:FilzaSSHErrorDomain code:20 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"wolfCrypt could not generate host key (%d).", derSz]}];
+        return nil;
+    }
+    NSData *data = [NSData dataWithBytes:der length:(NSUInteger)derSz];
+    if (![data writeToFile:path options:NSDataWritingAtomic error:error]) return nil;
+    chmod(path.fileSystemRepresentation, S_IRUSR | S_IWUSR);
+    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"generated persistent wolfSSH ECDSA host key at %@", path]);
+    return data;
+}
+
+NSString *FilzaSSHServerLANAddress(void)
+{
+    struct ifaddrs *list = NULL;
+    if (getifaddrs(&list) != 0 || !list) return nil;
+    NSString *fallback = nil, *preferred = nil;
+    for (struct ifaddrs *cursor = list; cursor; cursor = cursor->ifa_next) {
+        if (!cursor->ifa_addr || cursor->ifa_addr->sa_family != AF_INET) continue;
+        if (!(cursor->ifa_flags & IFF_UP) || (cursor->ifa_flags & IFF_LOOPBACK)) continue;
+        char buffer[INET_ADDRSTRLEN] = {0};
+        struct sockaddr_in *address = (struct sockaddr_in *)cursor->ifa_addr;
+        if (!inet_ntop(AF_INET, &address->sin_addr, buffer, sizeof(buffer))) continue;
+        NSString *value = [NSString stringWithUTF8String:buffer];
+        if (!fallback) fallback = value;
+        if (cursor->ifa_name && strcmp(cursor->ifa_name, "en0") == 0) { preferred = value; break; }
+    }
+    freeifaddrs(list);
+    return preferred ?: fallback;
+}
+
+static NSString *FilzaSSHInitialDirectory(void)
+{
+    Class cls = NSClassFromString(@"TGPreferences");
+    SEL shared = NSSelectorFromString(@"sharedInstance");
+    id prefs = (cls && [cls respondsToSelector:shared]) ? ((id (*)(id, SEL))objc_msgSend)(cls, shared) : nil;
+    SEL uploader = NSSelectorFromString(@"uploaderPath");
+    NSString *candidate = (prefs && [prefs respondsToSelector:uploader]) ? ((id (*)(id, SEL))objc_msgSend)(prefs, uploader) : nil;
+    BOOL directory = NO;
+    if ([candidate isKindOfClass:NSString.class] && [NSFileManager.defaultManager fileExistsAtPath:candidate isDirectory:&directory] && directory)
+        return candidate;
+    NSString *documents = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+    return documents.length ? documents : NSHomeDirectory();
+}
+
+static int FilzaWolfSSHUserAuth(byte authType, WS_UserAuthData *authData, void *ctx)
+{
+    (void)ctx;
+    if (!authData) return WOLFSSH_USERAUTH_FAILURE;
+    if (!FilzaSSHAuthenticationEnabled()) return WOLFSSH_USERAUTH_SUCCESS;
+    if (authType != WOLFSSH_USERAUTH_PASSWORD) return WOLFSSH_USERAUTH_FAILURE;
+
+    NSData *usernameData = [NSData dataWithBytes:authData->username length:authData->usernameSz];
+    NSString *username = [[NSString alloc] initWithData:usernameData encoding:NSUTF8StringEncoding];
+    if (![username isEqualToString:FilzaSSHConfiguredUsername()]) return WOLFSSH_USERAUTH_FAILURE;
+
+    NSData *passwordData = [NSData dataWithBytes:authData->sf.password.password length:authData->sf.password.passwordSz];
+    NSString *password = [[NSString alloc] initWithData:passwordData encoding:NSUTF8StringEncoding];
+    NSData *salt = FilzaSSHDecodeDefault(FilzaSSHPasswordSaltKey);
+    NSData *expected = FilzaSSHDecodeDefault(FilzaSSHPasswordHashKey);
+    NSData *actual = password ? FilzaSSHDerivePassword(password, salt) : nil;
+    return FilzaSSHConstantTimeEqual(actual, expected) ? WOLFSSH_USERAUTH_SUCCESS : WOLFSSH_USERAUTH_FAILURE;
+}
+
+static NSArray<NSString *> *FilzaSSHTokens(NSString *command)
+{
+    NSMutableArray<NSString *> *tokens = NSMutableArray.array;
+    for (NSString *part in [command componentsSeparatedByCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet])
+        if (part.length) [tokens addObject:part];
+    return tokens;
+}
+
+static NSString *FilzaSSHResolve(NSString *operand, NSString *cwd)
+{
+    if (!operand.length || [operand isEqualToString:@"."]) return cwd;
+    if ([operand isEqualToString:@"~"]) return FilzaSSHInitialDirectory();
+    if ([operand hasPrefix:@"~/"]) return [[FilzaSSHInitialDirectory() stringByAppendingPathComponent:[operand substringFromIndex:2]] stringByStandardizingPath];
+    if ([operand hasPrefix:@"/"]) return operand.stringByStandardizingPath;
+    return [[cwd stringByAppendingPathComponent:operand] stringByStandardizingPath];
+}
+
+static NSString *FilzaSSHExecute(NSString *command, NSString **cwd, BOOL *shouldClose)
+{
+    NSArray<NSString *> *args = FilzaSSHTokens(command ?: @"");
+    if (!args.count) return @"";
+    NSString *name = args[0];
+    NSFileManager *fm = NSFileManager.defaultManager;
+    NSString *current = *cwd ?: FilzaSSHInitialDirectory();
+
+    if ([name isEqualToString:@"help"]) return @"Commands: pwd cd ls cat mkdir touch cp mv rm whoami id uname echo help exit\r\nSFTP is provided by wolfSSH. Filesystem access equals the Filza process.\r\n";
+    if ([name isEqualToString:@"exit"] || [name isEqualToString:@"logout"]) { if (shouldClose) *shouldClose = YES; return @"logout\r\n"; }
+    if ([name isEqualToString:@"pwd"]) return [current stringByAppendingString:@"\r\n"];
+    if ([name isEqualToString:@"whoami"]) return [FilzaSSHConfiguredUsername() stringByAppendingString:@"\r\n"];
+    if ([name isEqualToString:@"id"]) return [NSString stringWithFormat:@"uid=%u gid=%u euid=%u egid=%u\r\n", getuid(), getgid(), geteuid(), getegid()];
+    if ([name isEqualToString:@"uname"]) { struct utsname info = {0}; return uname(&info) == 0 ? [NSString stringWithFormat:@"%s %s %s %s %s\r\n", info.sysname, info.nodename, info.release, info.version, info.machine] : @"uname failed\r\n"; }
+    if ([name isEqualToString:@"echo"]) return [NSString stringWithFormat:@"%@\r\n", args.count > 1 ? [[args subarrayWithRange:NSMakeRange(1, args.count - 1)] componentsJoinedByString:@" "] : @""];
+    if ([name isEqualToString:@"cd"]) {
+        NSString *path = FilzaSSHResolve(args.count > 1 ? args[1] : @"~", current); BOOL dir = NO;
+        if (![fm fileExistsAtPath:path isDirectory:&dir] || !dir) return [NSString stringWithFormat:@"cd: %@: inaccessible\r\n", path];
+        *cwd = path; return @"";
+    }
+    if ([name isEqualToString:@"ls"]) {
+        NSString *path = FilzaSSHResolve(args.count > 1 ? args[1] : @".", current); BOOL dir = NO;
+        if (![fm fileExistsAtPath:path isDirectory:&dir]) return [NSString stringWithFormat:@"ls: %@: inaccessible\r\n", path];
+        NSArray *items = dir ? [fm contentsOfDirectoryAtPath:path error:nil] : @[path.lastPathComponent];
+        return [[[items sortedArrayUsingSelector:@selector(localizedStandardCompare:)] componentsJoinedByString:@"\r\n"] stringByAppendingString:@"\r\n"];
+    }
+    if ([name isEqualToString:@"cat"] && args.count > 1) {
+        NSString *path = FilzaSSHResolve(args[1], current);
+        NSData *data = [NSData dataWithContentsOfFile:path];
+        if (!data) return [NSString stringWithFormat:@"cat: %@: inaccessible\r\n", path];
+        if (data.length > 16ULL * 1024ULL * 1024ULL) return @"cat: file exceeds 16 MiB limit\r\n";
+        NSString *text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        return text ? [text stringByAppendingString:@"\r\n"] : @"cat: binary/non-UTF8 data\r\n";
+    }
+    if ([name isEqualToString:@"mkdir"] && args.count > 1) {
+        NSString *path = FilzaSSHResolve(args[1], current); NSError *error = nil;
+        return [fm createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:&error] ? @"" : [NSString stringWithFormat:@"mkdir: %@\r\n", error.localizedDescription];
+    }
+    if ([name isEqualToString:@"touch"] && args.count > 1) {
+        NSString *path = FilzaSSHResolve(args[1], current); int fd = open(path.fileSystemRepresentation, O_WRONLY | O_CREAT, 0644);
+        if (fd < 0) return [NSString stringWithFormat:@"touch: %s\r\n", strerror(errno)]; close(fd); return @"";
+    }
+    if (([name isEqualToString:@"cp"] || [name isEqualToString:@"mv"]) && args.count > 2) {
+        NSString *src = FilzaSSHResolve(args[1], current), *dst = FilzaSSHResolve(args[2], current); NSError *error = nil;
+        BOOL ok = [name isEqualToString:@"cp"] ? [fm copyItemAtPath:src toPath:dst error:&error] : [fm moveItemAtPath:src toPath:dst error:&error];
+        return ok ? @"" : [NSString stringWithFormat:@"%@: %@\r\n", name, error.localizedDescription];
+    }
+    if ([name isEqualToString:@"rm"] && args.count > 1) {
+        NSString *path = FilzaSSHResolve(args.lastObject, current); NSError *error = nil;
+        return [fm removeItemAtPath:path error:&error] ? @"" : [NSString stringWithFormat:@"rm: %@\r\n", error.localizedDescription];
+    }
+    return [NSString stringWithFormat:@"%@: command not found (type help)\r\n", name];
+}
+
+static void FilzaWolfSSHSend(WOLFSSH *ssh, NSString *text)
+{
+    NSData *data = [text dataUsingEncoding:NSUTF8StringEncoding];
+    const byte *bytes = data.bytes;
+    NSUInteger offset = 0;
+    while (offset < data.length) {
+        int sent = wolfSSH_stream_send(ssh, bytes + offset, (word32)MIN((NSUInteger)32768, data.length - offset));
+        if (sent <= 0) break;
+        offset += (NSUInteger)sent;
+    }
+}
+
+static void FilzaWolfSSHServeSFTP(WOLFSSH *ssh)
+{
+    NSString *root = FilzaSSHInitialDirectory();
+    int setup = wolfSSH_SFTP_SetDefaultPath(ssh, root.fileSystemRepresentation);
+    if (setup != WS_SUCCESS) {
+        FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH SFTP default path setup failed rc=%d", setup]);
+        return;
+    }
+    FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH SFTP session active root=%@", root]);
+    for (;;) {
+        int rc = wolfSSH_SFTP_read(ssh);
+        if (rc == WS_EOF) break;
+        if (rc == WS_SUCCESS || rc == WS_WANT_READ || rc == WS_WANT_WRITE || rc == WS_CHAN_RXD || rc == WS_REKEYING) continue;
+        if (rc < 0) {
+            int error = wolfSSH_get_error(ssh);
+            if (error == WS_WANT_READ || error == WS_WANT_WRITE || error == WS_CHAN_RXD || error == WS_REKEYING) continue;
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH SFTP loop ended rc=%d error=%d", rc, error]);
+            break;
+        }
+    }
+}
+
+static void FilzaWolfSSHServeShell(WOLFSSH *ssh)
+{
+    __block NSString *cwd = FilzaSSHInitialDirectory();
+    NSMutableData *line = NSMutableData.data;
+    FilzaWolfSSHSend(ssh, @"Filza 27 wolfSSH\r\n");
+    FilzaWolfSSHSend(ssh, [NSString stringWithFormat:@"filza:%@$ ", cwd]);
+    byte buffer[4096];
+    BOOL closeSession = NO;
+    while (!closeSession && atomic_load(&FilzaSSHRunning)) {
+        int rc = wolfSSH_stream_read(ssh, buffer, sizeof(buffer));
+        if (rc <= 0) break;
+        for (int i = 0; i < rc; i++) {
+            byte ch = buffer[i];
+            if (ch == '\r' || ch == '\n') {
+                if (!line.length) continue;
+                NSString *command = [[NSString alloc] initWithData:line encoding:NSUTF8StringEncoding] ?: @"";
+                [line setLength:0];
+                NSString *output = FilzaSSHExecute(command, &cwd, &closeSession);
+                FilzaWolfSSHSend(ssh, @"\r\n");
+                FilzaWolfSSHSend(ssh, output);
+                if (!closeSession) FilzaWolfSSHSend(ssh, [NSString stringWithFormat:@"filza:%@$ ", cwd]);
+            } else if (ch == 0x7f || ch == 0x08) {
+                if (line.length) [line setLength:line.length - 1];
+            } else if (ch >= 0x20 || ch == '\t') {
+                [line appendBytes:&ch length:1];
+            }
+        }
+    }
+}
+
+static void FilzaWolfSSHServeClient(int clientFD)
+{
+    @autoreleasepool {
+        NSError *keyError = nil;
+        NSData *hostKey = FilzaSSHHostKey(&keyError);
+        if (!hostKey.length) {
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH client rejected: host key unavailable %@", keyError.localizedDescription]);
+            close(clientFD); return;
+        }
+
+        WOLFSSH_CTX *ctx = wolfSSH_CTX_new(WOLFSSH_ENDPOINT_SERVER, NULL);
+        if (!ctx) { FilzaDiagnosticsAppend(@"SSH", @"wolfSSH_CTX_new failed"); close(clientFD); return; }
+        wolfSSH_SetUserAuth(ctx, FilzaWolfSSHUserAuth);
+        wolfSSH_CTX_SetBanner(ctx, "Filza 27 wolfSSH server");
+        if (wolfSSH_CTX_UsePrivateKey_buffer(ctx, hostKey.bytes, (word32)hostKey.length, WOLFSSH_FORMAT_ASN1) < 0) {
+            FilzaDiagnosticsAppend(@"SSH", @"wolfSSH rejected persistent ECDSA host key");
+            wolfSSH_CTX_free(ctx); close(clientFD); return;
+        }
+
+        WOLFSSH *ssh = wolfSSH_new(ctx);
+        if (!ssh) { wolfSSH_CTX_free(ctx); close(clientFD); return; }
+        wolfSSH_SetUserAuthCtx(ssh, NULL);
+        wolfSSH_set_fd(ssh, clientFD);
+        int rc = wolfSSH_accept(ssh);
+        if (rc == WS_SUCCESS) {
+            FilzaDiagnosticsAppend(@"SSH", @"wolfSSH authenticated shell session accepted");
+            FilzaWolfSSHServeShell(ssh);
+        } else if (rc == WS_SFTP_COMPLETE) {
+            FilzaDiagnosticsAppend(@"SSH", @"wolfSSH authenticated SFTP subsystem accepted");
+            FilzaWolfSSHServeSFTP(ssh);
+        } else {
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH_accept failed rc=%d error=%d", rc, wolfSSH_get_error(ssh)]);
+        }
+        wolfSSH_shutdown(ssh);
+        wolfSSH_free(ssh);
+        wolfSSH_CTX_free(ctx);
+        close(clientFD);
+        FilzaDiagnosticsAppend(@"SSH", @"wolfSSH client session closed");
+    }
+}
+
+static void FilzaWolfSSHAcceptAvailable(void)
+{
+    if (!atomic_load(&FilzaSSHRunning) || FilzaSSHListenFD < 0) return;
+    for (;;) {
+        struct sockaddr_storage peer = {0};
+        socklen_t peerLen = sizeof(peer);
+        int fd = accept(FilzaSSHListenFD, (struct sockaddr *)&peer, &peerLen);
+        if (fd < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+            FilzaDiagnosticsAppend(@"SSH", [NSString stringWithFormat:@"wolfSSH accept() failed: %s", strerror(errno)]);
+            break;
+        }
+        int flags = fcntl(fd, F_GETFL, 0);
+        if (flags >= 0) fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+#ifdef SO_NOSIGPIPE
+        int one = 1; setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+#endif
+        dispatch_async(FilzaSSHClientQueue, ^{ FilzaWolfSSHServeClient(fd); });
+    }
+}
+
+BOOL FilzaSSHServerStart(NSError **error)
+{
+    __block BOOL success = NO;
+    __block NSError *failure = nil;
+    FilzaSSHSync(^{
+        if (atomic_load(&FilzaSSHRunning)) { success = YES; return; }
+        if (FilzaSSHAuthenticationEnabled() && !FilzaSSHPasswordConfigured()) {
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:30 userInfo:@{NSLocalizedDescriptionKey: @"Authentication is enabled but no SSH password is configured."}];
+            FilzaSSHSetFailure(failure.localizedDescription); return;
+        }
+        NSError *keyError = nil;
+        if (!FilzaSSHHostKey(&keyError).length) { failure = keyError; FilzaSSHSetFailure(failure.localizedDescription); return; }
+
+        int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+        if (fd < 0) {
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:31 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"socket() failed: %s", strerror(errno)]}];
+            FilzaSSHSetFailure(failure.localizedDescription); return;
+        }
+        int one = 1;
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+#ifdef SO_NOSIGPIPE
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one));
+#endif
+        struct sockaddr_in address = {0};
+        address.sin_len = sizeof(address);
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_ANY);
+        address.sin_port = htons((uint16_t)FilzaSSHConfiguredPort());
+        if (bind(fd, (struct sockaddr *)&address, sizeof(address)) != 0 || listen(fd, 16) != 0) {
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:32 userInfo:@{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"wolfSSH listener failed on port %ld: %s", (long)FilzaSSHConfiguredPort(), strerror(errno)]}];
+            close(fd); FilzaSSHSetFailure(failure.localizedDescription); return;
+        }
+        int flags = fcntl(fd, F_GETFL, 0);
+        if (flags >= 0) fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+        struct sockaddr_in verified = {0}; socklen_t verifiedLen = sizeof(verified);
+        if (getsockname(fd, (struct sockaddr *)&verified, &verifiedLen) != 0 || ntohs(verified.sin_port) != FilzaSSHConfiguredPort()) {
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:33 userInfo:@{NSLocalizedDescriptionKey: @"wolfSSH listener could not verify its bound port."}];
+            close(fd); FilzaSSHSetFailure(failure.localizedDescription); return;
+        }
+
+        FilzaSSHListenFD = fd;
+        atomic_store(&FilzaSSHRunning, true);
+        FilzaSSHAcceptSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, (uintptr_t)fd, 0, FilzaSSHListenerQueue);
+        if (!FilzaSSHAcceptSource) {
+            atomic_store(&FilzaSSHRunning, false); FilzaSSHListenFD = -1; close(fd);
+            failure = [NSError errorWithDomain:FilzaSSHErrorDomain code:34 userInfo:@{NSLocalizedDescriptionKey: @"Could not create wolfSSH listener dispatch source."}];
+            FilzaSSHSetFailure(failure.localizedDescription); return;
+        }
+        dispatch_source_set_event_handler(FilzaSSHAcceptSource, ^{ FilzaWolfSSHAcceptAvailable(); });
+        dispatch_resume(FilzaSSHAcceptSource);
+
+        if (FilzaSSHBonjourEnabled()) {
+            FilzaSSHBonjourService = [[NSNetService alloc] initWithDomain:@"local." type:@"_ssh._tcp." name:@"Filza SSH" port:(int)FilzaSSHConfiguredPort()];
+            [FilzaSSHBonjourService publish];
+        }
+        FilzaSSHClearFailure();
+        NSString *lan = FilzaSSHServerLANAddress() ?: @"0.0.0.0";
+        NSString *summary = [NSString stringWithFormat:@"wolfSSH SSH/SFTP server listening address=%@ port=%ld auth=%@ backend=wolfSSH", lan, (long)FilzaSSHConfiguredPort(), FilzaSSHAuthenticationEnabled() ? @"YES" : @"NO"];
+        FilzaDiagnosticsAppend(@"SSH", summary);
+        FilzaSSHWriteStatus(summary);
+        success = YES;
+    });
+    if (!success && error) *error = failure ?: [NSError errorWithDomain:FilzaSSHErrorDomain code:99 userInfo:@{NSLocalizedDescriptionKey: @"wolfSSH server failed to start."}];
+    return success;
+}
+
+void FilzaSSHServerStop(void)
+{
+    FilzaSSHSync(^{
+        atomic_store(&FilzaSSHRunning, false);
+        if (FilzaSSHBonjourService) { [FilzaSSHBonjourService stop]; FilzaSSHBonjourService = nil; }
+        if (FilzaSSHAcceptSource) { dispatch_source_cancel(FilzaSSHAcceptSource); FilzaSSHAcceptSource = nil; }
+        if (FilzaSSHListenFD >= 0) { close(FilzaSSHListenFD); FilzaSSHListenFD = -1; }
+        FilzaDiagnosticsAppend(@"SSH", @"wolfSSH listener stopped");
+    });
+}
+
+BOOL FilzaSSHServerRestart(NSError **error)
+{
+    FilzaSSHServerStop();
+    return FilzaSSHServerStart(error);
+}
+
+BOOL FilzaSSHServerIsRunning(void)
+{
+    FilzaSSHInitialize();
+    return atomic_load(&FilzaSSHRunning);
+}
+
+NSString *FilzaSSHServerLastError(void)
+{
+    @synchronized (FilzaSSHLock()) { return [FilzaSSHFailure copy]; }
+}
+
+NSString *FilzaSSHServerConnectionSummary(void)
+{
+    if (!FilzaSSHServerIsRunning()) return FilzaSSHServerLastError() ?: @"Not listening";
+    NSString *address = FilzaSSHServerLANAddress() ?: @"iPhone";
+    NSInteger port = FilzaSSHConfiguredPort();
+    NSString *user = FilzaSSHConfiguredUsername();
+    return [NSString stringWithFormat:@"wolfSSH + SFTP listening\nssh://%@:%ld\nssh %@@%@ -p %ld\nsftp -P %ld %@@%@",
+            address, (long)port, user, address, (long)port, (long)port, user, address];
+}

--- a/FilzaWolfSSHServer.m
+++ b/FilzaWolfSSHServer.m
@@ -1,4 +1,5 @@
 @import Foundation;
+@import AVFoundation;
 @import Security;
 @import UIKit;
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See [`RELEASE_NOTES.md`](RELEASE_NOTES.md) for the release changelog.
 | PosterBoard / Tendies | ✅ | Applying changes still depends on writable target access |
 | HouseArrest / Santander | ✅ | Access remains OS/build-specific |
 | WebDAV server | ✅ | App-hosted service |
-| SSH/SFTP server | ✅ | App-hosted service |
+| SSH/SFTP server | ✅ wolfSSH | Password-authenticated shell + SFTP, multiple RFC 4254 session channels, local self-connection, and audio-mode background keepalive |
 | Home Screen quick actions | ✅ | Apps Manager, Music Library, Gestalt, and Patches routes |
 | Shared third-party panel | ✅ | 3105, Mond, presented ByeTunes; Filza browser UI unchanged |
 | Full jailbreak / writable system volume | ❌ Not claimed | Outside this project's proven capabilities |
@@ -174,6 +174,21 @@ The MobileGestalt cache used by the editor is:
 /private/var/containers/Shared/SystemGroup/systemgroup.com.apple.mobilegestaltcache/Library/Caches/com.apple.MobileGestalt.plist
 ```
 
+## SSH/SFTP
+
+The server uses the pinned wolfSSH/wolfSSL stack, listens on the configured TCP port, and supports password-authenticated interactive shell and SFTP sessions. Multiple SSH `session` channels are enabled because clients such as Clauntty open a control PTY before opening their actual terminal or setup channel.
+
+For a device at `192.168.4.20` using port `2222`:
+
+```sh
+ssh filza@192.168.4.20 -p 2222
+sftp -P 2222 filza@192.168.4.20
+```
+
+The app activates an audio-mode keepalive while SSH/SFTP is enabled so an established listener can continue when Filza moves to the background. Force-quitting the app, process termination, or the OS revoking execution still stops an in-process server.
+
+The displayed private address is reachable only on the local network (and can also be used by a terminal app on the same device). Remote Internet access requires a successful router mapping, a manually configured forward, or a separate VPN/tunnel. A NAT-PMP/UPnP failure is a public-mapping failure, not an SSH listener failure.
+
 ## Shared third-party UI contract
 
 `ThirdParty/3105/Sources/FilzaEmbeddedPanel.swift` is the canonical host shell for presented third-party tools. It provides the persistent Close action, material header/divider, page-sheet presentation, large detent, grabber, and consistent dismissal behavior.
@@ -218,7 +233,7 @@ Filza-27-SHA256.txt
 - `/System/Library` can be readable while remaining on iOS's signed read-only system volume.
 - Access to an App Group or data container does not imply access to the entire filesystem.
 - No full jailbreak, root shell, SPTM bypass, or system-volume remount is claimed by the packaging work.
-- WebDAV and SSH/SFTP are app-hosted services and can be suspended in the background.
+- WebDAV is app-hosted and may be suspended in the background. SSH/SFTP requests audio-mode background execution while enabled, but cannot survive a force-quit or process termination.
 
 ## Upstream projects and credits
 

--- a/scripts/build-wolfssh-stack.sh
+++ b/scripts/build-wolfssh-stack.sh
@@ -39,7 +39,7 @@ git -C "$WORK/wolfssl" checkout --detach "$WOLFSSL_COMMIT"
   cd "$WORK/wolfssl"
   autoreconf -fi
   env CC="$CC" AR="$AR" RANLIB="$RANLIB" \
-      CFLAGS="$COMMON_CFLAGS" CPPFLAGS="-DWOLFSSL_APPLE_NATIVE_CERT_VALIDATION=0" \
+      CFLAGS="$COMMON_CFLAGS" \
       ./configure \
         --host="$HOST" \
         --enable-static --disable-shared \

--- a/scripts/build-wolfssh-stack.sh
+++ b/scripts/build-wolfssh-stack.sh
@@ -4,6 +4,19 @@ set -euo pipefail
 PREFIX="${1:-$PWD/Vendor/wolfssh}"
 WOLFSSH_COMMIT="${WOLFSSH_COMMIT:-e7c8dc2c2c54e5f0f2986be592e2243725a4dd33}"
 WOLFSSL_COMMIT="${WOLFSSL_COMMIT:-9ab8a4b19debdade06b10d30cf70167de8f9b915}"
+
+# GitHub's macOS image includes autoconf but does not guarantee Automake's
+# aclocal or GNU libtool. wolfSSL/wolfSSH master are source checkouts, so their
+# configure scripts must be regenerated reproducibly before cross-compiling.
+if ! command -v aclocal >/dev/null 2>&1 || ! command -v automake >/dev/null 2>&1; then
+  command -v brew >/dev/null 2>&1 || { echo "Homebrew is required to install automake" >&2; exit 2; }
+  brew install automake
+fi
+if ! command -v glibtoolize >/dev/null 2>&1 && ! command -v libtoolize >/dev/null 2>&1; then
+  command -v brew >/dev/null 2>&1 || { echo "Homebrew is required to install GNU libtool" >&2; exit 2; }
+  brew install libtool
+fi
+
 SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
 CC="$(xcrun --sdk iphoneos --find clang)"
 AR="$(xcrun --sdk iphoneos --find ar)"

--- a/scripts/build-wolfssh-stack.sh
+++ b/scripts/build-wolfssh-stack.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX="${1:-$PWD/Vendor/wolfssh}"
+WOLFSSH_COMMIT="${WOLFSSH_COMMIT:-e7c8dc2c2c54e5f0f2986be592e2243725a4dd33}"
+WOLFSSL_COMMIT="${WOLFSSL_COMMIT:-9ab8a4b19debdade06b10d30cf70167de8f9b915}"
+SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
+CC="$(xcrun --sdk iphoneos --find clang)"
+AR="$(xcrun --sdk iphoneos --find ar)"
+RANLIB="$(xcrun --sdk iphoneos --find ranlib)"
+JOBS="$(sysctl -n hw.logicalcpu 2>/dev/null || echo 4)"
+MIN_IOS="17.0"
+WORK="$(mktemp -d /tmp/filza-wolfssh.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/lib" "$PREFIX/include"
+
+COMMON_CFLAGS="-arch arm64 -isysroot $SDK -miphoneos-version-min=$MIN_IOS -fPIC -O2"
+HOST="arm-apple-darwin"
+
+printf 'Building wolfSSL %s for iOS arm64\n' "$WOLFSSL_COMMIT"
+git clone --filter=blob:none https://github.com/wolfSSL/wolfssl.git "$WORK/wolfssl"
+git -C "$WORK/wolfssl" checkout --detach "$WOLFSSL_COMMIT"
+(
+  cd "$WORK/wolfssl"
+  autoreconf -fi
+  env CC="$CC" AR="$AR" RANLIB="$RANLIB" \
+      CFLAGS="$COMMON_CFLAGS" CPPFLAGS="-DWOLFSSL_APPLE_NATIVE_CERT_VALIDATION=0" \
+      ./configure \
+        --host="$HOST" \
+        --enable-static --disable-shared \
+        --enable-wolfssh --enable-keygen \
+        --disable-examples
+  make -j"$JOBS" src/libwolfssl.la
+)
+
+test -s "$WORK/wolfssl/src/.libs/libwolfssl.a"
+cp "$WORK/wolfssl/src/.libs/libwolfssl.a" "$PREFIX/lib/libwolfssl.a"
+mkdir -p "$PREFIX/include/wolfssl"
+cp -R "$WORK/wolfssl/wolfssl/." "$PREFIX/include/wolfssl/"
+
+printf 'Building wolfSSH %s for iOS arm64\n' "$WOLFSSH_COMMIT"
+git clone --filter=blob:none https://github.com/wolfSSL/wolfssh.git "$WORK/wolfssh"
+git -C "$WORK/wolfssh" checkout --detach "$WOLFSSH_COMMIT"
+(
+  cd "$WORK/wolfssh"
+  autoreconf -fi
+  env CC="$CC" AR="$AR" RANLIB="$RANLIB" \
+      CFLAGS="$COMMON_CFLAGS" \
+      CPPFLAGS="-I$PREFIX/include" \
+      LDFLAGS="-L$PREFIX/lib" \
+      LIBS="-lwolfssl" \
+      ./configure \
+        --host="$HOST" \
+        --enable-static --disable-shared \
+        --enable-sftp --enable-scp \
+        --disable-examples
+  make -j"$JOBS" src/libwolfssh.la
+)
+
+test -s "$WORK/wolfssh/src/.libs/libwolfssh.a"
+cp "$WORK/wolfssh/src/.libs/libwolfssh.a" "$PREFIX/lib/libwolfssh.a"
+mkdir -p "$PREFIX/include/wolfssh"
+cp -R "$WORK/wolfssh/wolfssh/." "$PREFIX/include/wolfssh/"
+
+printf '%s\n' "$WOLFSSH_COMMIT" > "$PREFIX/WOLFSSH_COMMIT"
+printf '%s\n' "$WOLFSSL_COMMIT" > "$PREFIX/WOLFSSL_COMMIT"
+
+lipo -info "$PREFIX/lib/libwolfssh.a"
+lipo -info "$PREFIX/lib/libwolfssl.a"
+file "$PREFIX/lib/libwolfssh.a" "$PREFIX/lib/libwolfssl.a"
+echo "wolfSSH iOS stack staged at $PREFIX"

--- a/scripts/build-wolfssh-stack.sh
+++ b/scripts/build-wolfssh-stack.sh
@@ -60,7 +60,16 @@ cp -R "$WORK/wolfssl/wolfssl/." "$PREFIX/include/wolfssl/"
 printf 'Building wolfSSH %s for iOS arm64\n' "$WOLFSSH_COMMIT"
 git clone --filter=blob:none https://github.com/wolfSSL/wolfssh.git "$WORK/wolfssh"
 git -C "$WORK/wolfssh" checkout --detach "$WOLFSSH_COMMIT"
-# Pinned wolfSSH rejects a second RFC 4254 session channel. Clauntty opens an\n# initial control PTY and then a separate terminal/exec channel, so apply our\n# narrow, reviewed compatibility patch before configuring the library.\ngit -C "$WORK/wolfssh" apply "$SCRIPT_DIR/wolfssh-allow-multiple-session-channels.patch"\nif grep -Fq "if (ssh->channelListSz >= 1)" "$WORK/wolfssh/src/internal.c"; then\n  echo "wolfSSH multi-session compatibility patch was not applied" >&2\n  exit 2\nfi\n(\n  cd "$WORK/wolfssh"
+# Pinned wolfSSH rejects a second RFC 4254 session channel. Clauntty opens an
+# initial control PTY and then a separate terminal/exec channel, so apply our
+# narrow, reviewed compatibility patch before configuring the library.
+git -C "$WORK/wolfssh" apply "$SCRIPT_DIR/wolfssh-allow-multiple-session-channels.patch"
+if grep -Fq "if (ssh->channelListSz >= 1)" "$WORK/wolfssh/src/internal.c"; then
+  echo "wolfSSH multi-session compatibility patch was not applied" >&2
+  exit 2
+fi
+(
+  cd "$WORK/wolfssh"
   autoreconf -fi
   env CC="$CC" AR="$AR" RANLIB="$RANLIB" \
       CFLAGS="$COMMON_CFLAGS" \

--- a/scripts/build-wolfssh-stack.sh
+++ b/scripts/build-wolfssh-stack.sh
@@ -30,7 +30,9 @@ rm -rf "$PREFIX"
 mkdir -p "$PREFIX/lib" "$PREFIX/include"
 
 COMMON_CFLAGS="-arch arm64 -isysroot $SDK -miphoneos-version-min=$MIN_IOS -fPIC -O2"
-HOST="arm-apple-darwin"
+# Autoconf's CPU tuple must agree with clang -arch arm64. Using `arm-*` makes
+# wolfSSL select its 32-bit ARM SP assembly even though clang emits arm64.
+HOST="aarch64-apple-darwin"
 
 printf 'Building wolfSSL %s for iOS arm64\n' "$WOLFSSL_COMMIT"
 git clone --filter=blob:none https://github.com/wolfSSL/wolfssl.git "$WORK/wolfssl"

--- a/scripts/build-wolfssh-stack.sh
+++ b/scripts/build-wolfssh-stack.sh
@@ -46,6 +46,7 @@ git -C "$WORK/wolfssl" checkout --detach "$WOLFSSL_COMMIT"
         --host="$HOST" \
         --enable-static --disable-shared \
         --enable-wolfssh --enable-keygen \
+        --enable-harden \
         --disable-examples
   make -j"$JOBS" src/libwolfssl.la
 )

--- a/scripts/build-wolfssh-stack.sh
+++ b/scripts/build-wolfssh-stack.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PREFIX="${1:-$PWD/Vendor/wolfssh}"
 WOLFSSH_COMMIT="${WOLFSSH_COMMIT:-e7c8dc2c2c54e5f0f2986be592e2243725a4dd33}"
 WOLFSSL_COMMIT="${WOLFSSL_COMMIT:-9ab8a4b19debdade06b10d30cf70167de8f9b915}"
@@ -59,7 +60,7 @@ cp -R "$WORK/wolfssl/wolfssl/." "$PREFIX/include/wolfssl/"
 printf 'Building wolfSSH %s for iOS arm64\n' "$WOLFSSH_COMMIT"
 git clone --filter=blob:none https://github.com/wolfSSL/wolfssh.git "$WORK/wolfssh"
 git -C "$WORK/wolfssh" checkout --detach "$WOLFSSH_COMMIT"
-# Pinned wolfSSH rejects a second RFC 4254 session channel. Clauntty opens an\n# initial control PTY and then a separate terminal/exec channel, so apply our\n# narrow, reviewed compatibility patch before configuring the library.\ngit -C "$WORK/wolfssh" apply "$PWD/scripts/wolfssh-allow-multiple-session-channels.patch"\nif grep -Fq "if (ssh->channelListSz >= 1)" "$WORK/wolfssh/src/internal.c"; then\n  echo "wolfSSH multi-session compatibility patch was not applied" >&2\n  exit 2\nfi\n(\n  cd "$WORK/wolfssh"
+# Pinned wolfSSH rejects a second RFC 4254 session channel. Clauntty opens an\n# initial control PTY and then a separate terminal/exec channel, so apply our\n# narrow, reviewed compatibility patch before configuring the library.\ngit -C "$WORK/wolfssh" apply "$SCRIPT_DIR/wolfssh-allow-multiple-session-channels.patch"\nif grep -Fq "if (ssh->channelListSz >= 1)" "$WORK/wolfssh/src/internal.c"; then\n  echo "wolfSSH multi-session compatibility patch was not applied" >&2\n  exit 2\nfi\n(\n  cd "$WORK/wolfssh"
   autoreconf -fi
   env CC="$CC" AR="$AR" RANLIB="$RANLIB" \
       CFLAGS="$COMMON_CFLAGS" \

--- a/scripts/build-wolfssh-stack.sh
+++ b/scripts/build-wolfssh-stack.sh
@@ -59,8 +59,7 @@ cp -R "$WORK/wolfssl/wolfssl/." "$PREFIX/include/wolfssl/"
 printf 'Building wolfSSH %s for iOS arm64\n' "$WOLFSSH_COMMIT"
 git clone --filter=blob:none https://github.com/wolfSSL/wolfssh.git "$WORK/wolfssh"
 git -C "$WORK/wolfssh" checkout --detach "$WOLFSSH_COMMIT"
-(
-  cd "$WORK/wolfssh"
+# Pinned wolfSSH rejects a second RFC 4254 session channel. Clauntty opens an\n# initial control PTY and then a separate terminal/exec channel, so apply our\n# narrow, reviewed compatibility patch before configuring the library.\ngit -C "$WORK/wolfssh" apply "$PWD/scripts/wolfssh-allow-multiple-session-channels.patch"\nif grep -Fq "if (ssh->channelListSz >= 1)" "$WORK/wolfssh/src/internal.c"; then\n  echo "wolfSSH multi-session compatibility patch was not applied" >&2\n  exit 2\nfi\n(\n  cd "$WORK/wolfssh"
   autoreconf -fi
   env CC="$CC" AR="$AR" RANLIB="$RANLIB" \
       CFLAGS="$COMMON_CFLAGS" \

--- a/scripts/wolfssh-allow-multiple-session-channels.patch
+++ b/scripts/wolfssh-allow-multiple-session-channels.patch
@@ -1,0 +1,15 @@
+diff --git a/src/internal.c b/src/internal.c
+index 2fb3e2a..6a9e86c 100644
+--- a/src/internal.c
++++ b/src/internal.c
+@@ -10937,10 +10937,6 @@ static int DoChannelOpen(WOLFSSH* ssh,
+         typeId = NameToId(type, typeSz);
+         switch (typeId) {
+             case ID_CHANTYPE_SESSION:
+-                if (ssh->channelListSz >= 1) {
+-                    ret = WS_INVALID_CHANID;
+-                    fail_reason = OPEN_ADMINISTRATIVELY_PROHIBITED;
+-                }
+                 break;
+         #ifdef WOLFSSH_FWD
+             case ID_CHANTYPE_TCPIP_DIRECT:


### PR DESCRIPTION
Replaces the custom libssh server listener with wolfSSL/wolfSSH as the production SSH/SFTP engine while retaining libssh only as an independent loopback interoperability probe.

Key changes:
- pinned wolfSSH + wolfSSL iOS arm64 build
- raw POSIX listener owned by Filza, wolfSSH handles SSH protocol/auth/session/SFTP
- persistent per-install ECDSA host key generated with wolfCrypt
- existing PBKDF2 password preferences preserved
- existing Filza shell command adapter preserved
- SFTP v3 handled by wolfSSH
- verifier builds both stacks and checks wolfSSH symbols/runtime markers

Pinned upstreams:
- wolfSSH e7c8dc2c2c54e5f0f2986be592e2243725a4dd33
- wolfSSL 9ab8a4b19debdade06b10d30cf70167de8f9b915

Do not merge until the full IPA verifier is green.

## Summary by Sourcery

Replace the embedded libssh SSH/SFTP server with a wolfSSH-based production backend while retaining libssh for interoperability verification.

New Features:
- Use wolfSSH and wolfSSL as the production SSH/SFTP backend with shell and SFTP support.
- Generate and persist an ECDSA host key per installation for SSH server identity.
- Provide a pinned iOS arm64 build of the wolfSSH and wolfSSL dependency stack.

Bug Fixes:
- Replace the embedded libssh listener while retaining libssh as an independent interoperability verifier.

Enhancements:
- Preserve existing PBKDF2 password authentication, Filza shell command handling, Bonjour publishing, and server lifecycle APIs while moving listener ownership into Filza and protocol handling into wolfSSH.

Build:
- Add a reproducible script for building pinned wolfSSL and wolfSSH static libraries for iOS arm64.

CI:
- Extend the IPA verifier with wolfSSH/wolfSSL dependency caching, build checks, runtime markers, symbol validation, and production-source assertions.

Tests:
- Expand verification to confirm both the libssh probe and wolfSSH production backend are present and independently validated.