### PR TITLE
Force stable Filza release trigger

### DIFF
--- a/.github/workflows/publish-stable-filza-release.yml
+++ b/.github/workflows/publish-stable-filza-release.yml
@@ -1,6 +1,7 @@
 name: Publish Stable Filza Release
 
 # Stable tag is always sourced from an exact successful main verifier run.
+# A merged main push is also an explicit release trigger.
 on:
   workflow_run:
     workflows: ["Verify ByeTunes All Sources + YouTube + SSH IPA"]


### PR DESCRIPTION
Forces a merged main push through the normal verifier and stable-release publisher path. No runtime code changes.

## Summary by Sourcery

CI:
- Allow merged pushes to the main branch to explicitly trigger the stable Filza release workflow in addition to successful verifier runs.