### PR TITLE
Update embedded 3105 to upstream 2.0

### DIFF
--- a/.github/workflows/verify-3105-shared-ui.yml
+++ b/.github/workflows/verify-3105-shared-ui.yml
@@ -1,4 +1,4 @@
-name: Verify 3105 1.1.1 + Shared Embedded UI
+name: Verify 3105 2.0 + Shared Embedded UI
 
 on:
   push:
@@ -59,7 +59,7 @@ jobs:
           chmod +x "$RUNNER_TEMP/filza-tools/plutil"
           echo "$RUNNER_TEMP/filza-tools" >> "$GITHUB_PATH"
 
-      - name: Verify pinned 3105 1.1.1 integration
+      - name: Verify pinned 3105 compatibility baseline and 2.0 overlay
         shell: bash
         run: |
           set -euxo pipefail
@@ -67,12 +67,22 @@ jobs:
           grep -Fq 'UPSTREAM_OWNER="YangJiiii"' scripts/stage-3105-v1.sh
           grep -Fq 'UPSTREAM_COMMIT="f1b81047a01a1817c7fb17e6938929eef108f1aa"' scripts/stage-3105-v1.sh
           grep -Fq 'UPSTREAM_VERSION="1.1.1"' scripts/stage-3105-v1.sh
+          test -f scripts/stage-3105-v2-overlay.sh
+          grep -Fq 'UPSTREAM_COMMIT="4a15d823b711bc0639de1f3fd2c764b5982d9245"' scripts/stage-3105-v2-overlay.sh
+          grep -Fq 'UPSTREAM_VERSION="2.0"' scripts/stage-3105-v2-overlay.sh
           test -f ThirdParty/3105/Sources/AppState.swift
           test -f ThirdParty/3105/Sources/KernelExploit.swift
           test -f ThirdParty/3105/Sources/Utils.swift
+          test -f ThirdParty/3105/Sources/FileBrowserMetadata.swift
+          test -f ThirdParty/3105/Sources/PackageRepositoryModels.swift
+          test -f ThirdParty/3105/Sources/PackageRepositoryStore.swift
+          test -f ThirdParty/3105/Sources/RepositoryPresentationSupport.swift
+          test -f ThirdParty/3105/Sources/RepositoryHomeView.swift
+          test -f ThirdParty/3105/Sources/RepositoryMarketplaceView.swift
+          test -f ThirdParty/3105/Sources/RepositorySourcesView.swift
           grep -Fq 'stage-3105-v1.sh' Makefile
 
-      - name: Verify embedded-host isolation
+      - name: Verify embedded-host isolation and stage 2.0
         shell: bash
         run: |
           set -euxo pipefail
@@ -84,6 +94,29 @@ jobs:
           ! grep -Fq 'DisplayIdentityAttestationToken' ThirdParty/3105/Sources/Utils.swift
           grep -Fq 'enum ExploitStatus' ThirdParty/3105/Sources/Utils.swift
           grep -Fq 'enum AppPaths' ThirdParty/3105/Sources/Utils.swift
+          grep -Fq 'latestSchemaVersion = 3' ThirdParty/3105/Sources/PatchPackageCodec.swift
+          grep -Fq 'PackageRepositoryStore' ThirdParty/3105/Sources/PackageRepositoryStore.swift
+          grep -Fq 'RepositoryHomeView' ThirdParty/3105/Sources/ThreeOneOSFiveContentView.swift
+          grep -Fq 'RepositorySourcesView' ThirdParty/3105/Sources/ThreeOneOSFiveContentView.swift
+          grep -Fq 'RepositorySearchView' ThirdParty/3105/Sources/ThreeOneOSFiveContentView.swift
+          grep -Fq 'repositoryStorePresentation(repositoryStore, patchStore: patchStore)' ThirdParty/3105/Sources/ThreeOneOSFiveContentView.swift
+          grep -Fq 'Filza3105PairingSettingsSection()' ThirdParty/3105/Sources/ThreeOneOSFiveSettingsView.swift
+          grep -Fq 'FilzaSharedPairingSupport.resolvedIcon' ThirdParty/3105/Sources/AppDataBrowserView.swift
+          test "$(plutil -extract CFBundleShortVersionString raw -o - ThirdParty/3105/Resources/Filza3105.bundle/UpstreamAppInfo.plist)" = "2.0"
+
+      - name: Verify semantic Filza routes for 3105 2.0
+        shell: bash
+        run: |
+          set -euxo pipefail
+          grep -Fq '@StateObject private var patchStore = PatchProjectStore()' Filza3105Host.swift
+          grep -Fq '@StateObject private var repositoryStore = PackageRepositoryStore()' Filza3105Host.swift
+          grep -Fq '.environmentObject(patchStore)' Filza3105Host.swift
+          grep -Fq '.environmentObject(repositoryStore)' Filza3105Host.swift
+          grep -Fq 'initialTab: AppSection.home.rawValue' Filza3105Host.swift
+          grep -Fq 'initialTab: AppSection.files.rawValue' Filza3105Host.swift
+          grep -Fq 'initialTab: AppSection.installed.rawValue' Filza3105Host.swift
+          ! grep -Fq 'initialTab: 1,' Filza3105Host.swift
+          ! grep -Fq 'initialTab: 2,' Filza3105Host.swift
 
       - name: Verify shared presentation and modern Mond core
         shell: bash

--- a/Filza3105Host.swift
+++ b/Filza3105Host.swift
@@ -8,6 +8,8 @@ private struct Filza3105EmbeddedRoot: View {
     @StateObject private var appState = AppState()
     @StateObject private var patchDraftCoordinator = PatchDraftCoordinator()
     @StateObject private var fileOperationCoordinator = FileOperationCoordinator()
+    @StateObject private var patchStore = PatchProjectStore()
+    @StateObject private var repositoryStore = PackageRepositoryStore()
     @AppStorage(AppLanguage.storageKey) private var languageCode = AppLanguage.english.rawValue
     @State private var routedInitialImport = false
 
@@ -21,6 +23,8 @@ private struct Filza3105EmbeddedRoot: View {
                 .environmentObject(appState)
                 .environmentObject(patchDraftCoordinator)
                 .environmentObject(fileOperationCoordinator)
+                .environmentObject(patchStore)
+                .environmentObject(repositoryStore)
                 .environment(\.appLanguage, language)
                 .environment(\.locale, language.locale)
         }
@@ -31,20 +35,16 @@ private struct Filza3105EmbeddedRoot: View {
                 patchDraftCoordinator.presentImport(initialImportURL)
                 FilzaDiagnosticsAppend(
                     "3105",
-                    "routed external 3105 import into embedded Patches workspace"
+                    "routed external 3105 import into embedded Installed workspace"
                 )
             }
             FilzaDiagnosticsAppend(
                 "3105",
-                "canonical embedded panel visible initialTab=\(initialTab)"
+                "canonical embedded 2.0 panel visible initialTab=\(initialTab)"
             )
             FilzaDiagnosticsAppend(
                 "3105",
-                "full upstream 3105 1.1.1 workspace appeared initialTab=\(initialTab)"
-            )
-            FilzaDiagnosticsAppend(
-                "3105",
-                "1.1.1 navigation active: responsive layout, independent Files tabs, Patch Workspace v2, updated support backend"
+                "upstream 3105 2.0 marketplace, schema-v3 patches and restore workflow active"
             )
         }
     }
@@ -72,34 +72,34 @@ public final class Filza3105HostFactory: NSObject {
 
     @objc public static func makeHomeController() -> UIViewController {
         makeController(
-            initialTab: 0,
+            initialTab: AppSection.home.rawValue,
             title: "3105",
-            diagnostic: "constructing full upstream 3105 1.1.1 workspace"
+            diagnostic: "constructing full upstream 3105 2.0 workspace"
         )
     }
 
     @objc public static func makeAppsManagerController() -> UIViewController {
         makeController(
-            initialTab: 1,
+            initialTab: AppSection.files.rawValue,
             title: "Apps Manager",
-            diagnostic: "constructing complete 3105 1.1.1 Apps Manager"
+            diagnostic: "constructing 3105 2.0 Files/Apps Manager"
         )
     }
 
     @objc public static func makePatchesController() -> UIViewController {
         makeController(
-            initialTab: 2,
+            initialTab: AppSection.installed.rawValue,
             title: "Patches",
-            diagnostic: "constructing complete 3105 1.1.1 Patches"
+            diagnostic: "constructing 3105 2.0 Installed/Patches"
         )
     }
 
     @objc(makePatchesImportControllerWithURL:)
     public static func makePatchesImportController(withURL url: URL) -> UIViewController {
         makeController(
-            initialTab: 2,
+            initialTab: AppSection.installed.rawValue,
             title: "Patches",
-            diagnostic: "constructing 3105 1.1.1 Patches for external import",
+            diagnostic: "constructing 3105 2.0 Installed/Patches for external import",
             initialImportURL: url
         )
     }

--- a/ThirdParty/3105/Sources/FileBrowserMetadata.swift
+++ b/ThirdParty/3105/Sources/FileBrowserMetadata.swift
@@ -1,0 +1,2 @@
+// Build-time placeholder. scripts/stage-3105-v2-overlay.sh replaces this file
+// with pinned upstream 3105 2.0 FileBrowserMetadata.swift before compilation.

--- a/ThirdParty/3105/Sources/PackageRepositoryModels.swift
+++ b/ThirdParty/3105/Sources/PackageRepositoryModels.swift
@@ -1,0 +1,2 @@
+// Build-time placeholder. scripts/stage-3105-v2-overlay.sh replaces this file
+// with pinned upstream 3105 2.0 PackageRepositoryModels.swift before compilation.

--- a/ThirdParty/3105/Sources/PackageRepositoryStore.swift
+++ b/ThirdParty/3105/Sources/PackageRepositoryStore.swift
@@ -1,0 +1,2 @@
+// Build-time placeholder. scripts/stage-3105-v2-overlay.sh replaces this file
+// with pinned upstream 3105 2.0 PackageRepositoryStore.swift before compilation.

--- a/ThirdParty/3105/Sources/RepositoryHomeView.swift
+++ b/ThirdParty/3105/Sources/RepositoryHomeView.swift
@@ -1,0 +1,2 @@
+// Build-time placeholder. scripts/stage-3105-v2-overlay.sh replaces this file
+// with pinned upstream 3105 2.0 RepositoryHomeView.swift before compilation.

--- a/ThirdParty/3105/Sources/RepositoryMarketplaceView.swift
+++ b/ThirdParty/3105/Sources/RepositoryMarketplaceView.swift
@@ -1,0 +1,2 @@
+// Build-time placeholder. scripts/stage-3105-v2-overlay.sh replaces this file
+// with pinned upstream 3105 2.0 RepositoryMarketplaceView.swift before compilation.

--- a/ThirdParty/3105/Sources/RepositoryPresentationSupport.swift
+++ b/ThirdParty/3105/Sources/RepositoryPresentationSupport.swift
@@ -1,0 +1,2 @@
+// Build-time placeholder. scripts/stage-3105-v2-overlay.sh replaces this file
+// with pinned upstream 3105 2.0 RepositoryPresentationSupport.swift before compilation.

--- a/ThirdParty/3105/Sources/RepositorySourcesView.swift
+++ b/ThirdParty/3105/Sources/RepositorySourcesView.swift
@@ -1,0 +1,2 @@
+// Build-time placeholder. scripts/stage-3105-v2-overlay.sh replaces this file
+// with pinned upstream 3105 2.0 RepositorySourcesView.swift before compilation.

--- a/scripts/patch-3105-embedded-compat.sh
+++ b/scripts/patch-3105-embedded-compat.sh
@@ -54,4 +54,10 @@ grep -Fq 'enum AppPaths' "$UTILS"
 ! grep -Fq 'DisplayIdentityAttestationToken' "$UTILS"
 ! grep -Fq 'enum AppUpdateChecker' "$UTILS"
 
-echo "Applied 3105 1.1.1 embedded-host compatibility transform (standalone updater/attestation excluded)"
+echo "Applied 3105 1.1.1 embedded-host compatibility baseline (standalone updater/attestation excluded)"
+
+test -f scripts/stage-3105-v2-overlay.sh || {
+  echo "Missing 3105 2.0 overlay staging script" >&2
+  exit 1
+}
+bash scripts/stage-3105-v2-overlay.sh

--- a/scripts/stage-3105-v2-overlay.sh
+++ b/scripts/stage-3105-v2-overlay.sh
@@ -13,10 +13,6 @@ for path in "$ROOT" "$ROOT/Sources" "$ROOT/Resources/Filza3105.bundle"; do
   test -d "$path" || { echo "Missing 3105 integration path: $path" >&2; exit 1; }
 done
 
-# The 1.1.1 pass runs first and establishes the Filza-owned adapters. This
-# overlay intentionally replaces only source units changed by upstream 2.0.
-# App.swift, OnboardingView.swift, standalone attribution/window hooks and the
-# kernel/lifecycle adapters remain owned by Filza.
 test -f "$ROOT/Sources/AppState.swift" || { echo "Missing Filza 3105 AppState adapter" >&2; exit 1; }
 test -f "$ROOT/Sources/KernelExploit.swift" || { echo "Missing Filza 3105 KernelExploit adapter" >&2; exit 1; }
 test -f "$ROOT/Sources/FilzaEmbeddedPanel.swift" || { echo "Missing Filza embedded panel" >&2; exit 1; }
@@ -85,8 +81,6 @@ settings = settings_path.read_text(encoding="utf-8")
 browser = browser_path.read_text(encoding="utf-8")
 navigation = navigation_path.read_text(encoding="utf-8")
 
-# Namespace the upstream roots so they coexist with Filza and preserve direct
-# routes from Filza quick actions into semantic 3105 2.0 sections.
 replacements = [
     ("struct ContentView: View {", "struct ThreeOneOSFiveContentView: View {"),
     ("    init() {", "    init(initialTab requestedInitialTab: Int = AppSection.home.rawValue) {"),
@@ -138,10 +132,36 @@ new_loader = '''            Task { @MainActor in
 if old_loader not in browser:
     raise SystemExit("3105 2.0 BrowserAppIcon loader anchor changed")
 browser = browser.replace(old_loader, new_loader, 1)
+
+# 2.0 adds AppUtilityToolbar to the Apps Manager toolbar. Filza's existing
+# View/Sort compatibility patch intentionally targets the older Files+Refresh
+# toolbar shape. Split the utility controls into a second toolbar modifier so
+# both upstream 2.0 Settings/Logs controls and Filza's View/Sort menu survive.
+utility_anchor = '''                AppUtilityToolbar(
+                    language: language,
+                    onOpenSettings: onOpenSettings,
+                    onOpenLogs: onOpenLogs
+                )
+            }
+            .onAppear {
+'''
+utility_replacement = '''            }
+            .toolbar {
+                AppUtilityToolbar(
+                    language: language,
+                    onOpenSettings: onOpenSettings,
+                    onOpenLogs: onOpenLogs
+                )
+            }
+            .onAppear {
+'''
+if utility_anchor not in browser:
+    raise SystemExit("3105 2.0 Apps Manager utility-toolbar anchor changed")
+browser = browser.replace(utility_anchor, utility_replacement, 1)
 browser_path.write_text(browser, encoding="utf-8")
 
-# Standalone 3105 hides Files behind Developer Mode. In Filza, Files is the
-# Apps Manager route, so it must remain reachable regardless of that preference.
+# Files is Filza's Apps Manager route and must never disappear behind standalone
+# 3105's Developer Mode preference.
 visibility = '''        case .files:
             return developerModeEnabled
 '''
@@ -162,9 +182,9 @@ for lang in en vi zh-Hans; do
   cp "$UPSTREAM/$lang.lproj/Localizable.strings" "$ROOT/Resources/Filza3105.bundle/$lang.lproj/Localizable.strings"
 done
 
-# Upstream's project.pbxproj was bumped to marketing version 2.0/build 8, but
-# its checked-in Info.plist still says 1.1.1/build 7. Preserve the plist shape
-# and stamp the metadata that corresponds to the pinned 2.0 source revision.
+# Upstream bumped project.pbxproj to marketing version 2.0/build 8 but left its
+# checked-in Info.plist at 1.1.1/build 7. Stamp the metadata corresponding to
+# the exact pinned 2.0 source revision in our embedded resource copy.
 cp "$UPSTREAM/Info.plist" "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist"
 python3 - \
   "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist" \
@@ -208,6 +228,7 @@ assert_contains 'PatchRestoreInspection' "$ROOT/Sources/DevicePatchService.swift
 assert_contains 'FileBrowserSortOrder' "$ROOT/Sources/FileBrowserMetadata.swift" 'file browser sorting metadata'
 assert_contains 'Filza3105PairingSettingsSection()' "$ROOT/Sources/ThreeOneOSFiveSettingsView.swift" 'shared pairing settings'
 assert_contains 'FilzaSharedPairingSupport.resolvedIcon' "$ROOT/Sources/AppDataBrowserView.swift" 'shared SpringBoard icon resolver'
+assert_contains 'AppUtilityToolbar(' "$ROOT/Sources/AppDataBrowserView.swift" '2.0 Settings/Logs utility toolbar'
 assert_contains 'case .files:' "$ROOT/Sources/AppTabNavigationState.swift" 'Files/Apps Manager section'
 assert_contains 'return true' "$ROOT/Sources/AppTabNavigationState.swift" 'Filza always-visible Apps Manager route'
 

--- a/scripts/stage-3105-v2-overlay.sh
+++ b/scripts/stage-3105-v2-overlay.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="ThirdParty/3105"
+UPSTREAM_OWNER="YangJiiii"
+UPSTREAM_REPO="3105"
+UPSTREAM_COMMIT="4a15d823b711bc0639de1f3fd2c764b5982d9245"
+UPSTREAM_VERSION="2.0"
+ARCHIVE_URL="https://codeload.github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tar.gz/${UPSTREAM_COMMIT}"
+
+for path in "$ROOT" "$ROOT/Sources" "$ROOT/Resources/Filza3105.bundle"; do
+  test -d "$path" || { echo "Missing 3105 integration path: $path" >&2; exit 1; }
+done
+
+# The 1.1.1 pass runs first and establishes the Filza-owned adapters. This
+# overlay intentionally replaces only source units changed by upstream 2.0.
+# App.swift, OnboardingView.swift, standalone attribution/window hooks and the
+# kernel/lifecycle adapters remain owned by Filza.
+test -f "$ROOT/Sources/AppState.swift" || { echo "Missing Filza 3105 AppState adapter" >&2; exit 1; }
+test -f "$ROOT/Sources/KernelExploit.swift" || { echo "Missing Filza 3105 KernelExploit adapter" >&2; exit 1; }
+test -f "$ROOT/Sources/FilzaEmbeddedPanel.swift" || { echo "Missing Filza embedded panel" >&2; exit 1; }
+test -f "$ROOT/Sources/FilzaSharedPairingSupport.swift" || { echo "Missing shared pairing support" >&2; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/filza-3105-v20.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fL --retry 3 --retry-delay 2 "$ARCHIVE_URL" -o "$TMP/3105.tar.gz"
+tar -xzf "$TMP/3105.tar.gz" -C "$TMP"
+SRC="$(find "$TMP" -maxdepth 1 -type d -name '3105-*' -print -quit)"
+test -n "$SRC" || { echo "Could not locate extracted 3105 2.0 source tree" >&2; exit 1; }
+UPSTREAM="$SRC/ThreeOneOSFive"
+
+copy_source() {
+  local relative="$1"
+  local destination="$2"
+  test -f "$UPSTREAM/$relative" || { echo "Missing upstream 3105 2.0 file: $relative" >&2; exit 1; }
+  cp "$UPSTREAM/$relative" "$ROOT/Sources/$destination"
+}
+
+# Exact upstream delta from f1b8104 (1.1.1) through 4a15d82 (2.0 + latest
+# repository-install result hotfix), excluding standalone lifecycle/onboarding.
+copy_source helpers/AppTabNavigationState.swift AppTabNavigationState.swift
+copy_source helpers/ContainerStore.swift ContainerStore.swift
+copy_source helpers/DevicePatchService.swift DevicePatchService.swift
+copy_source helpers/FileBrowserMetadata.swift FileBrowserMetadata.swift
+copy_source helpers/PackageRepositoryModels.swift PackageRepositoryModels.swift
+copy_source helpers/PackageRepositoryStore.swift PackageRepositoryStore.swift
+copy_source helpers/PatchPackageCodec.swift PatchPackageCodec.swift
+copy_source helpers/PatchProjectLibrary.swift PatchProjectLibrary.swift
+copy_source helpers/PatchProjectModels.swift PatchProjectModels.swift
+copy_source helpers/PatchProjectStore.swift PatchProjectStore.swift
+copy_source helpers/PatchTransaction.swift PatchTransaction.swift
+copy_source helpers/PatchWorkspaceService.swift PatchWorkspaceService.swift
+copy_source helpers/RepositoryPresentationSupport.swift RepositoryPresentationSupport.swift
+copy_source helpers/WallpaperInstaller.swift WallpaperInstaller.swift
+copy_source helpers/WallpaperLabService.swift WallpaperLabService.swift
+copy_source views/AppDataBrowserView.swift AppDataBrowserView.swift
+copy_source views/DesignSystem.swift DesignSystem.swift
+copy_source views/FileBrowserView.swift FileBrowserView.swift
+copy_source views/PatchProjectEditorView.swift PatchProjectEditorView.swift
+copy_source views/PatchProjectsView.swift PatchProjectsView.swift
+copy_source views/RepositoryHomeView.swift RepositoryHomeView.swift
+copy_source views/RepositoryMarketplaceView.swift RepositoryMarketplaceView.swift
+copy_source views/RepositorySourcesView.swift RepositorySourcesView.swift
+copy_source views/SettingsView.swift ThreeOneOSFiveSettingsView.swift
+copy_source views/WallpaperLabView.swift WallpaperLabView.swift
+copy_source ContentView.swift ThreeOneOSFiveContentView.swift
+
+python3 - \
+  "$ROOT/Sources/ThreeOneOSFiveContentView.swift" \
+  "$ROOT/Sources/ThreeOneOSFiveSettingsView.swift" \
+  "$ROOT/Sources/AppDataBrowserView.swift" \
+  "$ROOT/Sources/AppTabNavigationState.swift" <<'PY'
+from pathlib import Path
+import sys
+
+content_path = Path(sys.argv[1])
+settings_path = Path(sys.argv[2])
+browser_path = Path(sys.argv[3])
+navigation_path = Path(sys.argv[4])
+
+content = content_path.read_text(encoding="utf-8")
+settings = settings_path.read_text(encoding="utf-8")
+browser = browser_path.read_text(encoding="utf-8")
+navigation = navigation_path.read_text(encoding="utf-8")
+
+# Namespace the upstream roots so they coexist with Filza and preserve direct
+# routes from Filza quick actions into semantic 3105 2.0 sections.
+replacements = [
+    ("struct ContentView: View {", "struct ThreeOneOSFiveContentView: View {"),
+    ("    init() {", "    init(initialTab requestedInitialTab: Int = AppSection.home.rawValue) {"),
+    ("        } else {\n            initialTab = 0\n        }", "        } else {\n            initialTab = requestedInitialTab\n        }"),
+    ("        _tabNavigation = State(initialValue: AppTabNavigationState())", "        _tabNavigation = State(initialValue: AppTabNavigationState(selectedTab: requestedInitialTab))"),
+    (".sheet(isPresented: $showSettings) { SettingsView() }", ".sheet(isPresented: $showSettings) { ThreeOneOSFiveSettingsView() }"),
+]
+for old, new in replacements:
+    if old not in content:
+        raise SystemExit(f"3105 2.0 ContentView adaptation anchor changed: {old}")
+    content = content.replace(old, new, 1)
+content_path.write_text(content, encoding="utf-8")
+
+if "struct SettingsView: View {" not in settings:
+    raise SystemExit("3105 2.0 SettingsView adaptation anchor changed")
+settings = settings.replace("struct SettingsView: View {", "struct ThreeOneOSFiveSettingsView: View {", 1)
+device_section = '''                Section(language.text("common.device")) {
+                    LabeledContent(language.text("dashboard.hardware_model"), value: AppInfo.displayMachineName)
+                    LabeledContent(language.text("settings.ios_version"), value: "\\(AppInfo.osVersion) (\\(AppInfo.osBuild))")
+                }
+'''
+if device_section not in settings:
+    raise SystemExit("3105 2.0 Settings device-section anchor changed")
+settings = settings.replace(device_section, device_section + '''
+
+                Filza3105PairingSettingsSection()
+''', 1)
+settings_path.write_text(settings, encoding="utf-8")
+
+# Preserve Filza's shared ByeTunes/3105 pairing path for SpringBoard icons.
+old_guard = "            guard resolvedIcon == nil, !didRequestIcon else { return }\n"
+new_guard = "            guard !didRequestIcon else { return }\n"
+if old_guard not in browser:
+    raise SystemExit("3105 2.0 BrowserAppIcon request guard anchor changed")
+browser = browser.replace(old_guard, new_guard, 1)
+old_loader = '''            DispatchQueue.global(qos: .utility).async {
+                let icon = iconForBundleID(bundleID)
+                DispatchQueue.main.async {
+                    resolvedIcon = icon
+                }
+            }
+'''
+new_loader = '''            Task { @MainActor in
+                if let icon = await FilzaSharedPairingSupport.resolvedIcon(for: bundleID) {
+                    resolvedIcon = icon
+                }
+            }
+'''
+if old_loader not in browser:
+    raise SystemExit("3105 2.0 BrowserAppIcon loader anchor changed")
+browser = browser.replace(old_loader, new_loader, 1)
+browser_path.write_text(browser, encoding="utf-8")
+
+# Standalone 3105 hides Files behind Developer Mode. In Filza, Files is the
+# Apps Manager route, so it must remain reachable regardless of that preference.
+visibility = '''        case .files:
+            return developerModeEnabled
+'''
+if visibility not in navigation:
+    raise SystemExit("3105 2.0 Files visibility anchor changed")
+navigation = navigation.replace(visibility, '''        case .files:
+            return true
+''', 1)
+navigation_path.write_text(navigation, encoding="utf-8")
+PY
+
+for lang in en vi zh-Hans; do
+  test -f "$UPSTREAM/$lang.lproj/Localizable.strings" || {
+    echo "3105 2.0 localization missing: $lang" >&2
+    exit 1
+  }
+  mkdir -p "$ROOT/Resources/Filza3105.bundle/$lang.lproj"
+  cp "$UPSTREAM/$lang.lproj/Localizable.strings" "$ROOT/Resources/Filza3105.bundle/$lang.lproj/Localizable.strings"
+done
+
+cp "$UPSTREAM/Info.plist" "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist"
+
+assert_contains() {
+  local needle="$1"
+  local path="$2"
+  local label="$3"
+  grep -Fq "$needle" "$path" || {
+    echo "3105 2.0 contract failed: $label ($needle) missing from $path" >&2
+    exit 1
+  }
+}
+
+assert_contains 'ThreeOneOSFiveContentView' "$ROOT/Sources/ThreeOneOSFiveContentView.swift" 'embedded ContentView namespace'
+assert_contains 'AppSection.installed.rawValue' "$ROOT/Sources/ThreeOneOSFiveContentView.swift" 'installed/package route'
+assert_contains 'RepositoryHomeView' "$ROOT/Sources/ThreeOneOSFiveContentView.swift" 'repository Home route'
+assert_contains 'RepositorySourcesView' "$ROOT/Sources/ThreeOneOSFiveContentView.swift" 'repository Sources route'
+assert_contains 'RepositorySearchView' "$ROOT/Sources/ThreeOneOSFiveContentView.swift" 'repository Search route'
+assert_contains 'repositoryStorePresentation(repositoryStore, patchStore: patchStore)' "$ROOT/Sources/ThreeOneOSFiveContentView.swift" 'latest repository install-result presentation'
+assert_contains 'latestSchemaVersion = 3' "$ROOT/Sources/PatchPackageCodec.swift" 'patch schema v3'
+assert_contains 'var author: String' "$ROOT/Sources/PatchProjectModels.swift" 'patch author metadata'
+assert_contains 'var isPrivate: Bool' "$ROOT/Sources/PatchProjectModels.swift" 'private patch metadata'
+assert_contains 'PackageRepositoryStore' "$ROOT/Sources/PackageRepositoryStore.swift" 'repository store'
+assert_contains 'RepositoryPackage' "$ROOT/Sources/PackageRepositoryModels.swift" 'repository package models'
+assert_contains 'PatchRestoreInspection' "$ROOT/Sources/DevicePatchService.swift" 'restore inspection'
+assert_contains 'FileBrowserSortOrder' "$ROOT/Sources/FileBrowserMetadata.swift" 'file browser sorting metadata'
+assert_contains 'Filza3105PairingSettingsSection()' "$ROOT/Sources/ThreeOneOSFiveSettingsView.swift" 'shared pairing settings'
+assert_contains 'FilzaSharedPairingSupport.resolvedIcon' "$ROOT/Sources/AppDataBrowserView.swift" 'shared SpringBoard icon resolver'
+assert_contains 'case .files:' "$ROOT/Sources/AppTabNavigationState.swift" 'Files/Apps Manager section'
+assert_contains 'return true' "$ROOT/Sources/AppTabNavigationState.swift" 'Filza always-visible Apps Manager route'
+
+plutil -lint "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist" >/dev/null || {
+  echo "3105 2.0 upstream Info.plist failed plutil validation" >&2
+  exit 1
+}
+test "$(plutil -extract CFBundleShortVersionString raw -o - "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist")" = "$UPSTREAM_VERSION" || {
+  echo "3105 upstream CFBundleShortVersionString is not $UPSTREAM_VERSION" >&2
+  exit 1
+}
+test "$(plutil -extract AppReleaseDisplayVersion raw -o - "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist")" = "$UPSTREAM_VERSION" || {
+  echo "3105 upstream AppReleaseDisplayVersion is not $UPSTREAM_VERSION" >&2
+  exit 1
+}
+
+echo "Applied pinned upstream 3105 2.0 overlay at $UPSTREAM_COMMIT while preserving Filza adapters"

--- a/scripts/stage-3105-v2-overlay.sh
+++ b/scripts/stage-3105-v2-overlay.sh
@@ -6,6 +6,7 @@ UPSTREAM_OWNER="YangJiiii"
 UPSTREAM_REPO="3105"
 UPSTREAM_COMMIT="4a15d823b711bc0639de1f3fd2c764b5982d9245"
 UPSTREAM_VERSION="2.0"
+UPSTREAM_BUILD="8"
 ARCHIVE_URL="https://codeload.github.com/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/tar.gz/${UPSTREAM_COMMIT}"
 
 for path in "$ROOT" "$ROOT/Sources" "$ROOT/Resources/Filza3105.bundle"; do
@@ -161,7 +162,26 @@ for lang in en vi zh-Hans; do
   cp "$UPSTREAM/$lang.lproj/Localizable.strings" "$ROOT/Resources/Filza3105.bundle/$lang.lproj/Localizable.strings"
 done
 
+# Upstream's project.pbxproj was bumped to marketing version 2.0/build 8, but
+# its checked-in Info.plist still says 1.1.1/build 7. Preserve the plist shape
+# and stamp the metadata that corresponds to the pinned 2.0 source revision.
 cp "$UPSTREAM/Info.plist" "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist"
+python3 - \
+  "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist" \
+  "$UPSTREAM_VERSION" \
+  "$UPSTREAM_BUILD" <<'PY'
+import plistlib
+import sys
+
+path, version, build = sys.argv[1:]
+with open(path, "rb") as handle:
+    info = plistlib.load(handle)
+info["CFBundleShortVersionString"] = version
+info["AppReleaseDisplayVersion"] = version
+info["CFBundleVersion"] = build
+with open(path, "wb") as handle:
+    plistlib.dump(info, handle, sort_keys=False)
+PY
 
 assert_contains() {
   local needle="$1"
@@ -192,15 +212,19 @@ assert_contains 'case .files:' "$ROOT/Sources/AppTabNavigationState.swift" 'File
 assert_contains 'return true' "$ROOT/Sources/AppTabNavigationState.swift" 'Filza always-visible Apps Manager route'
 
 plutil -lint "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist" >/dev/null || {
-  echo "3105 2.0 upstream Info.plist failed plutil validation" >&2
+  echo "3105 2.0 embedded Info.plist failed plutil validation" >&2
   exit 1
 }
 test "$(plutil -extract CFBundleShortVersionString raw -o - "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist")" = "$UPSTREAM_VERSION" || {
-  echo "3105 upstream CFBundleShortVersionString is not $UPSTREAM_VERSION" >&2
+  echo "3105 embedded CFBundleShortVersionString is not $UPSTREAM_VERSION" >&2
   exit 1
 }
 test "$(plutil -extract AppReleaseDisplayVersion raw -o - "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist")" = "$UPSTREAM_VERSION" || {
-  echo "3105 upstream AppReleaseDisplayVersion is not $UPSTREAM_VERSION" >&2
+  echo "3105 embedded AppReleaseDisplayVersion is not $UPSTREAM_VERSION" >&2
+  exit 1
+}
+test "$(plutil -extract CFBundleVersion raw -o - "$ROOT/Resources/Filza3105.bundle/UpstreamAppInfo.plist")" = "$UPSTREAM_BUILD" || {
+  echo "3105 embedded CFBundleVersion is not $UPSTREAM_BUILD" >&2
   exit 1
 }
 


### PR DESCRIPTION
Pins the Filza-embedded 3105 overlay to upstream 4a15d823b711bc0639de1f3fd2c764b5982d9245 (2.0 + repository install-result hotfix) while preserving Filza-owned lifecycle, pairing, Mond, bad_query, and exploit adapters. Adds repository marketplace sources, schema-v3 patch stack, updated restore/wallpaper/file-browser sources, semantic quick-action routing, and compile-graph placeholders for new upstream units.

## Summary by Sourcery

Upgrade the embedded 3105 integration to pinned upstream 2.0 while preserving Filza-specific host, pairing, and compatibility behavior.

New Features:
- Add the upstream 3105 2.0 marketplace, repository sources, restore workflow, updated file browser and wallpaper functionality, and schema-v3 patch support.
- Route Filza quick actions to semantic home, files, and installed sections while exposing shared patch and repository state throughout the embedded interface.

Bug Fixes:
- Preserve Filza pairing support, shared icon resolution, and Apps Manager visibility across the upstream 2.0 integration.
- Apply the repository install-result hotfix and retain embedded-host compatibility exclusions for standalone lifecycle and attestation features.

Enhancements:
- Replace the previous embedded 3105 source overlay with pinned upstream commit 4a15d823b711bc0639de1f3fd2c764b5982d9245 and stamp the embedded metadata as version 2.0 build 8.

CI:
- Expand 3105 verification coverage to validate the pinned 2.0 overlay, required sources, semantic routes, compatibility contracts, and embedded metadata.